### PR TITLE
mockout ResizeObserver

### DIFF
--- a/__mocks__/resize-observe-polyfill.js
+++ b/__mocks__/resize-observe-polyfill.js
@@ -1,0 +1,12 @@
+class ResizeObserver {
+  observe() {
+    // do nothing
+  }
+  unobserve() {
+    // do nothing
+  }
+}
+
+window.ResizeObserver = ResizeObserver;
+
+export default ResizeObserver;

--- a/packages/synchro-charts/src/components/sc-size-provider/sc-size-provider.spec.tsx
+++ b/packages/synchro-charts/src/components/sc-size-provider/sc-size-provider.spec.tsx
@@ -1,3 +1,4 @@
+jest.mock('resize-observer-polyfill');
 import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { update } from '../charts/common/tests/merge';
@@ -38,13 +39,13 @@ const CONTAINER_SIZE = { width: 200, height: 300 };
  * Warning: Observer will not fire or work as expected in jest test. This makes certain unit tests impossible to write.
  */
 
-it.skip('does not render on initial load when size is not set', async () => {
+it('does not render on initial load when size is not set', async () => {
   // container size is the size of the container holder our widget
   const { widgetSizer } = await newWidgetSizerSpecPage(CONTAINER_SIZE, { size: undefined });
   expect(widgetSizer.renderFunc).not.toBeCalled();
 });
 
-describe.skip('when size is set', () => {
+describe('when size is set', () => {
   const size = { width: 120, height: 300 };
 
   it('renders on initial load when size is set', async () => {


### PR DESCRIPTION
Mocks out the Resize Observer for the purposes of the jest unit tests.

```
=============================== Coverage summary ===============================
Statements   : 89.42% ( 2433/2721 )
Branches     : 84.62% ( 1128/1333 )
Functions    : 86.38% ( 501/580 )
Lines        : 89.06% ( 2321/2606 )
================================================================================

Test Suites: 75 passed, 75 total
Tests:       6 skipped, 1219 passed, 1225 total
Snapshots:   4 passed, 4 total
Time:        44.497s
```