### PR TITLE
Add isEditable field to Annotations

### DIFF
--- a/packages/synchro-charts/src/components/charts/common/types.ts
+++ b/packages/synchro-charts/src/components/charts/common/types.ts
@@ -115,9 +115,9 @@ export interface Annotation<T extends AnnotationValue> {
   // Utilized to provide context where annotation/thresholds are utilized/breached
   description?: string;
 
-  // Whether the annotation is draggable (set by application layer)
+  // configures whether the annotation is editable
   // false or undefined = annotation is not draggable
-  draggable?: boolean;
+  isEditable?: boolean;
 }
 
 /**


### PR DESCRIPTION
Add new optional field to Annotations: isEditable

This field will be set by the application layer. If it is false or undefined (as default), the annotation is not editable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
