### PR TITLE
doc-site: prevent multiple webgl-contexts from being created

### DIFF
--- a/packages/doc-site/src/styleguide/Sections.js
+++ b/packages/doc-site/src/styleguide/Sections.js
@@ -4,12 +4,17 @@ import DefaultSectionsRenderer from 'react-styleguidist/lib/client/rsg-component
 import { WebglContext } from '@synchro-charts/react';
 import './Sections.css';
 
-const Sections = ({ children }) => (
+const Sections = ({ children }) => {
+  // Styleguidist will render multiple sections per a single screen - we want to ensure that were only
+  // rendering a single `<WebglContext />`.
+  const mountWebglContext = children.length > 0;
+  return (
     <div className="section">
-        <DefaultSectionsRenderer>{children}</DefaultSectionsRenderer>
-        <WebglContext />
+      <DefaultSectionsRenderer>{children}</DefaultSectionsRenderer>
+      {mountWebglContext && <WebglContext />}
     </div>
-);
+  );
+}
 
 export default Sections;
 

--- a/packages/synchro-charts/src/components/sc-webgl-context/webglContext.ts
+++ b/packages/synchro-charts/src/components/sc-webgl-context/webglContext.ts
@@ -154,7 +154,8 @@ export const createWebGLRenderer = () => {
   const mustBeInitialized = () => {
     if (rectMap == null) {
       throw new Error(
-        'webgl context must be initialized before it can be utilized. Please refer to https://synchrocharts.com/#/Setup to learn more about how to setup Synchro Charts.'
+        'webgl context must be initialized before it can be utilized. ' +
+          'Please refer to https://synchrocharts.com/#/Setup to learn more about how to setup Synchro Charts.'
       );
     }
   };


### PR DESCRIPTION
## Overview

Fix bug where multiple `<sc-webgl-context />` would mount within the documentation site, causing rendering issues.

This is achieved by utilizing the `children` passed into the sections to prevent `empty` sections causing additional `<sc-webgl-context>`s from being mounted.

## Changes
- webgl mounting fix in doc site
- minor eslint mishap in synchro charts

## Tests

integration tests, `yarn test:cypress`

```
       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  charts/alarms.spec.ts                    00:32       18       18        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/empty-status.spec.      00:04        2        2        -        -        - │
  │    ts                                                                                          │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/errors.spec.ts          00:03        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/gestures.spec.ts        00:05        3        3        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/loading.spec.ts         00:02        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/sc-webgl-bar-chart      00:31       15       15        -        -        - │
  │    .spec.ts                                                                                    │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/threshold-colorati      00:11        6        6        -        -        - │
  │    on.spec.ts                                                                                  │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/tooltip.spec.ts         00:06        3        3        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/cross-resolution.spec.ts          00:04        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/empty-status.spec      00:04        2        2        -        -        - │
  │    .ts                                                                                         │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/errors.spec.ts         00:03        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/gestures.spec.ts       00:11        4        4        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/loading.spec.ts        00:02        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/sc-webgl-chart.sp      00:40       20       18        -        2        - │
  │    ec.ts                                                                                       │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/threshold-colorat      00:10        5        5        -        -        - │
  │    ion.spec.ts                                                                                 │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/tooltip.spec.ts        00:05        2        2        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/performance.spec.ts                24ms        6        -        -        6        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/rendering-meshes.spec.ts          00:28       10       10        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/empty-status.s      00:05        2        2        -        -        - │
  │    pec.ts                                                                                      │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/errors.spec.ts      00:04        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/gestures.spec.      00:05        2        2        -        -        - │
  │    ts                                                                                          │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/loading.spec.t      00:03        1        1        -        -        - │
  │    s                                                                                           │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/sc-webgl-scatt      00:23        4        4        -        -        - │
  │    er-chart.spec.ts                                                                            │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/threshold-colo      00:11        6        6        -        -        - │
  │    ration.spec.ts                                                                              │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/tooltip.spec.t      00:05        2        2        -        -        - │
  │    s                                                                                           │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/empty-status      00:04        2        2        -        -        - │
  │    .spec.ts                                                                                    │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/errors.spec.      00:04        2        2        -        -        - │
  │    ts                                                                                          │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/gestures.spe      00:04        2        2        -        -        - │
  │    c.ts                                                                                        │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/loading.spec      00:02        1        1        -        -        - │
  │    .ts                                                                                         │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/status-timel      00:39       17       17        -        -        - │
  │    ine.spec.ts                                                                                 │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/threshold-co      00:13        7        7        -        -        - │
  │    loration.spec.ts                                                                            │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/threshold-le      00:05        3        3        -        -        - │
  │    gend.spec.ts                                                                                │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/tooltip.spec      00:05        1        1        -        -        - │
  │    .ts                                                                                         │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  expandable-input.spec.ts                 00:01        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  kpi/kpi.spec.ts                          00:08        5        5        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  size-provider.spec.ts                    00:09        6        6        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  status-grid/status-grid.spec.ts          00:26       14       13        -        1        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  table/table.spec.ts                      00:11        9        9        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  webglContext.spec.ts                     00:17        6        6        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        07:02      195      186        -        9        -  
```

root level `yarn test`

```
@synchro-charts/core: =============================== Coverage summary ===============================
@synchro-charts/core: Statements   : 89.48% ( 2441/2728 )
@synchro-charts/core: Branches     : 84.64% ( 1130/1335 )
@synchro-charts/core: Functions    : 86.57% ( 503/581 )
@synchro-charts/core: Lines        : 89.13% ( 2329/2613 )
@synchro-charts/core: ================================================================================
@synchro-charts/core: Test Suites: 75 passed, 75 total
@synchro-charts/core: Tests:       6 skipped, 1224 passed, 1230 total
@synchro-charts/core: Snapshots:   4 passed, 4 total
@synchro-charts/core: Time:        67.351s
@synchro-charts/core: Ran all test suites.
@synchro-charts/core: (node:21509) [DEP0128] DeprecationWarning: Invalid 'main' field in '/Users/diehbria/aws-synchro-charts/node_modules/eslint-config-airbnb-typescript/package.json' of 'dist/eslint-config-airbnb-typescript.js'. Please either fix that or report it to the module author
@synchro-charts/core: (Use `node --trace-deprecation ...` to show where the warning was created)
@synchro-charts/doc-site: $ echo "INFO: no test specified"
@synchro-charts/doc-site: INFO: no test specified
lerna success run Ran npm script 'test' in 2 packages in 108.9s:
lerna success - @synchro-charts/doc-site
lerna success - @synchro-charts/core
✨  Done in 109.88s.
```