### PR TITLE
doc-site: add documentation around WebGL context

### DIFF
--- a/packages/doc-site/README.md
+++ b/packages/doc-site/README.md
@@ -2,10 +2,16 @@
 
 The website which makes up the Synchro Charts documentation, as seen in https://synchrocharts.com.
 
-## Pre-requisite
-In the root project directory, make sure you already ran:
+## Setup
+Run the following commands:
 
-- `yarn install && yarn build`
+1. `yarn install`
+
+2. `yarn build`
+
+3. `yarn start`
+
+4. Open your browser at `localhost:6060` to see a local instance of the documentation site.
 
 ## Available scripts
 
@@ -24,5 +30,16 @@ In the project directory, you can run:
   Cleans up artifacts as well as the generated `docs` in the root directory.
 
 ## Deployment
+To construct the correct artifacts, you will need to perform the following steps:
 
-create a pull request to https://github.com/awslabs/aws-synchro-charts, which will cause an update to the website https://synchrocharts.com/.
+1. Alter the `.gitignore` file at the root level of the repository, and remove the following lines:
+    - `build`
+    - `/docs/*`
+  
+   This will allow the build artifacts to be included in the commit you will construct. 
+
+2. Run `yarn build` at the root of the repository.
+
+3. Force push your branch to the `docs` branch: `git push --force origin docs`
+
+GitHub will then serve the updated artifacts as contained in the `docs` folder constructed from the build process. The update process should take less than a couple of minutes.

--- a/packages/doc-site/docs/setup.md
+++ b/packages/doc-site/docs/setup.md
@@ -1,7 +1,16 @@
 
 
 1. Install to your project
-    For use within react,
+
+   To utilize as webcomponents
+    ```bash
+    yarn add @synchro-charts/core
+   
+    # or with npm..
+    npm install --save @synchro-charts/core
+    ```
+   
+   For use within react,
    
     ```bash
     yarn add @synchro-charts/react
@@ -9,28 +18,18 @@
     # or with npm..
     npm install --save @synchro-charts/react
     ```
-   
-    To utilize as webcomponents
-    ```bash
-    yarn add @synchro-charts/core
-   
-    # or with npm..
-    npm install --save @synchro-charts/core
-    ```
-2. Initialize components
-   
+2. Initialize components if you are not using the react wrapper
+
     ```js static
     import { defineComponents, applyPolyfill } from '@synchro-charts/core/dist/loader';
 
     applyPolyfill().then(() => defineComponents());
     ```
+   
+    If you are using the react wrapper, this step is not necessary.
 
 3. Include a `<sc-webgl-context>`
-    Include the webgl context such that it's present where ever you utilize webgl based widgets (not required for all widgets)
-
-    The position of 'webgl context' will determine where the canvas is rendered which is rendered ontop of all the webgl based widgets.
-
-    It is important to assure that the `z-depth` of this canvas is above the Synchro Charts widgets
+    Include the webgl context such that it's present where ever you utilize webgl based components (not required for all components)
 
     ```jsx static
      ...
@@ -38,3 +37,6 @@
      ...
         
     ```
+    
+    Visit the [WebGL context documentation]( https://synchrocharts.com//#/WebGL%20context ) to learn more about how to set up the WebGL context.
+

--- a/packages/doc-site/docs/webglContext.md
+++ b/packages/doc-site/docs/webglContext.md
@@ -1,0 +1,67 @@
+In order to utilize Synchro Chart components which use WebGL to render the data, we will need to correctly initialize the WebGL context.
+
+### Why?
+In order to utilize WebGL, there must be a WebGL context initialized, which will allow you to render graphics onto a `canvas` element.
+
+However, there is a limit to the number of WebGL contexts which can be present within a browser. This limit can vary based on the browser utilized, but for Chrome that limit is 16.
+When more WebGL contexts are created than the browser supports, previously initialized WebGL contexts will disappear, causing the associated visualizations using that context to also disappear.
+
+In order to prevent having a limit of the number of visualizations utilizing WebGL, we share a single WebGL instance across all visualizations.
+
+Unfortunately, this presents a couple of complications, since the WebGL context must exist outside the individual components, and the canvas associated with the
+WebGL context must be large enough to contain all the visualizations. 
+
+### How to set up the WebGL context
+
+To set up the WebGL context, you will create a single instance of the following web component:
+
+```jsx static
+<sc-webgl-context />
+```
+
+This component will create a single canvas element which spans across the entire screen, and create an associated WebGL context to this canvas. Additionally, this component
+contains some Synchro Charts specific logic so that components can register and be part of the various update loops.
+
+#### Correct place of initialization
+
+Ensure that the position of the `<sc-webgl-context />` is correct
+ Since this component constructs the canvas which the visualizations are painted on, it's important that the `<sc-webgl-context />` is rendered on top of respective components.
+ 
+ Here's an example of a correct utilization of the component:
+
+ ```jsx static
+    <div>
+      <sc-line-chart ... />
+      <sc-bar-chart ... />
+      ...
+      <sc-webgl-context />
+    </div>
+ ```
+ 
+ Notice that the `<sc-webgl-context />` is initialized after the other visualizations - this ensures that the axis lines are rendered underneath the visualized data.
+
+ More information about rendering HTML elements in the correct order within [Mozilla's documentation on stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context)
+
+### Current pitfalls and issues
+
+1. Visualization clips on bottom 16px of screen
+   
+   This [issue](https://github.com/awslabs/synchro-charts/issues/30) is caused due to the canvas constructed by the `<sc-webgl-context />` not covering the last `16px` of the screen. This issue
+   will only be visible if you have no horizontal scroll bar on the bottom of the browser.
+   
+2. Visualized data briefly lag behind the associated component on browser resize
+
+   The visualized data is rendered to an absolutely positioned location on the canvas, however when resizing the canvas size changes and breifly causes the visualizations rendered onto it to not align correctly.
+
+3. Does not work well with components contained within nested scrolled areas.
+
+   Currently, the WebGL context doesn't have a way to know that a component has moved when a scroll action takes place within a nested element on the browser.
+
+   Synchro Charts however does work well when scrolling occurs to the entire page.
+
+### Components which require a WebGL context
+
+- Line chart
+- Scatter chart
+- Bar chart
+- Status timeline

--- a/packages/doc-site/src/components/BarChart.md
+++ b/packages/doc-site/src/components/BarChart.md
@@ -146,3 +146,5 @@ import { DataType, COMPARISON_OPERATOR, StatusIcon } from '@synchro-charts/core'
 </div>
 ```
 
+**Note**: This component requires a WebGL context to be initialized. Read more about how to set that up in the [WebGL context documentation]( https://synchrocharts.com//#/WebGL%20context )
+

--- a/packages/doc-site/src/components/LineChart.md
+++ b/packages/doc-site/src/components/LineChart.md
@@ -154,4 +154,4 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
 </div>
 ```
 
-
+**Note**: This component requires a WebGL context to be initialized. Read more about how to set that up in the [WebGL context documentation]( https://synchrocharts.com//#/WebGL%20context )

--- a/packages/doc-site/src/components/ScatterChart.md
+++ b/packages/doc-site/src/components/ScatterChart.md
@@ -153,3 +153,5 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
   />
 </div>
 ```
+
+**Note**: This component requires a WebGL context to be initialized. Read more about how to set that up in the [WebGL context documentation]( https://synchrocharts.com//#/WebGL%20context )

--- a/packages/doc-site/src/components/StatusTimeline.md
+++ b/packages/doc-site/src/components/StatusTimeline.md
@@ -159,3 +159,5 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
   />
 </div>
 ```
+
+**Note**: This component requires a WebGL context to be initialized. Read more about how to set that up in the [WebGL context documentation]( https://synchrocharts.com//#/WebGL%20context )

--- a/packages/doc-site/styleguide.config.js
+++ b/packages/doc-site/styleguide.config.js
@@ -35,7 +35,11 @@ module.exports = {
             exampleMode: 'hide',
         },
         {
-            name: 'Components',
+          name: 'WebGL context',
+          content: 'docs/webglContext.md',
+        },
+      {
+        name: 'Components',
             sectionDepth: 2,
             content: 'docs/components.md',
             components: 'src/components/**/*.js',


### PR DESCRIPTION
### Overview

Update doc-site to have more information regarding the WebGL context.

Other various minor documentation improvements as well.

This PR only effects the `doc-site`, so the integration test results for `synchro-charts` are omitted.

```
@synchro-charts/core: =============================== Coverage summary ===============================
@synchro-charts/core: Statements   : 89.54% ( 2430/2714 )
@synchro-charts/core: Branches     : 85% ( 1145/1347 )
@synchro-charts/core: Functions    : 86.63% ( 499/576 )
@synchro-charts/core: Lines        : 89.19% ( 2319/2600 )
@synchro-charts/core: ================================================================================
@synchro-charts/core: Test Suites: 75 passed, 75 total
@synchro-charts/core: Tests:       6 skipped, 1240 passed, 1246 total
@synchro-charts/core: Snapshots:   9 passed, 9 total
@synchro-charts/core: Time:        62.491s
@synchro-charts/core: Ran all test suites.
@synchro-charts/core: (node:75406) [DEP0128] DeprecationWarning: Invalid 'main' field in '/Users/diehbria/aws-synchro-charts/node_modules/eslint-config-airbnb-typescript/package.json' of 'dist/eslint-config-airbnb-typescript.js'. Please either fix that or report it to the module author
@synchro-charts/core: (Use `node --trace-deprecation ...` to show where the warning was created)
@synchro-charts/doc-site: $ echo "INFO: no test specified"
@synchro-charts/doc-site: INFO: no test specified
lerna success run Ran npm script 'test' in 2 packages in 90.4s:
lerna success - @synchro-charts/doc-site
lerna success - @synchro-charts/core
✨  Done in 91.47s.
```