### PR TITLE
viewPort -> viewport refactor

### DIFF
--- a/packages/doc-site/docs/annotation.md
+++ b/packages/doc-site/docs/annotation.md
@@ -10,7 +10,7 @@ const annotations = {
     showValue: true,
   }],
 };
-const viewPort = {
+const viewport = {
   start: new Date(2000, 0, 0),
   end: new Date(2001, 0, 0),
   group: 'viewport-group',
@@ -59,7 +59,7 @@ const dataStreams = [{
     style={style}
     annotations={annotations}
     widgetId="widget-id"
-    viewPort={viewPort}
+    viewport={viewport}
     legend={legend}
     dataStreams={dataStreams}
   />
@@ -67,7 +67,7 @@ const dataStreams = [{
     style={style}
     annotations={annotations}
     widgetId="widget-id"
-    viewPort={viewPort}
+    viewport={viewport}
     legend={legend}
     dataStreams={dataStreams}
   />
@@ -75,7 +75,7 @@ const dataStreams = [{
     style={style}
     annotations={annotations}
     widgetId="widget-id"
-    viewPort={viewPort}
+    viewport={viewport}
     legend={legend}
     dataStreams={[{
       id: 'car-count',

--- a/packages/doc-site/docs/performance.md
+++ b/packages/doc-site/docs/performance.md
@@ -24,7 +24,7 @@ return (
     <ScatterChart
       widgetId={`chart-${i}`}
       size={{ marginRight: 10 }}
-      viewPort={{
+      viewport={{
         yMin: -250,
         yMax: 250,
         start: new Date(2000, 0, 0),

--- a/packages/doc-site/docs/properties.md
+++ b/packages/doc-site/docs/properties.md
@@ -5,7 +5,7 @@
   
 --- 
   
-- `viewPort`: Object
+- `viewport`: Object
 
     Specifies the window of data which will be visible within the widget.
     

--- a/packages/doc-site/docs/synchronization.md
+++ b/packages/doc-site/docs/synchronization.md
@@ -6,7 +6,7 @@ const DAY_RESOLUTION = 1000 * 60 * 60 * 24; // one day
   <div style={{ width: "300px", height: "400px" }}>
     <LineChart
       widgetId="chart-1"
-      viewPort={{
+      viewport={{
         start: new Date(2000, 0, 0),
         end: new Date(2001, 0, 0),
         group: 'my-group',
@@ -62,7 +62,7 @@ const DAY_RESOLUTION = 1000 * 60 * 60 * 24; // one day
   <div style={{ width: "300px", height: "400px" }}>
     <LineChart
       widgetId="chart-2"
-      viewPort={{
+      viewport={{
         start: new Date(2000, 0, 0),
         end: new Date(2001, 0, 0),
         group: 'my-group',
@@ -117,7 +117,7 @@ const DAY_RESOLUTION = 1000 * 60 * 60 * 24; // one day
   <div style={{ width: "300px", height: "400px" }}>
     <LineChart
       widgetId="chart-3"
-      viewPort={{
+      viewport={{
         start: new Date(2000, 0, 0),
         end: new Date(2001, 0, 0),
         group: 'my-group',
@@ -186,14 +186,14 @@ The default behavior of a chart is to not synchronize with any other charts. To 
 ```jsx static
 <LineChart
   widgetId="chart-1"
-  viewPort={{
+  viewport={{
     group: 'my-group',
   }}
   ...
 />
 <LineChart
   widgetId="chart-2"
-  viewPort={{
+  viewport={{
     group: 'my-group',
   }}
   ...
@@ -205,25 +205,25 @@ Any number of view port groups may be defined, such as below:
 ```jsx static
 <LineChart
   widgetId="chart-1"
-  viewPort={{
+  viewport={{
     group: 'my-group',
   }}  ...
 />
 <LineChart
   widgetId="chart-2"
-  viewPort={{
+  viewport={{
     group: 'my-group',
   }}  ...
 />
 <LineChart
   widgetId="chart-3"
-  viewPort={{
+  viewport={{
     group: 'my-second-group',
   }}  ...
 />
 <LineChart
   widgetId="chart-4"
-  viewPort={{
+  viewport={{
     group: 'my-second-group',
   }}
   ...

--- a/packages/doc-site/docs/threshold.md
+++ b/packages/doc-site/docs/threshold.md
@@ -11,7 +11,7 @@ const annotations = {
     comparisonOperator: 'GTE',
   }],
 };
-const viewPort = {
+const viewport = {
   start: new Date(2000, 0, 0),
   end: new Date(2001, 0, 0),
   group: 'threshold',
@@ -61,7 +61,7 @@ const dataStreams = [{
     style={style}
     annotations={annotations}
     widgetId="widget-id"
-    viewPort={viewPort}
+    viewport={viewport}
     legend={legend}
     dataStreams={dataStreams}
   />
@@ -69,7 +69,7 @@ const dataStreams = [{
     style={style}
     annotations={annotations}
     widgetId="widget-id"
-    viewPort={viewPort}
+    viewport={viewport}
     legend={legend}
     dataStreams={dataStreams}
   />
@@ -77,7 +77,7 @@ const dataStreams = [{
     style={style}
     annotations={annotations}
     widgetId="widget-id"
-    viewPort={viewPort}
+    viewport={viewport}
     legend={legend}
     dataStreams={[{
       id: 'car-count',
@@ -205,7 +205,7 @@ const annotations = {
     comparisonOperator: 'GTE',
   }],
 };
-const viewPort = {
+const viewport = {
    start: new Date(2000, 0, 0),
    end: new Date(2001, 0, 0),
 };
@@ -254,7 +254,7 @@ const dataStreams = [{
     style={style}        
     annotations={annotations}
     widgetId="widget-id"
-    viewPort={viewPort}
+    viewport={viewport}
     legend={legend}
     dataStreams={dataStreams}
   />
@@ -280,7 +280,7 @@ const annotations = {
     comparisonOperator: 'LTE',
   }],
 };
-const viewPort = {
+const viewport = {
    start: new Date(2000, 0, 0),
    end: new Date(2001, 0, 0),
 };
@@ -329,7 +329,7 @@ const dataStreams = [{
     style={style}        
     annotations={annotations}
     widgetId="widget-id"
-    viewPort={viewPort}
+    viewport={viewport}
     legend={legend}
     dataStreams={dataStreams}
   />
@@ -356,7 +356,7 @@ const annotations = {
     comparisonOperator: 'GTE',
   }],
 };
-const viewPort = {
+const viewport = {
    start: new Date(2000, 0, 0),
    end: new Date(2001, 0, 0),
 };
@@ -405,7 +405,7 @@ const dataStreams = [{
     style={style}        
     annotations={annotations}
     widgetId="widget-id"
-    viewPort={viewPort}
+    viewport={viewport}
     legend={legend}
     dataStreams={dataStreams}
   />
@@ -431,7 +431,7 @@ const annotations = {
     comparisonOperator: 'LTE',
   }],
 };
-const viewPort = {
+const viewport = {
    start: new Date(2000, 0, 0),
    end: new Date(2001, 0, 0),
 };
@@ -481,7 +481,7 @@ const dataStreams = [{
     style={style}        
     annotations={annotations}
     widgetId="widget-id"
-    viewPort={viewPort}
+    viewport={viewport}
     legend={legend}
     dataStreams={dataStreams}
   />

--- a/packages/doc-site/docs/trendLine.md
+++ b/packages/doc-site/docs/trendLine.md
@@ -7,7 +7,7 @@ import { ScatterChart } from "@synchro-charts/react";
       type: 'linear-regression',
     }]}
     widgetId="widget-id"
-    viewPort={{
+    viewport={{
       start: new Date(2000, 0, 0),
       end: new Date(2001, 0, 0),
     }}

--- a/packages/doc-site/src/components/BarChart.md
+++ b/packages/doc-site/src/components/BarChart.md
@@ -2,7 +2,7 @@
 <div style={{ width: '100%', height: '500px' }}>
   <BarChart
     widgetId="widget-id"
-    viewPort={{
+    viewport={{
         start: new Date(2000, 0, 0),
         end: new Date(2001, 0, 0),
     }}
@@ -74,7 +74,7 @@ import { DataType, COMPARISON_OPERATOR, StatusIcon } from '@synchro-charts/core'
 <div style={{ width: '100%', height: '500px' }}>
   <BarChart
     widgetId="widget-id"
-    viewPort={{
+    viewport={{
         start: new Date(2000, 0, 0),
         end: new Date(2001, 0, 0),
     }}

--- a/packages/doc-site/src/components/KPI.md
+++ b/packages/doc-site/src/components/KPI.md
@@ -69,7 +69,7 @@ import { LEGEND_POSITION, DataType, COMPARISON_OPERATOR, StreamType, StatusIcon 
         icon: StatusIcon.LATCHED,
       }],
     }}
-    viewPort={{ duration: 0, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
+    viewport={{ duration: 0, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
   />
 </div>
 ```
@@ -111,7 +111,7 @@ import { LEGEND_POSITION, DataType, COMPARISON_OPERATOR } from '@synchro-charts/
         dataStreamIds: ['car-speed-alarm']
       }],
     }}
-    viewPort={{ duration: 0, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
+    viewport={{ duration: 0, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
   />
 </div>
 ```
@@ -149,7 +149,7 @@ import { LEGEND_POSITION, DataType, COMPARISON_OPERATOR } from '@synchro-charts/
         comparisonOperator: COMPARISON_OPERATOR.EQUAL,
       }],
     }}
-    viewPort={{ duration: 0, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
+    viewport={{ duration: 0, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
   />
 </div>
 ```
@@ -212,7 +212,7 @@ import { LEGEND_POSITION, DataType, COMPARISON_OPERATOR, StatusIcon, StreamType 
         icon: StatusIcon.LATCHED
       }],
     }}
-    viewPort={{ duration: 0, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
+    viewport={{ duration: 0, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
   />
 </div>
 ```

--- a/packages/doc-site/src/components/LineChart.md
+++ b/packages/doc-site/src/components/LineChart.md
@@ -3,7 +3,7 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
 <div style={{ width: '100%', height: '500px' }}>
   <LineChart
     widgetId="widget-id"
-    viewPort={{
+    viewport={{
         start: new Date(2000, 0, 0),
         end: new Date(2001, 2, 0),
     }}
@@ -79,7 +79,7 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
 <div style={{ width: '100%', height: '500px' }}>
   <LineChart
     widgetId="widget-id"
-    viewPort={{
+    viewport={{
         start: new Date(2000, 0, 0),
         end: new Date(2001, 2, 0),
     }}

--- a/packages/doc-site/src/components/ScatterChart.md
+++ b/packages/doc-site/src/components/ScatterChart.md
@@ -3,7 +3,7 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
 <div style={{ width: '100%', height: '500px' }}>
   <ScatterChart
     widgetId="widget-id"
-    viewPort={{
+    viewport={{
       start: new Date(1999, 11, 0),
       end: new Date(2001, 2, 0),
     }}
@@ -78,7 +78,7 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
 <div style={{ width: '100%', height: '500px' }}>
   <ScatterChart
     widgetId="widget-id"
-    viewPort={{
+    viewport={{
         start: new Date(1999, 11, 0),
         end: new Date(2001, 2, 0),
     }}

--- a/packages/doc-site/src/components/StatusGrid.md
+++ b/packages/doc-site/src/components/StatusGrid.md
@@ -73,7 +73,7 @@ import { LEGEND_POSITION, DataType, COMPARISON_OPERATOR, StreamType } from '@syn
           dataStreamIds: ['car-speed-alarm']
         }],
     }}
-    viewPort={{ duration: 0, iyMin: 0, yMax: 100, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
+    viewport={{ duration: 0, iyMin: 0, yMax: 100, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
   />
 </div>
 ```
@@ -131,7 +131,7 @@ import { LEGEND_POSITION, DataType, COMPARISON_OPERATOR } from '@synchro-charts/
     ]}
     labelsConfig={{ showName: true, showValue: true, showUnit: true }}
     widgetId="widget-id"
-    viewPort={{ duration: 0, iyMin: 0, yMax: 100, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
+    viewport={{ duration: 0, iyMin: 0, yMax: 100, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
   />
 </div>
 ```
@@ -179,7 +179,7 @@ import { LEGEND_POSITION, DataType, COMPARISON_OPERATOR } from '@synchro-charts/
         comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN_EQUAL,
       }],
     }}
-    viewPort={{ duration: 0, iyMin: 0, yMax: 100, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
+    viewport={{ duration: 0, iyMin: 0, yMax: 100, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
   />
 </div>
 ```
@@ -236,7 +236,7 @@ import { LEGEND_POSITION, DataType, COMPARISON_OPERATOR, StreamType } from '@syn
         dataStreamIds: ['car-speed-alarm']
       }],
     }}
-    viewPort={{ duration: 0, iyMin: 0, yMax: 100, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
+    viewport={{ duration: 0, iyMin: 0, yMax: 100, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
   />
 </div>
 ```

--- a/packages/doc-site/src/components/StatusTimeline.md
+++ b/packages/doc-site/src/components/StatusTimeline.md
@@ -51,7 +51,7 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
       width: 100,
       position: LEGEND_POSITION.BOTTOM,
     }}
-    viewPort={{ yMin: 0, yMax: 100, start: new Date(1999, 0, 0), end: new Date(2001, 6, 0) }}
+    viewport={{ yMin: 0, yMax: 100, start: new Date(1999, 0, 0), end: new Date(2001, 6, 0) }}
   />
 </div>
 ```
@@ -155,7 +155,7 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
       width: 100,
       position: LEGEND_POSITION.BOTTOM,
     }}
-    viewPort={{ yMin: 0, yMax: 100, start: new Date(1999, 0, 0), end: new Date(2001, 6, 0) }}
+    viewport={{ yMin: 0, yMax: 100, start: new Date(1999, 0, 0), end: new Date(2001, 6, 0) }}
   />
 </div>
 ```

--- a/packages/doc-site/src/components/Table.md
+++ b/packages/doc-site/src/components/Table.md
@@ -161,7 +161,7 @@ const carSpeedTableColumn = {
       }
     ]}
     widgetId="widget-id"
-    viewPort={{ duration: 0, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
+    viewport={{ duration: 0, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
     tableColumns={[windTableColumn, carSpeedTableColumn]}
   />
 </div>
@@ -384,7 +384,7 @@ const carSpeedTableColumn = {
       width: 100,
       position: LEGEND_POSITION.BOTTOM,
     }}
-    viewPort={{ duration: 0, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
+    viewport={{ duration: 0, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
     tableColumns={[windTableColumn, carSpeedTableColumn]}
   />
 </div>
@@ -605,7 +605,7 @@ const windTempAlarm = {
       width: 100,
       position: LEGEND_POSITION.BOTTOM,
     }}
-    viewPort={{ duration: 0, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
+    viewport={{ duration: 0, start: new Date(1999, 0, 0), end: new Date(2001, 0, 0) }}
     tableColumns={[windTableColumn, windTempAlarm]}
   />
 </div>

--- a/packages/doc-site/src/components/chart-demo/Demo.jsx
+++ b/packages/doc-site/src/components/chart-demo/Demo.jsx
@@ -44,7 +44,7 @@ const TESTING_GROUND_CHART_CONFIG = {
     position: LEGEND_POSITION.BOTTOM,
     width: 170,
   },
-  viewPort: {
+  viewport: {
     start: new Date(1998, 0, 0),
     end: new Date(2000, 0, 1),
   },
@@ -104,8 +104,8 @@ export class Demo extends React.Component {
       annotationComp: COMPARISON_OPERATOR.LESS_THAN,
       config: {
         ...TESTING_GROUND_CHART_CONFIG,
-        viewPort: {
-          ...TESTING_GROUND_CHART_CONFIG.viewPort,
+        viewport: {
+          ...TESTING_GROUND_CHART_CONFIG.viewport,
           start: new Date(1998, 0, 0),
           end: new Date(1998, 1, 0),
         }
@@ -372,7 +372,7 @@ export class Demo extends React.Component {
             >
               <ChartName
                 widgetId={this.config.widgetId + i.toString()}
-                viewPort={{...this.config.viewPort, duration: this.duration, group: 'DEMO_GROUP'}}
+                viewport={{...this.config.viewport, duration: this.duration, group: 'DEMO_GROUP'}}
                 legend={this.config.legend}
                 dataStreams={this.config.dataStreams}
                 annotations={this.state.annotations}

--- a/packages/doc-site/src/components/chart-demo/LiveDemo.jsx
+++ b/packages/doc-site/src/components/chart-demo/LiveDemo.jsx
@@ -139,7 +139,7 @@ export class LiveDemo extends React.Component {
       dataStreams,
       alarmStatusStreams,
       isLiveMode: true,
-      viewPort: {
+      viewport: {
         start: new Date (Date.now() - DURATION),
         end: new Date(),
         group: 'Live_demo',
@@ -151,8 +151,8 @@ export class LiveDemo extends React.Component {
     setInterval(() => {
       if (this.state.isLiveMode) {
         this.setState({
-          viewPort: {
-            ...this.state.viewPort,
+          viewport: {
+            ...this.state.viewport,
             start: new Date (Date.now() - DURATION),
             end: new Date(),
           },
@@ -198,8 +198,8 @@ export class LiveDemo extends React.Component {
   onDateRangeChange = ({ detail: [start, end]}) => {
     this.setState({
       isLiveMode: false,
-      viewPort: {
-        ...this.state.viewPort,
+      viewport: {
+        ...this.state.viewport,
         start,
         end,
       }
@@ -207,13 +207,13 @@ export class LiveDemo extends React.Component {
   }
 
   render() {
-    const { viewPort, dataStreams, alarmStatusStreams } = this.state;
+    const { viewport, dataStreams, alarmStatusStreams } = this.state;
     return (
       <div ref={this.liveDemoContainer}>
         <div style={{ height: '250px', width: '100%' }}>
           <LineChart
             widgetId="line-chart-1"
-            viewPort={viewPort}
+            viewport={viewport}
             dataStreams={dataStreams}
             annotations={propertyAnnotations}
           />
@@ -221,7 +221,7 @@ export class LiveDemo extends React.Component {
         <div style={{ height: '250px', marginLeft: '40px', width: 'calc(100% - 75px)' }}>
           <StatusTimeline
             widgetId="status-timeline-1"
-            viewPort={viewPort}
+            viewport={viewport}
             dataStreams={alarmStatusStreams}
             annotations={annotations}
           />

--- a/packages/synchro-charts/cypress/integration/charts/alarms.spec.ts
+++ b/packages/synchro-charts/cypress/integration/charts/alarms.spec.ts
@@ -75,8 +75,8 @@ describe('when provided alarm data through a `dynamic-widget`', () => {
   const DATE_OF_POINT = NUMERICAL_ALARM_STREAM.data[0].x;
 
   // View port which contains the point
-  const viewPortStart = new Date(DATE_OF_POINT - MINUTE_IN_MS);
-  const viewPortEnd = new Date(DATE_OF_POINT + 5 * MINUTE_IN_MS);
+  const viewportStart = new Date(DATE_OF_POINT - MINUTE_IN_MS);
+  const viewportEnd = new Date(DATE_OF_POINT + 5 * MINUTE_IN_MS);
 
   describe('widgets determine whether to visualize alarm data or not', () => {
     describe('kpi', () => {
@@ -86,8 +86,8 @@ describe('when provided alarm data through a `dynamic-widget`', () => {
           dataStreams: [NUMERICAL_ALARM_STREAM, PROPERTY_STREAM],
           annotations: { y: [ALARM_THRESHOLD] },
           duration: MINUTE_IN_MS,
-          viewPortStart,
-          viewPortEnd,
+          viewportStart,
+          viewportEnd,
         });
 
         cy.get('sc-chart-icon').should('be.visible');
@@ -105,8 +105,8 @@ describe('when provided alarm data through a `dynamic-widget`', () => {
           dataStreams: [NUMERICAL_ALARM_STREAM, PROPERTY_STREAM],
           annotations: { y: [ALARM_THRESHOLD] },
           duration: MINUTE_IN_MS,
-          viewPortStart,
-          viewPortEnd,
+          viewportStart,
+          viewportEnd,
         });
 
         cy.get('sc-chart-icon').should('be.visible');
@@ -126,8 +126,8 @@ describe('when provided alarm data through a `dynamic-widget`', () => {
         visitDynamicWidget(cy, {
           componentTag: 'sc-line-chart',
           dataStreams: [NUMERICAL_ALARM_STREAM],
-          viewPortStart,
-          viewPortEnd,
+          viewportStart,
+          viewportEnd,
         });
 
         cy.waitForChart();
@@ -140,8 +140,8 @@ describe('when provided alarm data through a `dynamic-widget`', () => {
         visitDynamicWidget(cy, {
           componentTag: 'sc-line-chart',
           dataStreams: [NUMERICAL_ALARM_STREAM],
-          viewPortStart,
-          viewPortEnd,
+          viewportStart,
+          viewportEnd,
         });
 
         cy.waitForChart();
@@ -162,8 +162,8 @@ describe('when provided alarm data through a `dynamic-widget`', () => {
         visitDynamicWidget(cy, {
           componentTag: 'sc-scatter-chart',
           dataStreams: [NUMERICAL_ALARM_STREAM],
-          viewPortStart,
-          viewPortEnd,
+          viewportStart,
+          viewportEnd,
         });
 
         cy.waitForChart();
@@ -176,8 +176,8 @@ describe('when provided alarm data through a `dynamic-widget`', () => {
         visitDynamicWidget(cy, {
           componentTag: 'sc-scatter-chart',
           dataStreams: [NUMERICAL_ALARM_STREAM],
-          viewPortStart,
-          viewPortEnd,
+          viewportStart,
+          viewportEnd,
         });
 
         cy.waitForChart();
@@ -198,8 +198,8 @@ describe('when provided alarm data through a `dynamic-widget`', () => {
         visitDynamicWidget(cy, {
           componentTag: 'sc-bar-chart',
           dataStreams: [NUMERICAL_ALARM_STREAM],
-          viewPortStart,
-          viewPortEnd,
+          viewportStart,
+          viewportEnd,
         });
 
         cy.waitForChart();
@@ -212,8 +212,8 @@ describe('when provided alarm data through a `dynamic-widget`', () => {
         visitDynamicWidget(cy, {
           componentTag: 'sc-bar-chart',
           dataStreams: [NUMERICAL_ALARM_STREAM],
-          viewPortStart,
-          viewPortEnd,
+          viewportStart,
+          viewportEnd,
         });
 
         cy.waitForChart();
@@ -235,8 +235,8 @@ describe('when provided alarm data through a `dynamic-widget`', () => {
           componentTag: 'sc-status-timeline',
           alarms: { expires: MINUTE_IN_MS },
           dataStreams: [NUMERICAL_ALARM_STREAM],
-          viewPortStart,
-          viewPortEnd,
+          viewportStart,
+          viewportEnd,
         });
 
         cy.contains(STATUS_TIMELINE_OVERLAY_ROW_SELECTOR, NUMERICAL_ALARM_STREAM.data[0].y).should('be.visible');
@@ -250,8 +250,8 @@ describe('when provided alarm data through a `dynamic-widget`', () => {
           componentTag: 'sc-status-timeline',
           dataStreams: [NUMERICAL_ALARM_STREAM],
           annotations: { y: [ALARM_THRESHOLD] },
-          viewPortStart,
-          viewPortEnd,
+          viewportStart,
+          viewportEnd,
         });
 
         cy.waitForChart();
@@ -353,8 +353,8 @@ describe('when provided alarm data through a `dynamic-widget`', () => {
       componentTag: 'sc-line-chart',
       dataStreams: DATA,
       annotations: ANNOTATIONS,
-      viewPortStart: new Date(2000, 0, 0, 6),
-      viewPortEnd: new Date(2000, 0, 0, 12),
+      viewportStart: new Date(2000, 0, 0, 6),
+      viewportEnd: new Date(2000, 0, 0, 12),
     });
 
     cy.get(LEGEND_VALUE_SELECTOR)
@@ -373,8 +373,8 @@ describe('when provided alarm data through a `dynamic-widget`', () => {
       componentTag: 'sc-line-chart',
       dataStreams: DATA,
       annotations: ANNOTATIONS,
-      viewPortStart: new Date(2000, 0, 3),
-      viewPortEnd: new Date(2000, 0, 4),
+      viewportStart: new Date(2000, 0, 3),
+      viewportEnd: new Date(2000, 0, 4),
     });
 
     cy.get(LEGEND_VALUE_SELECTOR)
@@ -393,8 +393,8 @@ describe('when provided alarm data through a `dynamic-widget`', () => {
       componentTag: 'sc-line-chart',
       annotations: ANNOTATIONS,
       dataStreams: DATA,
-      viewPortStart: new Date(1990, 0, 0),
-      viewPortEnd: new Date(1991, 0, 0),
+      viewportStart: new Date(1990, 0, 0),
+      viewportEnd: new Date(1991, 0, 0),
     });
 
     cy.get(LEGEND_VALUE_SELECTOR)

--- a/packages/synchro-charts/cypress/integration/charts/annotation-rescaling.spec.ts
+++ b/packages/synchro-charts/cypress/integration/charts/annotation-rescaling.spec.ts
@@ -5,12 +5,12 @@ import { X_MAX, X_MIN, Y_MAX, Y_MIN } from '../../../src/testing/test-routes/cha
 const baseChartHeight = 500;
 const baseChartWidth = 700;
 
-const viewPortStart = X_MIN;
-const viewPortEnd = X_MAX;
+const viewportStart = X_MIN;
+const viewportEnd = X_MAX;
 const timelineParams: Partial<SearchQueryParams> = {
   componentTag: 'sc-line-chart',
-  viewPortStart,
-  viewPortEnd,
+  viewportStart,
+  viewportEnd,
   dataStreams: [],
   width: '95%',
   height: '95%',

--- a/packages/synchro-charts/cypress/integration/charts/bar-chart/gestures.spec.ts
+++ b/packages/synchro-charts/cypress/integration/charts/bar-chart/gestures.spec.ts
@@ -16,8 +16,8 @@ it('moves viewport when gestures are applied', () => {
 
   visitDynamicWidget(cy, {
     componentTag: 'sc-bar-chart',
-    viewPortStart: START,
-    viewPortEnd: END,
+    viewportStart: START,
+    viewportEnd: END,
     gestures: true,
   });
 
@@ -41,8 +41,8 @@ it('does not move viewport when gestures are not applied', () => {
 
   visitDynamicWidget(cy, {
     componentTag: 'sc-bar-chart',
-    viewPortStart: START,
-    viewPortEnd: END,
+    viewportStart: START,
+    viewportEnd: END,
     gestures: false,
   });
 

--- a/packages/synchro-charts/cypress/integration/charts/bar-chart/tooltip.spec.ts
+++ b/packages/synchro-charts/cypress/integration/charts/bar-chart/tooltip.spec.ts
@@ -19,8 +19,8 @@ import {
 it('renders no tooltip when only info is empty or string', () => {
   visitDynamicWidget(cy, {
     componentTag: 'sc-bar-chart',
-    viewPortStart: new Date(START_DATE.getTime() - MINUTE_IN_MS),
-    viewPortEnd: new Date(START_DATE.getTime() + 10 * MINUTE_IN_MS),
+    viewportStart: new Date(START_DATE.getTime() - MINUTE_IN_MS),
+    viewportEnd: new Date(START_DATE.getTime() + 10 * MINUTE_IN_MS),
     dataStreams: [
       { ...NUMBER_EMPTY_STREAM, resolution: SECOND_IN_MS },
       { ...STRING_STREAM_1, data: [], aggregates: { [SECOND_IN_MS]: STRING_STREAM_1.data }, resolution: SECOND_IN_MS },
@@ -42,8 +42,8 @@ it('renders no tooltip when only info is empty or string', () => {
 it('renders no tooltip when there is no data for the requested resolution', () => {
   visitDynamicWidget(cy, {
     componentTag: 'sc-bar-chart',
-    viewPortStart: new Date(START_DATE.getTime() - MINUTE_IN_MS),
-    viewPortEnd: new Date(START_DATE.getTime() + 10 * MINUTE_IN_MS),
+    viewportStart: new Date(START_DATE.getTime() - MINUTE_IN_MS),
+    viewportEnd: new Date(START_DATE.getTime() + 10 * MINUTE_IN_MS),
     dataStreams: [{ ...NUMBER_STREAM_1, resolution: SECOND_IN_MS }],
   });
 
@@ -63,8 +63,8 @@ it('renders tooltip rows in order of values magnitude', () => {
   const resolution = MINUTE_IN_MS;
   visitDynamicWidget(cy, {
     componentTag: 'sc-bar-chart',
-    viewPortStart: new Date(START_DATE.getTime() - MINUTE_IN_MS),
-    viewPortEnd: new Date(START_DATE.getTime() + 10 * MINUTE_IN_MS),
+    viewportStart: new Date(START_DATE.getTime() - MINUTE_IN_MS),
+    viewportEnd: new Date(START_DATE.getTime() + 10 * MINUTE_IN_MS),
     dataStreams: [
       { ...NUMBER_STREAM_1, data: [], aggregates: { [resolution]: NUMBER_STREAM_1.data }, resolution },
       { ...NUMBER_STREAM_2, data: [], aggregates: { [resolution]: NUMBER_STREAM_2.data }, resolution },

--- a/packages/synchro-charts/cypress/integration/charts/cross-resolution.spec.ts
+++ b/packages/synchro-charts/cypress/integration/charts/cross-resolution.spec.ts
@@ -42,8 +42,8 @@ const AGGREGATED_DATA_STREAM = {
 it('displays each aggregation description within tooltip', () => {
   visitDynamicWidget(cy, {
     componentTag: 'sc-line-chart',
-    viewPortStart: START,
-    viewPortEnd: END,
+    viewportStart: START,
+    viewportEnd: END,
     dataStreams: [RAW_DATA_STREAM, AGGREGATED_DATA_STREAM],
   });
   cy.waitForChart();

--- a/packages/synchro-charts/cypress/integration/charts/line-chart/gestures.spec.ts
+++ b/packages/synchro-charts/cypress/integration/charts/line-chart/gestures.spec.ts
@@ -16,8 +16,8 @@ it('moves viewport when gestures are applied', () => {
 
   visitDynamicWidget(cy, {
     componentTag: 'sc-line-chart',
-    viewPortStart: START,
-    viewPortEnd: END,
+    viewportStart: START,
+    viewportEnd: END,
     gestures: true,
   });
 
@@ -39,8 +39,8 @@ it('does not move viewport when gestures are not applied', () => {
 
   visitDynamicWidget(cy, {
     componentTag: 'sc-scatter-chart',
-    viewPortStart: START,
-    viewPortEnd: END,
+    viewportStart: START,
+    viewportEnd: END,
     gestures: false,
   });
 

--- a/packages/synchro-charts/cypress/integration/charts/line-chart/sc-webgl-chart.spec.ts
+++ b/packages/synchro-charts/cypress/integration/charts/line-chart/sc-webgl-chart.spec.ts
@@ -278,7 +278,7 @@ describe('line chart', () => {
 });
 
 describe('view port updating', () => {
-  const VIEW_PORT_CHANGE_URL = 'localhost:3333/tests/line-chart/viewport-change';
+  const VIEWPORT_CHANGE_URL = 'localhost:3333/tests/line-chart/viewport-change';
   const NARROW_VIEWPORT_X_AXIS_LABEL = '12 PM'; // A label which renders when viewing the 'narrow' view port
   const WIDE_VIEWPORT_X_AXIS_LABEL = 'July'; // A label which renders when viewing the 'wide' view port
 
@@ -293,7 +293,7 @@ describe('view port updating', () => {
 
   describe('while part of a view port group', () => {
     it('takes new viewport on first view port update', () => {
-      cy.visit(VIEW_PORT_CHANGE_URL);
+      cy.visit(VIEWPORT_CHANGE_URL);
 
       /** Has initially loaded */
       cy.contains(NARROW_VIEWPORT_X_AXIS_LABEL).should('exist');
@@ -308,7 +308,7 @@ describe('view port updating', () => {
     });
 
     it('takes new viewport on second view port update', () => {
-      cy.visit(VIEW_PORT_CHANGE_URL);
+      cy.visit(VIEWPORT_CHANGE_URL);
 
       /** Has initially loaded */
       cy.contains(NARROW_VIEWPORT_X_AXIS_LABEL).should('exist');

--- a/packages/synchro-charts/cypress/integration/charts/line-chart/tooltip.spec.ts
+++ b/packages/synchro-charts/cypress/integration/charts/line-chart/tooltip.spec.ts
@@ -18,8 +18,8 @@ import {
 it('renders no tooltip when only info is empty or string', () => {
   visitDynamicWidget(cy, {
     componentTag: 'sc-line-chart',
-    viewPortStart: new Date(2000, 0, 0),
-    viewPortEnd: new Date(2000, 0, 0, 0, 5),
+    viewportStart: new Date(2000, 0, 0),
+    viewportEnd: new Date(2000, 0, 0, 0, 5),
     dataStreams: [NUMBER_EMPTY_STREAM, STRING_STREAM_1],
   });
 
@@ -38,8 +38,8 @@ it('renders no tooltip when only info is empty or string', () => {
 it('renders tooltip rows in order of values magnitude', () => {
   visitDynamicWidget(cy, {
     componentTag: 'sc-line-chart',
-    viewPortStart: new Date(new Date(2000, 0, 0).getTime() - MINUTE_IN_MS),
-    viewPortEnd: new Date(2000, 0, 0, 0, 5),
+    viewportStart: new Date(new Date(2000, 0, 0).getTime() - MINUTE_IN_MS),
+    viewportEnd: new Date(2000, 0, 0, 0, 5),
     dataStreams: [NUMBER_STREAM_1, NUMBER_STREAM_2],
   });
 

--- a/packages/synchro-charts/cypress/integration/charts/performance.spec.ts
+++ b/packages/synchro-charts/cypress/integration/charts/performance.spec.ts
@@ -15,7 +15,7 @@ type PerfTestCase = {
   // Data added per round
   dataPerRound: number;
   // Incremental increase in MS of the viewport per frame
-  viewPortSpeed?: number;
+  viewportSpeed?: number;
 };
 
 const RUN_EACH_TEST_NUM_TIMES = 1;
@@ -63,14 +63,14 @@ const testCases: PerfTestCase[] = [
     testDuration: 5 * SECOND_IN_MS,
     roundFrequency: SECOND_IN_MS / 50,
     dataPerRound: 2000,
-    viewPortSpeed: DAY_IN_MS,
+    viewportSpeed: DAY_IN_MS,
   },
   {
     minFPS: 7,
     testDuration: 15 * SECOND_IN_MS,
     roundFrequency: SECOND_IN_MS / 50,
     dataPerRound: 2000,
-    viewPortSpeed: DAY_IN_MS,
+    viewportSpeed: DAY_IN_MS,
   },
 ];
 
@@ -83,15 +83,15 @@ describe.skip('line chart', () => {
   const results: any = {};
 
   describe('with all data being added within the viewport', () => {
-    testCases.forEach(({ viewPortSpeed, minFPS, roundFrequency, dataPerRound, testDuration }) => {
-      const testName = `${viewPortSpeed != null ? `view port moving at a rate of ${viewPortSpeed}ms ` : ''}with ${dataPerRound} data per round, coming in at a frequency of ${roundFrequency}ms, a min FPS will be ${minFPS} over a duration of ${Math.floor(
+    testCases.forEach(({ viewportSpeed, minFPS, roundFrequency, dataPerRound, testDuration }) => {
+      const testName = `${viewportSpeed != null ? `view port moving at a rate of ${viewportSpeed}ms ` : ''}with ${dataPerRound} data per round, coming in at a frequency of ${roundFrequency}ms, a min FPS will be ${minFPS} over a duration of ${Math.floor(
         testDuration / SECOND_IN_MS
       )}sec`;
       results[testName] = {};
       new Array(RUN_EACH_TEST_NUM_TIMES).fill(0).forEach((_, runNum) => {
         it(`RUN ${runNum + 1}: ${testName}`, () => {
           cy.visit(
-            `${root}/sc-line-chart-stream-data?viewPortSpeed=${viewPortSpeed || 0}&roundFrequency=${roundFrequency}&dataPerRound=${dataPerRound}`
+            `${root}/sc-line-chart-stream-data?viewportSpeed=${viewportSpeed || 0}&roundFrequency=${roundFrequency}&dataPerRound=${dataPerRound}`
           );
           cy.get('sc-line-chart').should('exist');
 

--- a/packages/synchro-charts/cypress/integration/charts/scatter-chart/gestures.spec.ts
+++ b/packages/synchro-charts/cypress/integration/charts/scatter-chart/gestures.spec.ts
@@ -7,8 +7,8 @@ it('moves viewport when gestures are applied', () => {
 
   visitDynamicWidget(cy, {
     componentTag: 'sc-scatter-chart',
-    viewPortStart: START,
-    viewPortEnd: END,
+    viewportStart: START,
+    viewportEnd: END,
     gestures: true,
   });
 
@@ -30,8 +30,8 @@ it('does not move viewport when gestures are not applied', () => {
 
   visitDynamicWidget(cy, {
     componentTag: 'sc-scatter-chart',
-    viewPortStart: START,
-    viewPortEnd: END,
+    viewportStart: START,
+    viewportEnd: END,
     gestures: false,
   });
 

--- a/packages/synchro-charts/cypress/integration/charts/scatter-chart/tooltip.spec.ts
+++ b/packages/synchro-charts/cypress/integration/charts/scatter-chart/tooltip.spec.ts
@@ -18,8 +18,8 @@ import {
 it('renders no tooltip when only info is empty or string', () => {
   visitDynamicWidget(cy, {
     componentTag: 'sc-scatter-chart',
-    viewPortStart: new Date(2000, 0, 0),
-    viewPortEnd: new Date(2000, 0, 0, 0, 5),
+    viewportStart: new Date(2000, 0, 0),
+    viewportEnd: new Date(2000, 0, 0, 0, 5),
     dataStreams: [NUMBER_EMPTY_STREAM, STRING_STREAM_1],
   });
 
@@ -38,8 +38,8 @@ it('renders no tooltip when only info is empty or string', () => {
 it('renders tooltip rows in order of values magnitude', () => {
   visitDynamicWidget(cy, {
     componentTag: 'sc-scatter-chart',
-    viewPortStart: new Date(2000, 0, 0),
-    viewPortEnd: new Date(2000, 0, 0, 0, 5),
+    viewportStart: new Date(2000, 0, 0),
+    viewportEnd: new Date(2000, 0, 0, 0, 5),
     dataStreams: [NUMBER_STREAM_1, NUMBER_EMPTY_STREAM, NUMBER_STREAM_2],
   });
 

--- a/packages/synchro-charts/cypress/integration/charts/status-timeline/gestures.spec.ts
+++ b/packages/synchro-charts/cypress/integration/charts/status-timeline/gestures.spec.ts
@@ -7,8 +7,8 @@ it('moves viewport when gestures are applied', () => {
 
   visitDynamicWidget(cy, {
     componentTag: 'sc-status-timeline',
-    viewPortStart: START,
-    viewPortEnd: END,
+    viewportStart: START,
+    viewportEnd: END,
     gestures: true,
   });
 
@@ -30,8 +30,8 @@ it('does not move viewport when gestures are not applied', () => {
 
   visitDynamicWidget(cy, {
     componentTag: 'sc-status-timeline',
-    viewPortStart: START,
-    viewPortEnd: END,
+    viewportStart: START,
+    viewportEnd: END,
     gestures: false,
   });
 

--- a/packages/synchro-charts/cypress/integration/charts/status-timeline/status-timeline.spec.ts
+++ b/packages/synchro-charts/cypress/integration/charts/status-timeline/status-timeline.spec.ts
@@ -27,16 +27,16 @@ describe('status timeline', () => {
   const VIEWPORT_WIDTH = 500;
 
   describe('alarm configuration', () => {
-    const viewPortStart = new Date(2000, 0, 0);
-    const viewPortEnd = new Date(2000, 0, 1);
+    const viewportStart = new Date(2000, 0, 0);
+    const viewportEnd = new Date(2000, 0, 1);
     const timelineParams: Partial<SearchQueryParams> = {
       componentTag: 'sc-status-timeline',
-      viewPortStart,
-      viewPortEnd,
+      viewportStart,
+      viewportEnd,
       dataStreams: [
         {
           ...DATA_STREAM,
-          data: [{ x: viewPortStart.getTime(), y: 100 }],
+          data: [{ x: viewportStart.getTime(), y: 100 }],
         },
       ],
     };

--- a/packages/synchro-charts/cypress/integration/charts/status-timeline/tooltip.spec.ts
+++ b/packages/synchro-charts/cypress/integration/charts/status-timeline/tooltip.spec.ts
@@ -21,8 +21,8 @@ it('renders with tooltip for multiple data streams with order in which they were
   // tooltip position is based on info order, *not* data order.
   visitDynamicWidget(cy, {
     componentTag: 'sc-status-timeline',
-    viewPortStart: new Date(2000, 0, 0),
-    viewPortEnd: new Date(2000, 0, 0, 0, 5),
+    viewportStart: new Date(2000, 0, 0),
+    viewportEnd: new Date(2000, 0, 0, 0, 5),
     dataStreams: [STRING_STREAM_1, NUMBER_EMPTY_STREAM, STRING_STREAM_2],
     annotations: ANNOTATIONS,
     alarms: { expires: MINUTE_IN_MS },

--- a/packages/synchro-charts/cypress/integration/table/table.spec.ts
+++ b/packages/synchro-charts/cypress/integration/table/table.spec.ts
@@ -9,8 +9,8 @@ const DISABLE_STATUS_SELECTOR = '.disable-status';
 
 const DATE_OF_POINT = new Date(2000, 0, 0);
 
-const viewPortStart = new Date(DATE_OF_POINT.getTime() - MINUTE_IN_MS);
-const viewPortEnd = new Date(DATE_OF_POINT.getTime() + 5 * MINUTE_IN_MS);
+const viewportStart = new Date(DATE_OF_POINT.getTime() - MINUTE_IN_MS);
+const viewportEnd = new Date(DATE_OF_POINT.getTime() + 5 * MINUTE_IN_MS);
 
 it('renders table column values', () => {
   const { tableColumns, dataStreams, annotations } = tableMockData({});
@@ -20,8 +20,8 @@ it('renders table column values', () => {
     dataStreams,
     tableColumns,
     annotations,
-    viewPortStart,
-    viewPortEnd,
+    viewportStart,
+    viewportEnd,
   });
 
   cy.get(COLUMN_SELECTOR)
@@ -47,8 +47,8 @@ it('renders table row values', () => {
     dataStreams,
     tableColumns,
     annotations,
-    viewPortStart,
-    viewPortEnd,
+    viewportStart,
+    viewportEnd,
   });
 
   cy.get(CELL_SELECTOR)
@@ -85,8 +85,8 @@ it('renders loading spinner for cells in a table', () => {
     duration: MINUTE_IN_MS,
     tableColumns,
     annotations,
-    viewPortStart,
-    viewPortEnd,
+    viewportStart,
+    viewportEnd,
   });
 
   cy.get(CELL_SELECTOR).should('be.visible');
@@ -105,8 +105,8 @@ it('renders error string and icon in a table', () => {
     delayBeforeDataLoads: 5 * SECOND_IN_MS,
     tableColumns,
     annotations,
-    viewPortStart,
-    viewPortEnd,
+    viewportStart,
+    viewportEnd,
   });
 
   cy.get(CELL_SELECTOR)
@@ -126,8 +126,8 @@ describe('layout edge cases', () => {
       dataStreams,
       duration: MINUTE_IN_MS,
       tableColumns,
-      viewPortStart,
-      viewPortEnd,
+      viewportStart,
+      viewportEnd,
       height: 140, // short enough not all 4 rows can be shown
     });
 
@@ -152,7 +152,7 @@ describe('layout edge cases', () => {
           ...dataStreams[0],
           data: [
             {
-              x: viewPortStart.getTime(),
+              x: viewportStart.getTime(),
               y:
                 'this is a cell with very very long text, i am unsure why i need to be this long but this is not the place to ask such questions. there is a secrete message embedded within this string. or is there?',
             },
@@ -160,8 +160,8 @@ describe('layout edge cases', () => {
         },
       ],
       tableColumns: [tableColumns[0]],
-      viewPortStart,
-      viewPortEnd,
+      viewportStart,
+      viewportEnd,
       height: 140,
       width: 100,
     });
@@ -183,8 +183,8 @@ describe('layout edge cases', () => {
         rows: [undefined],
       })),
       duration: MINUTE_IN_MS,
-      viewPortStart,
-      viewPortEnd,
+      viewportStart,
+      viewportEnd,
       width: 500, // small enough that not all columns can fit
     });
 
@@ -204,8 +204,8 @@ it('empty state', () => {
     dataStreams: [],
     tableColumns,
     annotations,
-    viewPortStart,
-    viewPortEnd,
+    viewportStart,
+    viewportEnd,
   });
   cy.get('sc-table')
     .get(EMPTY_STATUS_SELECTOR)
@@ -220,8 +220,8 @@ it('disable state', () => {
     dataStreams: [],
     tableColumns,
     annotations,
-    viewPortStart,
-    viewPortEnd,
+    viewportStart,
+    viewportEnd,
   });
   cy.get('sc-table')
     .get(DISABLE_STATUS_SELECTOR)

--- a/packages/synchro-charts/src/components.d.ts
+++ b/packages/synchro-charts/src/components.d.ts
@@ -50,7 +50,7 @@ export namespace Components {
         /**
           * Chart API
          */
-        "viewPort": MinimalViewPortConfig;
+        "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
     interface ScBox {
@@ -88,7 +88,7 @@ export namespace Components {
     interface ScGestureHandler {
         "onDateRangeChange": ({ end, start }: { start: Date; end: Date }) => void;
         "size": SizeConfig;
-        "viewPort": ViewPort;
+        "viewport": ViewPort;
     }
     interface ScGrid {
     }
@@ -108,7 +108,7 @@ export namespace Components {
         "isEditing": boolean;
         "liveModeOnlyMessage": string;
         "messageOverrides": MessageOverrides;
-        "viewPort": MinimalViewPortConfig;
+        "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
     interface ScKpiBase {
@@ -126,7 +126,7 @@ export namespace Components {
         "propertyStream"?: DataStream;
         "trendStream": DataStream | undefined;
         "valueColor"?: string;
-        "viewPort": MinimalViewPortConfig;
+        "viewport": MinimalViewPortConfig;
     }
     interface ScKpiStandard {
     }
@@ -140,7 +140,7 @@ export namespace Components {
         "thresholds": Threshold[];
         "trendResults": TrendResult[];
         "updateDataStreamName": ({ streamId, name }: { streamId: string; name: string }) => void;
-        "viewPort": ViewPort;
+        "viewport": ViewPort;
         "visualizesAlarms": boolean;
     }
     interface ScLegendRow {
@@ -184,7 +184,7 @@ export namespace Components {
         /**
           * Chart API
          */
-        "viewPort": MinimalViewPortConfig;
+        "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
     interface ScLineChartColoredPoint {
@@ -227,7 +227,7 @@ export namespace Components {
         /**
           * Chart API
          */
-        "viewPort": MinimalViewPortConfig;
+        "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
     interface ScScatterChartDynamicData {
@@ -287,7 +287,7 @@ export namespace Components {
         "labelsConfig": LabelsConfig;
         "liveModeOnlyMessage": string;
         "messageOverrides": MessageOverrides;
-        "viewPort": MinimalViewPortConfig;
+        "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
     interface ScStatusGridStandard {
@@ -316,7 +316,7 @@ export namespace Components {
         /**
           * Chart API
          */
-        "viewPort": MinimalViewPortConfig;
+        "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
     interface ScStatusTimelineOverlay {
@@ -351,7 +351,7 @@ export namespace Components {
          */
         "tableColumns": TableColumn[];
         "trends": Trend[];
-        "viewPort": MinimalViewPortConfig;
+        "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
     interface ScTableBase {
@@ -390,7 +390,7 @@ export namespace Components {
          */
         "top": number;
         "trendResults": TrendResult[];
-        "viewPort": ViewPort;
+        "viewport": ViewPort;
         "visualizesAlarms": boolean;
     }
     interface ScTooltipRow {
@@ -422,7 +422,7 @@ export namespace Components {
          */
         "top"?: number;
         "trendResults": TrendResult[];
-        "viewPort": ViewPort;
+        "viewport": ViewPort;
         "visualizesAlarms": boolean;
     }
     interface ScWebglAxis {
@@ -479,7 +479,7 @@ export namespace Components {
         /**
           * Optionally hooks to integrate custom logic into the base chart
          */
-        "onUpdateLifeCycle"?: (viewPort: ViewPortConfig) => void;
+        "onUpdateLifeCycle"?: (viewport: ViewPortConfig) => void;
         /**
           * Optionally provided callback to initiate a request for data. Used to ensure gestures emit events for request data.
          */
@@ -489,7 +489,7 @@ export namespace Components {
         "tooltip": (props: Tooltip.Props) => HTMLElement;
         "trends": Trend[];
         "updateChartScene": ChartSceneUpdater;
-        "viewPort": MinimalViewPortConfig;
+        "viewport": MinimalViewPortConfig;
         "visualizesAlarms": boolean;
         "yRangeStartFromZero": boolean;
     }
@@ -545,7 +545,7 @@ export namespace Components {
         "liveModeOnlyMessage": string;
         "messageOverrides": MessageOverrides;
         "renderCell": RenderCell;
-        "viewPort": MinimalViewPortConfig;
+        "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
     interface SingleColoredStatus {
@@ -1429,7 +1429,7 @@ declare namespace LocalJSX {
         /**
           * Chart API
          */
-        "viewPort"?: MinimalViewPortConfig;
+        "viewport"?: MinimalViewPortConfig;
         "widgetId": string;
     }
     interface ScBox {
@@ -1467,7 +1467,7 @@ declare namespace LocalJSX {
     interface ScGestureHandler {
         "onDateRangeChange": ({ end, start }: { start: Date; end: Date }) => void;
         "size": SizeConfig;
-        "viewPort": ViewPort;
+        "viewport": ViewPort;
     }
     interface ScGrid {
     }
@@ -1487,7 +1487,7 @@ declare namespace LocalJSX {
         "isEditing"?: boolean;
         "liveModeOnlyMessage"?: string;
         "messageOverrides"?: MessageOverrides;
-        "viewPort"?: MinimalViewPortConfig;
+        "viewport"?: MinimalViewPortConfig;
         "widgetId": string;
     }
     interface ScKpiBase {
@@ -1505,7 +1505,7 @@ declare namespace LocalJSX {
         "propertyStream"?: DataStream;
         "trendStream": DataStream | undefined;
         "valueColor"?: string;
-        "viewPort": MinimalViewPortConfig;
+        "viewport": MinimalViewPortConfig;
     }
     interface ScKpiStandard {
     }
@@ -1519,7 +1519,7 @@ declare namespace LocalJSX {
         "thresholds": Threshold[];
         "trendResults"?: TrendResult[];
         "updateDataStreamName": ({ streamId, name }: { streamId: string; name: string }) => void;
-        "viewPort": ViewPort;
+        "viewport": ViewPort;
         "visualizesAlarms": boolean;
     }
     interface ScLegendRow {
@@ -1563,7 +1563,7 @@ declare namespace LocalJSX {
         /**
           * Chart API
          */
-        "viewPort": MinimalViewPortConfig;
+        "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
     interface ScLineChartColoredPoint {
@@ -1606,7 +1606,7 @@ declare namespace LocalJSX {
         /**
           * Chart API
          */
-        "viewPort"?: MinimalViewPortConfig;
+        "viewport"?: MinimalViewPortConfig;
         "widgetId": string;
     }
     interface ScScatterChartDynamicData {
@@ -1666,7 +1666,7 @@ declare namespace LocalJSX {
         "labelsConfig"?: LabelsConfig;
         "liveModeOnlyMessage"?: string;
         "messageOverrides"?: MessageOverrides;
-        "viewPort"?: MinimalViewPortConfig;
+        "viewport"?: MinimalViewPortConfig;
         "widgetId": string;
     }
     interface ScStatusGridStandard {
@@ -1695,7 +1695,7 @@ declare namespace LocalJSX {
         /**
           * Chart API
          */
-        "viewPort"?: MinimalViewPortConfig;
+        "viewport"?: MinimalViewPortConfig;
         "widgetId": string;
     }
     interface ScStatusTimelineOverlay {
@@ -1731,7 +1731,7 @@ declare namespace LocalJSX {
          */
         "tableColumns"?: TableColumn[];
         "trends"?: Trend[];
-        "viewPort"?: MinimalViewPortConfig;
+        "viewport"?: MinimalViewPortConfig;
         "widgetId": string;
     }
     interface ScTableBase {
@@ -1770,7 +1770,7 @@ declare namespace LocalJSX {
          */
         "top"?: number;
         "trendResults"?: TrendResult[];
-        "viewPort": ViewPort;
+        "viewport": ViewPort;
         "visualizesAlarms": boolean;
     }
     interface ScTooltipRow {
@@ -1802,7 +1802,7 @@ declare namespace LocalJSX {
          */
         "top"?: number;
         "trendResults"?: TrendResult[];
-        "viewPort": ViewPort;
+        "viewport": ViewPort;
         "visualizesAlarms": boolean;
     }
     interface ScWebglAxis {
@@ -1863,7 +1863,7 @@ declare namespace LocalJSX {
         /**
           * Optionally hooks to integrate custom logic into the base chart
          */
-        "onUpdateLifeCycle"?: (viewPort: ViewPortConfig) => void;
+        "onUpdateLifeCycle"?: (viewport: ViewPortConfig) => void;
         "onWidgetUpdated"?: (event: CustomEvent<WidgetConfigurationUpdate>) => void;
         /**
           * Optionally provided callback to initiate a request for data. Used to ensure gestures emit events for request data.
@@ -1874,7 +1874,7 @@ declare namespace LocalJSX {
         "tooltip"?: (props: Tooltip.Props) => HTMLElement;
         "trends"?: Trend[];
         "updateChartScene": ChartSceneUpdater;
-        "viewPort": MinimalViewPortConfig;
+        "viewport": MinimalViewPortConfig;
         "visualizesAlarms"?: boolean;
         "yRangeStartFromZero"?: boolean;
     }
@@ -1931,7 +1931,7 @@ declare namespace LocalJSX {
         "messageOverrides"?: MessageOverrides;
         "onWidgetUpdated"?: (event: CustomEvent<WidgetConfigurationUpdate>) => void;
         "renderCell"?: RenderCell;
-        "viewPort"?: MinimalViewPortConfig;
+        "viewport"?: MinimalViewPortConfig;
         "widgetId": string;
     }
     interface SingleColoredStatus {

--- a/packages/synchro-charts/src/components/charts/common/annotations/XAnnotations/XAnnotations.ts
+++ b/packages/synchro-charts/src/components/charts/common/annotations/XAnnotations/XAnnotations.ts
@@ -12,13 +12,13 @@ export const LINE_SELECTOR = 'line.x-line';
 export const renderXAnnotations = ({
   container,
   xAnnotations,
-  viewPort,
+  viewport,
   resolution,
   size: { width, height },
 }: {
   container: SVGElement;
   xAnnotations: XAnnotation[];
-  viewPort: ViewPort;
+  viewport: ViewPort;
   resolution: number;
   size: { width: number; height: number };
 }) => {
@@ -26,7 +26,7 @@ export const renderXAnnotations = ({
     .selectAll(ANNOTATION_GROUP_SELECTOR)
     .data(xAnnotations);
 
-  const getXAnnotationTextX = (a: XAnnotation): number => -getX({ annotation: a, width, viewPort });
+  const getXAnnotationTextX = (a: XAnnotation): number => -getX({ annotation: a, width, viewport });
 
   const padding = 5;
 
@@ -42,8 +42,8 @@ export const renderXAnnotations = ({
     .append('line')
     .attr('class', 'x-line')
     .attr('font-size', ANNOTATION_FONT_SIZE)
-    .attr('x1', annotation => getX({ annotation, width, viewPort }))
-    .attr('x2', annotation => getX({ annotation, width, viewPort }))
+    .attr('x1', annotation => getX({ annotation, width, viewport }))
+    .attr('x2', annotation => getX({ annotation, width, viewport }))
     .attr('y1', 0)
     .attr('y2', height)
     .style('stroke', getColor)
@@ -52,7 +52,7 @@ export const renderXAnnotations = ({
   /** Create X Text */
   annotationGroup
     .append('text')
-    .text(annotation => getValueAndText({ annotation, resolution, viewPort }))
+    .text(annotation => getValueAndText({ annotation, resolution, viewport }))
     .attr('display', getValueAndTextVisibility)
     .attr('font-size', ANNOTATION_FONT_SIZE)
     .attr('class', 'x-text')
@@ -66,8 +66,8 @@ export const renderXAnnotations = ({
   /** Update Line */
   annotationSelection
     .select(LINE_SELECTOR)
-    .attr('x1', annotation => getX({ annotation, width, viewPort }))
-    .attr('x2', annotation => getX({ annotation, width, viewPort }))
+    .attr('x1', annotation => getX({ annotation, width, viewport }))
+    .attr('x2', annotation => getX({ annotation, width, viewport }))
     .attr('y2', height)
     .attr('stroke', getColor);
 
@@ -75,7 +75,7 @@ export const renderXAnnotations = ({
   annotationSelection
     .select(TEXT_SELECTOR)
     .attr('display', getValueAndTextVisibility)
-    .text(annotation => getValueAndText({ annotation, resolution, viewPort }))
+    .text(annotation => getValueAndText({ annotation, resolution, viewport }))
     .attr('y', getXAnnotationTextX)
     .style('fill', getColor);
 

--- a/packages/synchro-charts/src/components/charts/common/annotations/XAnnotations/utils.ts
+++ b/packages/synchro-charts/src/components/charts/common/annotations/XAnnotations/utils.ts
@@ -4,13 +4,13 @@ import { ViewPort } from '../../../../../utils/dataTypes';
 export const getX = ({
   annotation,
   width,
-  viewPort,
+  viewport,
 }: {
   annotation: XAnnotation;
   width: number;
-  viewPort: ViewPort;
+  viewport: ViewPort;
 }) => {
-  const { start, end } = viewPort;
+  const { start, end } = viewport;
 
   return Math.floor((width / (end.getTime() - start.getTime())) * (annotation.value.getTime() - start.getTime()));
 };

--- a/packages/synchro-charts/src/components/charts/common/annotations/YAnnotations/YAnnotations.ts
+++ b/packages/synchro-charts/src/components/charts/common/annotations/YAnnotations/YAnnotations.ts
@@ -17,13 +17,13 @@ export const LINE_SELECTOR = 'line.y-line';
 export const renderYAnnotations = ({
   container,
   yAnnotations,
-  viewPort,
+  viewport,
   resolution,
   size: { width, height },
 }: {
   container: SVGElement;
   yAnnotations: YAnnotation[];
-  viewPort: ViewPort;
+  viewport: ViewPort;
   resolution: number;
   size: { width: number; height: number };
 }) => {
@@ -31,7 +31,7 @@ export const renderYAnnotations = ({
     getY({
       annotation,
       height,
-      viewPort,
+      viewport,
     });
 
   const getYAnnotationValueTextY = (yAnnotation: YAnnotation): number =>
@@ -69,7 +69,7 @@ export const renderYAnnotations = ({
     .attr('x', width + Y_ANNOTATION_TEXT_LEFT_PADDING)
     .attr('text-anchor', 'start')
     .attr('y', getYAnnotationValueTextY)
-    .text(annotation => getValueText({ annotation, resolution, viewPort }))
+    .text(annotation => getValueText({ annotation, resolution, viewport }))
     .style('user-select', 'none')
     .style('pointer-events', 'none')
     .style('fill', getColor);
@@ -94,7 +94,7 @@ export const renderYAnnotations = ({
     .attr('display', getValueTextVisibility)
     .attr('y', getYAnnotationValueTextY)
     .attr('x', width + Y_ANNOTATION_TEXT_LEFT_PADDING)
-    .text(annotation => getValueText({ annotation, resolution, viewPort }))
+    .text(annotation => getValueText({ annotation, resolution, viewport }))
     .style('fill', getColor);
 
   /** Update Label Text */

--- a/packages/synchro-charts/src/components/charts/common/annotations/YAnnotations/utils.ts
+++ b/packages/synchro-charts/src/components/charts/common/annotations/YAnnotations/utils.ts
@@ -4,12 +4,12 @@ import { ViewPort } from '../../../../../utils/dataTypes';
 export const getY = ({
   annotation,
   height,
-  viewPort,
+  viewport,
 }: {
   annotation: YAnnotation;
   height: number;
-  viewPort: ViewPort;
+  viewport: ViewPort;
 }) => {
-  const { yMax, yMin } = viewPort;
+  const { yMax, yMin } = viewport;
   return height - (((annotation.value as number) - yMin) * height) / (yMax - yMin);
 };

--- a/packages/synchro-charts/src/components/charts/common/annotations/renderAnnotations.spec.ts
+++ b/packages/synchro-charts/src/components/charts/common/annotations/renderAnnotations.spec.ts
@@ -31,7 +31,7 @@ const render = (props: Partial<RenderAnnotationsOptions>, page: SpecPage) => {
     resolution: 0,
     annotations: {},
     container: page.body.querySelector('svg') as SVGElement,
-    viewPort: VIEWPORT,
+    viewport: VIEWPORT,
     size: SIZE,
   };
 

--- a/packages/synchro-charts/src/components/charts/common/annotations/renderAnnotations.ts
+++ b/packages/synchro-charts/src/components/charts/common/annotations/renderAnnotations.ts
@@ -7,22 +7,22 @@ export type RenderAnnotationsOptions = {
   container: SVGElement;
   resolution: number;
   annotations: Annotations;
-  viewPort: ViewPort;
+  viewport: ViewPort;
   size: { width: number; height: number };
 };
 
 type AnnotationPredicate = (annotation: Annotation<AnnotationValue>) => boolean;
 
-const withinViewport = (viewPort: ViewPort): AnnotationPredicate => {
+const withinViewport = (viewport: ViewPort): AnnotationPredicate => {
   return ({ value }: Annotation<AnnotationValue>) => {
     if (typeof value === 'number') {
-      return viewPort.yMin <= value && viewPort.yMax >= value;
+      return viewport.yMin <= value && viewport.yMax >= value;
     }
-    return viewPort.start <= value && viewPort.end >= value;
+    return viewport.start <= value && viewport.end >= value;
   };
 };
 
-export const renderAnnotations = ({ container, resolution, annotations, viewPort, size }: RenderAnnotationsOptions) => {
+export const renderAnnotations = ({ container, resolution, annotations, viewport, size }: RenderAnnotationsOptions) => {
   if (typeof annotations === 'object' && typeof annotations.show === 'boolean' && !annotations.show) {
     removeXAnnotations({ container });
     removeYAnnotations({ container });
@@ -30,8 +30,8 @@ export const renderAnnotations = ({ container, resolution, annotations, viewPort
   }
 
   // get annotations which have a value that lays within the viewport.
-  const xAnnotations: XAnnotation[] = annotations.x == null ? [] : annotations.x.filter(withinViewport(viewPort));
-  const yAnnotations: YAnnotation[] = annotations.y == null ? [] : annotations.y.filter(withinViewport(viewPort));
+  const xAnnotations: XAnnotation[] = annotations.x == null ? [] : annotations.x.filter(withinViewport(viewport));
+  const yAnnotations: YAnnotation[] = annotations.y == null ? [] : annotations.y.filter(withinViewport(viewport));
 
   /**
    * X Annotations
@@ -39,7 +39,7 @@ export const renderAnnotations = ({ container, resolution, annotations, viewPort
   renderXAnnotations({
     container,
     xAnnotations,
-    viewPort,
+    viewport,
     resolution,
     size,
   });
@@ -50,7 +50,7 @@ export const renderAnnotations = ({ container, resolution, annotations, viewPort
   renderYAnnotations({
     container,
     yAnnotations,
-    viewPort,
+    viewport,
     resolution,
     size,
   });

--- a/packages/synchro-charts/src/components/charts/common/annotations/utils.spec.ts
+++ b/packages/synchro-charts/src/components/charts/common/annotations/utils.spec.ts
@@ -14,7 +14,7 @@ import {
   isThresholdBreached,
   sortThreshold,
 } from './utils';
-import { VIEW_PORT } from '../testUtil';
+import { VIEWPORT } from '../testUtil';
 import { highestPriorityThreshold, thresholdAppliesToDataStream } from './breachedThreshold';
 import { COMPARISON_OPERATOR } from '../constants';
 
@@ -56,7 +56,7 @@ describe('getValueAndText and getValueAndTextVisibility', () => {
     const valueText = getValueText({
       annotation: yAnnotations[0],
       resolution: 1000,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
     });
     expect(valueText).toBe(value.toString());
 
@@ -81,7 +81,7 @@ describe('getValueAndText and getValueAndTextVisibility', () => {
     const valueAndText = getValueAndText({
       annotation: yAnnotations[0],
       resolution: 1000,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
     });
 
     expect(valueAndText).toBe(`${label} (${value})`);
@@ -107,7 +107,7 @@ describe('getValueAndText and getValueAndTextVisibility', () => {
     const valueAndText = getValueAndText({
       annotation: yAnnotations[0],
       resolution: 1000,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
     });
 
     expect(valueAndText).toBe(label);
@@ -126,7 +126,7 @@ describe('getValueAndText and getValueAndTextVisibility', () => {
     const valueAndText = getValueAndText({
       annotation: yAnnotations[0],
       resolution: 1000,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
     });
 
     expect(valueAndText).toBeEmpty();
@@ -147,7 +147,7 @@ describe('getValueAndText and getValueAndTextVisibility', () => {
     const valueText = getValueText({
       annotation: yAnnotations[0],
       resolution: 1000,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
     });
 
     expect(valueText).toBeEmpty();

--- a/packages/synchro-charts/src/components/charts/common/annotations/utils.ts
+++ b/packages/synchro-charts/src/components/charts/common/annotations/utils.ts
@@ -41,11 +41,11 @@ export const getNumberAnnotations = (annotations: Annotations): Annotations => {
 const valueDisplayText = ({
   value,
   resolution,
-  viewPort,
+  viewport,
 }: {
   value: AnnotationValue;
   resolution: number;
-  viewPort: ViewPort;
+  viewport: ViewPort;
 }): string => {
   if (typeof value === 'number') {
     return value.toString();
@@ -53,7 +53,7 @@ const valueDisplayText = ({
   if (typeof value === 'string') {
     return value;
   }
-  return displayDate(value, resolution, viewPort);
+  return displayDate(value, resolution, viewport);
 };
 
 /**
@@ -65,13 +65,13 @@ export const getColor = (annotation: Annotation<AnnotationValue>) => annotation.
 export const getValueAndText = ({
   annotation,
   resolution,
-  viewPort,
+  viewport,
 }: {
   annotation: Annotation<AnnotationValue>;
   resolution: number;
-  viewPort: ViewPort;
+  viewport: ViewPort;
 }): string => {
-  const valueText = annotation.showValue ? valueDisplayText({ value: annotation.value, resolution, viewPort }) : null;
+  const valueText = annotation.showValue ? valueDisplayText({ value: annotation.value, resolution, viewport }) : null;
   const labelText = annotation.label && annotation.label.show ? annotation.label.text : null;
 
   if (labelText && valueText) {
@@ -123,13 +123,13 @@ export const getValueAndTextVisibility = (annotation: Annotation<AnnotationValue
 export const getValueText = ({
   annotation,
   resolution,
-  viewPort,
+  viewport,
 }: {
   annotation: Annotation<AnnotationValue>;
   resolution: number;
-  viewPort: ViewPort;
+  viewport: ViewPort;
 }): string => {
-  const valueText = annotation.showValue ? valueDisplayText({ value: annotation.value, resolution, viewPort }) : null;
+  const valueText = annotation.showValue ? valueDisplayText({ value: annotation.value, resolution, viewport }) : null;
 
   if (valueText) {
     return `${valueText}`;

--- a/packages/synchro-charts/src/components/charts/common/dataFilters.spec.ts
+++ b/packages/synchro-charts/src/components/charts/common/dataFilters.spec.ts
@@ -1,5 +1,5 @@
 import { getDataBeforeDate, getVisibleData } from './dataFilters';
-import { VIEW_PORT } from './testUtil';
+import { VIEWPORT } from './testUtil';
 import { MINUTE_IN_MS, MONTH_IN_MS } from '../../../utils/time';
 
 describe('getDataBeforeDate', () => {
@@ -90,29 +90,29 @@ describe('getVisibleData', () => {
 
   describe('get visible data to render within the chart, including boundary points', () => {
     it('returns an empty list when provided no data', () => {
-      expect(getVisibleData([], VIEW_PORT)).toHaveLength(0);
+      expect(getVisibleData([], VIEWPORT)).toHaveLength(0);
     });
 
     it('returns nothing for a single point beyond the end date', () => {
       const data = [{ x: new Date(2999, 1, 0).getTime(), y: 1 }];
-      const viewPort = {
+      const viewport = {
         yMin: 0,
         yMax: 100,
         start: new Date(2000, 0, 0),
         end: new Date(2001, 0, 0),
       };
-      expect(getVisibleData(data, viewPort)).toHaveLength(0);
+      expect(getVisibleData(data, viewport)).toHaveLength(0);
     });
 
     it('returns nothing for a single point before the start date', () => {
       const data = [{ x: new Date(999, 1, 0).getTime(), y: 1 }];
-      const viewPort = {
+      const viewport = {
         yMin: 0,
         yMax: 100,
         start: new Date(2000, 0, 0),
         end: new Date(2001, 0, 0),
       };
-      expect(getVisibleData(data, viewPort)).toHaveLength(0);
+      expect(getVisibleData(data, viewport)).toHaveLength(0);
     });
 
     it('returns data within the viewport date range', () => {
@@ -120,13 +120,13 @@ describe('getVisibleData', () => {
         { x: new Date(2000, 1, 0).getTime(), y: 1 },
         { x: new Date(2000, 2, 0).getTime(), y: 1 },
       ];
-      const viewPort = {
+      const viewport = {
         yMin: 0,
         yMax: 100,
         start: new Date(2000, 0, 0),
         end: new Date(2001, 0, 0),
       };
-      expect(getVisibleData(data, viewPort)).toEqual(data);
+      expect(getVisibleData(data, viewport)).toEqual(data);
     });
 
     it('returns the two closest points to the view port to include in the visible data', () => {
@@ -140,36 +140,36 @@ describe('getVisibleData', () => {
         ...visibleData,
         { x: new Date(2002, 0, 0).getTime(), y: 1 },
       ];
-      const viewPort = {
+      const viewport = {
         yMin: 0,
         yMax: 100,
         start: new Date(2000, 0, 0),
         end: new Date(2000, 1, 0),
       };
-      expect(getVisibleData(data, viewPort)).toEqual(visibleData);
+      expect(getVisibleData(data, viewport)).toEqual(visibleData);
     });
 
     describe('get visible data to render within the chart, not including boundary points', () => {
       it('returns nothing for a single point beyond the end date', () => {
         const data = [{ x: new Date(2999, 1, 0).getTime(), y: 1 }];
-        const viewPort = {
+        const viewport = {
           yMin: 0,
           yMax: 100,
           start: new Date(2000, 0, 0),
           end: new Date(2001, 0, 0),
         };
-        expect(getVisibleData(data, viewPort, false)).toHaveLength(0);
+        expect(getVisibleData(data, viewport, false)).toHaveLength(0);
       });
 
       it('returns nothing for a single point before the start date', () => {
         const data = [{ x: new Date(999, 1, 0).getTime(), y: 1 }];
-        const viewPort = {
+        const viewport = {
           yMin: 0,
           yMax: 100,
           start: new Date(2000, 0, 0),
           end: new Date(2001, 0, 0),
         };
-        expect(getVisibleData(data, viewPort, false)).toHaveLength(0);
+        expect(getVisibleData(data, viewport, false)).toHaveLength(0);
       });
 
       it('only returns points within viewport', () => {
@@ -178,13 +178,13 @@ describe('getVisibleData', () => {
           { x: new Date(2000, 0, 15).getTime(), y: 1 },
           { x: new Date(2001, 0, 0).getTime(), y: 1 },
         ];
-        const viewPort = {
+        const viewport = {
           yMin: 0,
           yMax: 100,
           start: new Date(2000, 0, 0),
           end: new Date(2000, 1, 0),
         };
-        expect(getVisibleData(data, viewPort, false)).toEqual([data[1]]);
+        expect(getVisibleData(data, viewport, false)).toEqual([data[1]]);
       });
     });
   });

--- a/packages/synchro-charts/src/components/charts/common/dataFilters.ts
+++ b/packages/synchro-charts/src/components/charts/common/dataFilters.ts
@@ -23,14 +23,14 @@ export const pointBisector = bisector((p: DataPoint<Primitive>) => p.x);
  */
 export const getVisibleData = <T extends Primitive>(
   data: DataPoint<T>[],
-  viewPort: MinimalViewPortConfig,
+  viewport: MinimalViewPortConfig,
   // Whether we want to include a single point to the right, and to the left of the provide viewport.
   // This is useful when rendering lines since you need to connect a point to a point outside of the viewport
   // to fully render the data correctly.
   includeBoundaryPoints: boolean = true
 ): DataPoint<T>[] => {
-  const start = viewPort.start ? viewPort.start : new Date(Date.now() - (viewPort.duration as number));
-  const end = viewPort.end ? viewPort.end : new Date();
+  const start = viewport.start ? viewport.start : new Date(Date.now() - (viewport.duration as number));
+  const end = viewport.end ? viewport.end : new Date();
 
   // If there is no data
   if (data.length === 0) {

--- a/packages/synchro-charts/src/components/charts/common/determineResolution.spec.ts
+++ b/packages/synchro-charts/src/components/charts/common/determineResolution.spec.ts
@@ -10,8 +10,8 @@ describe('determination of resolution for data fetching', () => {
     expect(
       determineResolution({
         supportedResolutions: [0, SECOND_IN_MS],
-        viewPortStartDate: START_DATE,
-        viewPortEndDate: new Date(2000, 0, 0, 0, 5),
+        viewportStartDate: START_DATE,
+        viewportEndDate: new Date(2000, 0, 0, 0, 5),
         maxPoints: 100,
       })
     ).toBe(0);
@@ -21,8 +21,8 @@ describe('determination of resolution for data fetching', () => {
     expect(
       determineResolution({
         supportedResolutions: [SECOND_IN_MS],
-        viewPortStartDate: START_DATE,
-        viewPortEndDate: END_DATE,
+        viewportStartDate: START_DATE,
+        viewportEndDate: END_DATE,
         maxPoints: 1,
       })
     ).toBe(SECOND_IN_MS);
@@ -32,8 +32,8 @@ describe('determination of resolution for data fetching', () => {
     expect(
       determineResolution({
         supportedResolutions: RESOLUTIONS,
-        viewPortStartDate: START_DATE,
-        viewPortEndDate: END_DATE,
+        viewportStartDate: START_DATE,
+        viewportEndDate: END_DATE,
         maxPoints: DAY_IN_MS / MINUTE_IN_MS,
       })
     ).toBe(MINUTE_IN_MS);
@@ -43,8 +43,8 @@ describe('determination of resolution for data fetching', () => {
     expect(
       determineResolution({
         supportedResolutions: RESOLUTIONS,
-        viewPortStartDate: START_DATE,
-        viewPortEndDate: END_DATE,
+        viewportStartDate: START_DATE,
+        viewportEndDate: END_DATE,
         maxPoints: DAY_IN_MS / HOUR_IN_MS,
       })
     ).toBe(HOUR_IN_MS);
@@ -54,8 +54,8 @@ describe('determination of resolution for data fetching', () => {
     expect(
       determineResolution({
         supportedResolutions: RESOLUTIONS,
-        viewPortStartDate: START_DATE,
-        viewPortEndDate: END_DATE,
+        viewportStartDate: START_DATE,
+        viewportEndDate: END_DATE,
         maxPoints: 30,
       })
     ).toBe(HOUR_IN_MS);
@@ -65,8 +65,8 @@ describe('determination of resolution for data fetching', () => {
     expect(
       determineResolution({
         supportedResolutions: RESOLUTIONS,
-        viewPortStartDate: START_DATE,
-        viewPortEndDate: END_DATE,
+        viewportStartDate: START_DATE,
+        viewportEndDate: END_DATE,
         maxPoints: 23,
       })
     ).toBe(DAY_IN_MS);
@@ -76,8 +76,8 @@ describe('determination of resolution for data fetching', () => {
     expect(() =>
       determineResolution({
         supportedResolutions: [],
-        viewPortStartDate: START_DATE,
-        viewPortEndDate: END_DATE,
+        viewportStartDate: START_DATE,
+        viewportEndDate: END_DATE,
         maxPoints: 1000,
       })
     ).toThrowError('resolution');

--- a/packages/synchro-charts/src/components/charts/common/determineResolution.ts
+++ b/packages/synchro-charts/src/components/charts/common/determineResolution.ts
@@ -11,25 +11,25 @@ const ZERO_RESOLUTION_THRESHOLD = MINUTE_IN_MS / 4;
 
 export const determineResolution = ({
   supportedResolutions,
-  viewPortStartDate,
-  viewPortEndDate,
+  viewportStartDate,
+  viewportEndDate,
   maxPoints,
 }: {
   // The valid resolutions in seconds that can be utilized
   supportedResolutions: number[];
   // The maximum amount of points allowed to be rendered (too many points -> bad performance)
   maxPoints: number;
-  viewPortStartDate?: Date;
-  viewPortEndDate?: Date;
+  viewportStartDate?: Date;
+  viewportEndDate?: Date;
 }): number => {
   if (supportedResolutions.length === 0) {
     throw new Error('Must support at least one resolution of data');
   }
-  if (!viewPortEndDate || !viewPortStartDate) {
+  if (!viewportEndDate || !viewportStartDate) {
     throw new Error('determine resolution does not yet support not passing in start and end date');
   }
 
-  const timeSpan = viewPortEndDate.getTime() - viewPortStartDate.getTime();
+  const timeSpan = viewportEndDate.getTime() - viewportStartDate.getTime();
   const minResolution = timeSpan / maxPoints;
   const sortedResolutions = supportedResolutions.sort((a, b) => a - b);
 

--- a/packages/synchro-charts/src/components/charts/common/meshes/pointMesh.spec.ts
+++ b/packages/synchro-charts/src/components/charts/common/meshes/pointMesh.spec.ts
@@ -423,13 +423,13 @@ describe('update point mesh', () => {
   });
 
   it('updates the position buffer to match the data streams', () => {
-    const viewPort = {
+    const viewport = {
       start: new Date(1999, 11, 0),
       end: new Date(2001, 1, 0),
       yMax: 100,
       yMin: 0,
     };
-    const toClipSpace = clipSpaceConversion(viewPort);
+    const toClipSpace = clipSpaceConversion(viewport);
 
     const points = pointMesh({
       dataStreams: [],

--- a/packages/synchro-charts/src/components/charts/common/pixelDensity.spec.ts
+++ b/packages/synchro-charts/src/components/charts/common/pixelDensity.spec.ts
@@ -6,53 +6,53 @@ const SIZE = {
 };
 
 it('returns correct x pixel density', () => {
-  const viewPort = {
+  const viewport = {
     start: new Date(2000, 0, 0),
     end: new Date(2001, 0, 0),
     yMin: 0,
     yMax: 100,
   };
 
-  const { x } = pixelDensity({ viewPort, size: SIZE, toClipSpace: t => t });
+  const { x } = pixelDensity({ viewport, size: SIZE, toClipSpace: t => t });
 
-  expect(x).toEqual((viewPort.end.getTime() - viewPort.start.getTime()) / SIZE.width);
+  expect(x).toEqual((viewport.end.getTime() - viewport.start.getTime()) / SIZE.width);
 });
 
 it('returns correct x pixel density with a non-identity clip space conversion', () => {
-  const viewPort = {
+  const viewport = {
     start: new Date(2000, 0, 0),
     end: new Date(2001, 0, 0),
     yMin: 0,
     yMax: 100,
   };
 
-  const { x } = pixelDensity({ viewPort, size: SIZE, toClipSpace: t => t * 2 });
+  const { x } = pixelDensity({ viewport, size: SIZE, toClipSpace: t => t * 2 });
 
-  expect(x).toEqual((2 * viewPort.end.getTime() - 2 * viewPort.start.getTime()) / SIZE.width);
+  expect(x).toEqual((2 * viewport.end.getTime() - 2 * viewport.start.getTime()) / SIZE.width);
 });
 
 it('returns correct y pixel density', () => {
-  const viewPort = {
+  const viewport = {
     start: new Date(2000, 0, 0),
     end: new Date(2001, 0, 0),
     yMin: 0,
     yMax: 100,
   };
 
-  const { y } = pixelDensity({ viewPort, size: SIZE, toClipSpace: t => t });
+  const { y } = pixelDensity({ viewport, size: SIZE, toClipSpace: t => t });
 
-  expect(y).toEqual((viewPort.yMax - viewPort.yMin) / SIZE.height);
+  expect(y).toEqual((viewport.yMax - viewport.yMin) / SIZE.height);
 });
 
 it('returns zero for pixel densities when viewport has no area', () => {
-  const viewPort = {
+  const viewport = {
     start: new Date(2000, 0, 0),
     end: new Date(2000, 0, 0),
     yMin: 100,
     yMax: 100,
   };
 
-  const { x, y } = pixelDensity({ viewPort, size: SIZE, toClipSpace: t => t });
+  const { x, y } = pixelDensity({ viewport, size: SIZE, toClipSpace: t => t });
 
   expect(x).toEqual(0);
   expect(y).toEqual(0);
@@ -61,14 +61,14 @@ it('returns zero for pixel densities when viewport has no area', () => {
 it('returns infinity for pixel densities when container has no width or height', () => {
   // NOTE: I'm unsure if this is how we actually want to handle this edge case, but want to have this behavior
   // documented in the test suite.
-  const viewPort = {
+  const viewport = {
     start: new Date(2000, 0, 0),
     end: new Date(2001, 0, 0),
     yMin: 0,
     yMax: 100,
   };
 
-  const { x, y } = pixelDensity({ viewPort, size: { width: 0, height: 0 }, toClipSpace: t => t });
+  const { x, y } = pixelDensity({ viewport, size: { width: 0, height: 0 }, toClipSpace: t => t });
 
   expect(x).toEqual(Infinity);
   expect(y).toEqual(Infinity);

--- a/packages/synchro-charts/src/components/charts/common/pixelDensity.ts
+++ b/packages/synchro-charts/src/components/charts/common/pixelDensity.ts
@@ -8,11 +8,11 @@ import { ViewPort } from '../../../utils/dataTypes';
  */
 
 export const pixelDensity = ({
-  viewPort: { end, start, yMax, yMin },
+  viewport: { end, start, yMax, yMin },
   toClipSpace,
   size,
 }: {
-  viewPort: ViewPort;
+  viewport: ViewPort;
   toClipSpace: (time: number) => number;
   size: { width: number; height: number };
 }) => {

--- a/packages/synchro-charts/src/components/charts/common/testUtil.ts
+++ b/packages/synchro-charts/src/components/charts/common/testUtil.ts
@@ -5,7 +5,7 @@ import { ScaleType } from './constants';
 import { DataType } from '../../../utils/dataConstants';
 import { ViewPort } from '../../../utils/dataTypes';
 
-export const VIEW_PORT: ViewPort = {
+export const VIEWPORT: ViewPort = {
   start: new Date(2000, 0, 0, 0),
   end: new Date(2001, 0, 0, 0),
   yMin: 0,
@@ -18,7 +18,7 @@ export const VIEW_PORT: ViewPort = {
 export const CHART_CONFIG: BaseChartConfig = {
   ...DEFAULT_CHART_CONFIG,
   widgetId: 'base-chart-config',
-  viewPort: VIEW_PORT,
+  viewport: VIEWPORT,
   size: { width: 500, height: 500, marginLeft: 100, marginRight: 40, marginTop: 40, marginBottom: 100 },
   movement: {
     enableXScroll: true,

--- a/packages/synchro-charts/src/components/charts/common/trends/renderTrendLines.spec.ts
+++ b/packages/synchro-charts/src/components/charts/common/trends/renderTrendLines.spec.ts
@@ -38,7 +38,7 @@ const DATA_STREAMS: DataStream<Primitive>[] = [
 const render = (props: Partial<RenderTrendLinesOptions>, page: SpecPage) => {
   const defaultProps: RenderTrendLinesOptions = {
     container: page.body.querySelector('svg') as SVGElement,
-    viewPort: VIEWPORT,
+    viewport: VIEWPORT,
     size: SIZE,
     dataStreams: [],
     trendResults: [],

--- a/packages/synchro-charts/src/components/charts/common/trends/renderTrendLines.ts
+++ b/packages/synchro-charts/src/components/charts/common/trends/renderTrendLines.ts
@@ -8,11 +8,11 @@ import { TREND_TYPE } from '../../../../utils/dataConstants';
 const getLinearPathCommand = ({
   trendResult,
   size: { width, height },
-  viewPort: { start, end, yMin, yMax },
+  viewport: { start, end, yMin, yMax },
 }: {
   trendResult: LinearRegressionResult;
   size: { width: number; height: number };
-  viewPort: ViewPort;
+  viewport: ViewPort;
 }) => {
   // convert y-value to pixel position for start and end points of path
   const startY = Math.round(height - ((getTrendValue(trendResult, start.getTime()) - yMin) * height) / (yMax - yMin));
@@ -24,7 +24,7 @@ const getLinearPathCommand = ({
 
 export const renderTrendLines = ({
   container,
-  viewPort,
+  viewport,
   size: { width, height },
   dataStreams,
   trendResults,
@@ -41,7 +41,7 @@ export const renderTrendLines = ({
             command: getLinearPathCommand({
               trendResult,
               size: { width, height },
-              viewPort,
+              viewport,
             }),
           });
           break;

--- a/packages/synchro-charts/src/components/charts/common/trends/trendAnalysis.spec.ts
+++ b/packages/synchro-charts/src/components/charts/common/trends/trendAnalysis.spec.ts
@@ -99,7 +99,7 @@ describe('linear regression computation', () => {
 
 describe('no trend results', () => {
   it('does not compute trend result when data is completely to one side of viewport', async () => {
-    const viewPort = {
+    const viewport = {
       start: new Date(2019, 0, 1),
       end: new Date(2019, 11, 1),
       yMin: -50,
@@ -125,13 +125,13 @@ describe('no trend results', () => {
         type: TREND_TYPE.LINEAR,
       },
     ];
-    const trendResults = getAllTrendResults(viewPort, streams, trends);
+    const trendResults = getAllTrendResults(viewport, streams, trends);
 
     expect(trendResults).toHaveLength(0);
   });
 
   it('does not compute trend result when there is a single data point, which is inside the viewport', async () => {
-    const viewPort = {
+    const viewport = {
       start: new Date(2019, 0, 1),
       end: new Date(2019, 11, 1),
       yMin: -50,
@@ -152,7 +152,7 @@ describe('no trend results', () => {
         type: TREND_TYPE.LINEAR,
       },
     ];
-    const trendResults = getAllTrendResults(viewPort, streams, trends);
+    const trendResults = getAllTrendResults(viewport, streams, trends);
 
     expect(trendResults).toHaveLength(0);
   });
@@ -160,7 +160,7 @@ describe('no trend results', () => {
 
 describe('get all trend results', () => {
   it('computes multiple trend results', async () => {
-    const viewPort = {
+    const viewport = {
       start: new Date(2020, 0, 0),
       end: new Date(2020, 1, 12),
       yMin: -50,
@@ -208,7 +208,7 @@ describe('get all trend results', () => {
         type: TREND_TYPE.LINEAR,
       },
     ];
-    const trendResults = getAllTrendResults(viewPort, streams, trends);
+    const trendResults = getAllTrendResults(viewport, streams, trends);
 
     expect(trendResults).toHaveLength(2);
 

--- a/packages/synchro-charts/src/components/charts/common/trends/trendAnalysis.ts
+++ b/packages/synchro-charts/src/components/charts/common/trends/trendAnalysis.ts
@@ -64,7 +64,7 @@ export const computeTrendResult = (dataStream: DataStream<number>, trendType: TR
  * Computes trend results for all requested trends using the data in the provided viewport (including boundary points).
  */
 export const getAllTrendResults = (
-  viewPort: ViewPortConfig,
+  viewport: ViewPortConfig,
   dataStreams: DataStream<number>[],
   trends: Trend[]
 ): TrendResult[] => {
@@ -75,7 +75,7 @@ export const getAllTrendResults = (
 
     // only compute a trend line if there are at least two visible and/or boundary data points, the reason being that
     // a trend line based on a single point of data has no informational value and may actually be misleading
-    const dataInViewport = getVisibleData(dataPoints, viewPort);
+    const dataInViewport = getVisibleData(dataPoints, viewport);
     if (dataInViewport.length >= 2) {
       trends
         .filter(({ dataStreamId }) => id === dataStreamId)

--- a/packages/synchro-charts/src/components/charts/common/trends/types.ts
+++ b/packages/synchro-charts/src/components/charts/common/trends/types.ts
@@ -37,7 +37,7 @@ export type TrendResult = LinearRegressionResult;
  */
 export type RenderTrendLinesOptions = {
   container: SVGElement;
-  viewPort: ViewPort;
+  viewport: ViewPort;
   size: { width: number; height: number };
   dataStreams: DataStream<Primitive>[];
   trendResults: TrendResult[];

--- a/packages/synchro-charts/src/components/charts/common/types.ts
+++ b/packages/synchro-charts/src/components/charts/common/types.ts
@@ -49,7 +49,7 @@ export interface LegendConfig {
  * Missing fields will be substituted with defaults
  */
 export interface ChartConfig extends BaseConfig {
-  viewPort: MinimalViewPortConfig;
+  viewport: MinimalViewPortConfig;
   movement?: MovementConfig;
   scale?: ScaleConfig;
   layout?: LayoutConfig;
@@ -69,7 +69,7 @@ export type WidgetConfigurationUpdate = Partial<ChartConfig> & {
  */
 export interface BaseChartConfig extends ChartConfig {
   dataStreams: DataStream[];
-  viewPort: ViewPortConfig;
+  viewport: ViewPortConfig;
   movement: MovementConfig;
   layout: LayoutConfig;
   scale: ScaleConfig;
@@ -181,7 +181,7 @@ export namespace Tooltip {
     size: SizeConfig;
     style: StencilCSSProperty;
     dataStreams: DataStream[];
-    viewPort: ViewPort;
+    viewport: ViewPort;
     dataContainer: HTMLElement;
     thresholds: Threshold[];
     trendResults: TrendResult[];

--- a/packages/synchro-charts/src/components/charts/sc-bar-chart/barMesh.spec.ts
+++ b/packages/synchro-charts/src/components/charts/sc-bar-chart/barMesh.spec.ts
@@ -8,8 +8,8 @@ import { DataPoint, DataStream } from '../../../utils/dataTypes';
 import { Threshold } from '../common/types';
 import { COMPARISON_OPERATOR } from '../common/constants';
 
-const VIEW_PORT = { start: new Date(2000, 0, 0), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
-const toClipSpace = clipSpaceConversion(VIEW_PORT);
+const VIEWPORT = { start: new Date(2000, 0, 0), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
+const toClipSpace = clipSpaceConversion(VIEWPORT);
 
 const BUFFER_FACTOR = 2;
 const MIN_BUFFER_SIZE = 100;

--- a/packages/synchro-charts/src/components/charts/sc-bar-chart/chartScene.spec.ts
+++ b/packages/synchro-charts/src/components/charts/sc-bar-chart/chartScene.spec.ts
@@ -4,7 +4,7 @@ import { MONTH_IN_MS } from '../../../utils/time';
 import { BarChartBarMesh } from './barMesh';
 import { DataType } from '../../../utils/dataConstants';
 
-const VIEW_PORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
+const VIEWPORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
 
 const TEST_DATA_POINT: DataPoint<number>[] = Array.from({ length: 7 }, (_, index) => {
   return {
@@ -26,7 +26,7 @@ describe('bars', () => {
         { id: 'data-stream', name: 'some name', resolution: MONTH_IN_MS, data: [], dataType: DataType.NUMBER },
       ],
       minBufferSize: 0,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       thresholdOptions: {
         showColor: false,
       },
@@ -52,7 +52,7 @@ describe('bars', () => {
       hasDataChanged: true,
       minBufferSize: 0,
       scene,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       thresholdOptions: {
         showColor: false,
       },

--- a/packages/synchro-charts/src/components/charts/sc-bar-chart/chartScene.ts
+++ b/packages/synchro-charts/src/components/charts/sc-bar-chart/chartScene.ts
@@ -11,7 +11,7 @@ const maxDataPointsRendered = (bars: BarChartBarMesh): number =>
 export const chartScene: ChartSceneCreator = ({
   dataStreams,
   container,
-  viewPort,
+  viewport,
   bufferFactor,
   minBufferSize,
   onUpdate,
@@ -19,9 +19,9 @@ export const chartScene: ChartSceneCreator = ({
   thresholds,
 }) => {
   const scene = new Scene();
-  const toClipSpace = clipSpaceConversion(viewPort);
+  const toClipSpace = clipSpaceConversion(viewport);
   scene.add(barMesh({ dataStreams, toClipSpace, bufferFactor, minBufferSize, thresholdOptions, thresholds }));
-  return constructChartScene({ scene, viewPort, container, toClipSpace, onUpdate });
+  return constructChartScene({ scene, viewport, container, toClipSpace, onUpdate });
 };
 
 export const updateChartScene: ChartSceneUpdater = ({
@@ -30,7 +30,7 @@ export const updateChartScene: ChartSceneUpdater = ({
   hasDataChanged,
   minBufferSize,
   bufferFactor,
-  viewPort,
+  viewport,
   container,
   onUpdate,
   chartSize,
@@ -44,12 +44,12 @@ export const updateChartScene: ChartSceneUpdater = ({
   // chart scene, we must fully recreate the chart scene. This is a costly operation.
   const isDataOverflowingBuffer = maxDataPointsRendered(bars) < numDataPoints(dataStreams);
 
-  if (isDataOverflowingBuffer || needsNewClipSpace(viewPort, scene.toClipSpace) || hasAnnotationChanged) {
+  if (isDataOverflowingBuffer || needsNewClipSpace(viewport, scene.toClipSpace) || hasAnnotationChanged) {
     return chartScene({
       onUpdate,
       dataStreams,
       container,
-      viewPort,
+      viewport,
       minBufferSize,
       bufferFactor,
       chartSize,

--- a/packages/synchro-charts/src/components/charts/sc-bar-chart/displayLogic.spec.ts
+++ b/packages/synchro-charts/src/components/charts/sc-bar-chart/displayLogic.spec.ts
@@ -4,8 +4,8 @@ import { DataStream } from '../../../utils/dataTypes';
 import { MONTH_IN_MS } from '../../../utils/time';
 import { DataType } from '../../../utils/dataConstants';
 
-const VIEW_PORT = { start: new Date(2000, 0), end: new Date(2000, 1, 0), yMin: 0, yMax: 100 };
-const toClipSpace = clipSpaceConversion(VIEW_PORT);
+const VIEWPORT = { start: new Date(2000, 0), end: new Date(2000, 1, 0), yMin: 0, yMax: 100 };
+const toClipSpace = clipSpaceConversion(VIEWPORT);
 
 describe('bar chart display logic', () => {
   it('with of the bar is in between the view port', () => {
@@ -23,7 +23,7 @@ describe('bar chart display logic', () => {
       toClipSpace,
       resolution: MONTH_IN_MS,
     });
-    expect(barWidth).toBeGreaterThanOrEqual(toClipSpace(VIEW_PORT.start.getTime()));
-    expect(barWidth).toBeLessThanOrEqual(toClipSpace(VIEW_PORT.end.getTime()));
+    expect(barWidth).toBeGreaterThanOrEqual(toClipSpace(VIEWPORT.start.getTime()));
+    expect(barWidth).toBeLessThanOrEqual(toClipSpace(VIEWPORT.end.getTime()));
   });
 });

--- a/packages/synchro-charts/src/components/charts/sc-bar-chart/sc-bar-chart.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-bar-chart/sc-bar-chart.tsx
@@ -40,7 +40,7 @@ const tooltip = (props: Tooltip.Props) => (
 })
 export class ScBarChart implements ChartConfig {
   /** Chart API */
-  @Prop() viewPort: MinimalViewPortConfig;
+  @Prop() viewport: MinimalViewPortConfig;
   @Prop() movement?: MovementConfig;
   @Prop() scale?: ScaleConfig;
   @Prop() layout?: LayoutConfig;
@@ -84,7 +84,7 @@ export class ScBarChart implements ChartConfig {
             }}
             dataStreams={this.dataStreams}
             alarms={this.alarms}
-            viewPort={this.viewPort}
+            viewport={this.viewport}
             minBufferSize={this.minBufferSize}
             bufferFactor={this.bufferFactor}
             isEditing={this.isEditing}

--- a/packages/synchro-charts/src/components/charts/sc-heatmap/heatmapUtil.spec.ts
+++ b/packages/synchro-charts/src/components/charts/sc-heatmap/heatmapUtil.spec.ts
@@ -3,7 +3,7 @@ import { DataPoint, DataStream, ViewPort } from '../../../utils/dataTypes';
 import { calculateBucketIndex, HeatValueMap, addCount, calcHeatValues, calculateXBucketStart } from './heatmapUtil';
 import { MONTH_IN_MS } from '../../../utils/time';
 
-const VIEW_PORT: ViewPort = {
+const VIEWPORT: ViewPort = {
   start: new Date('June 1, 2021 10:00:00'),
   end: new Date('June 3, 2022 21:00:00'),
   yMin: 0,
@@ -11,7 +11,7 @@ const VIEW_PORT: ViewPort = {
 };
 
 const RESOLUTION: number = MONTH_IN_MS;
-const START_TIME = VIEW_PORT.start.getTime();
+const START_TIME = VIEWPORT.start.getTime();
 
 const DATA_POINT_1: DataPoint = { x: START_TIME, y: Math.random() * 100 };
 const DATA_POINT_2: DataPoint = { x: START_TIME + MONTH_IN_MS * 2, y: Math.random() * 100 };
@@ -168,7 +168,7 @@ describe('addCount', () => {
 describe('calcHeatValues', () => {
   it('returns aggregated data for dataStreams with different x-axis bucket ranges', () => {
     const dataStreams: DataStream[] = [DATASTREAM_1, DATASTREAM_2];
-    const newHeatValue = calcHeatValues({ oldHeatValue: {}, dataStreams, resolution: RESOLUTION, viewPort: VIEW_PORT });
+    const newHeatValue = calcHeatValues({ oldHeatValue: {}, dataStreams, resolution: RESOLUTION, viewport: VIEWPORT });
     expect(newHeatValue).toEqual({
       [START_TIME_EPOCH]: expect.any(Object),
       [START_TIME_EPOCH_2]: expect.any(Object),
@@ -186,7 +186,7 @@ describe('calcHeatValues', () => {
       dataType: DataType.STRING,
     };
     const dataStreams: DataStream[] = [DATASTREAM];
-    const newHeatValue = calcHeatValues({ oldHeatValue: {}, dataStreams, resolution: RESOLUTION, viewPort: VIEW_PORT });
+    const newHeatValue = calcHeatValues({ oldHeatValue: {}, dataStreams, resolution: RESOLUTION, viewport: VIEWPORT });
     expect(newHeatValue).toEqual({});
   });
 });

--- a/packages/synchro-charts/src/components/charts/sc-heatmap/heatmapUtil.ts
+++ b/packages/synchro-charts/src/components/charts/sc-heatmap/heatmapUtil.ts
@@ -74,19 +74,19 @@ export const calcHeatValues = ({
   oldHeatValue = {},
   dataStreams,
   resolution,
-  viewPort,
+  viewport,
 }: {
   oldHeatValue: HeatValueMap;
   dataStreams: DataStream[];
   resolution: number;
-  viewPort: ViewPort;
+  viewport: ViewPort;
 }) => {
   if (dataStreams[0].dataType !== DataType.NUMBER) {
     return {};
   }
   // if resolution is 0 then set the XAxisBucketRange to be 1 second
   const xAxisBucketRange = resolution === 0 ? SECOND_IN_MS : resolution;
-  const { yMax, yMin } = viewPort;
+  const { yMax, yMin } = viewport;
   return dataStreams.reduce(function reduceDataStream(newHeatValue, dataStream) {
     return dataStream.data.reduce(function reduceData(tempHeatValue, currPoint) {
       const xBucketRangeStart = calculateXBucketStart({ xValue: currPoint.x, xAxisBucketRange });

--- a/packages/synchro-charts/src/components/charts/sc-legend/sc-legend.spec.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-legend/sc-legend.spec.tsx
@@ -11,7 +11,7 @@ import { COMPARISON_OPERATOR, LEGEND_POSITION, StatusIcon, TREND_TYPE } from '..
 import { ScLegendRow } from './sc-legend-row/sc-legend-row';
 import { DEFAULT_LEGEND_TEXT_COLOR } from './constants';
 import { POINT_TYPE } from '../sc-webgl-base-chart/activePoints';
-import { VIEW_PORT } from '../common/testUtil';
+import { VIEWPORT } from '../common/testUtil';
 import { DAY_IN_MS } from '../../../utils/time';
 import { NON_BREACHED_ALARM_INFO } from '../../../testing/__mocks__/mockWidgetProperties';
 import { DataType, StreamType } from '../../../utils/dataConstants';
@@ -51,7 +51,7 @@ const ALARM_THRESHOLD: Threshold<string> = {
 };
 
 const WITHIN_VIEWPORT_DATE = new Date(2000, 0, 1).getTime();
-const BEFORE_VIEWPORT_DATE = new Date(VIEW_PORT.start.getTime() - DAY_IN_MS).getTime();
+const BEFORE_VIEWPORT_DATE = new Date(VIEWPORT.start.getTime() - DAY_IN_MS).getTime();
 
 const ALARM_STREAM: DataStream<string> = {
   id: 'alarm-stream',
@@ -128,7 +128,7 @@ const newChartLegendSpecPage = async (props: Partial<Components.ScLegend>) => {
     isLoading: false,
     isEditing: false,
     dataStreams: [],
-    viewPort: {
+    viewport: {
       yMin: 0,
       yMax: 100,
       start: new Date(2000, 0),
@@ -624,7 +624,7 @@ describe('active point passed into legend rows', () => {
     };
 
     const { legend } = await newChartLegendSpecPage({
-      viewPort: {
+      viewport: {
         yMin: 0,
         yMax: 100,
         start: new Date(2000, 0),
@@ -663,7 +663,7 @@ describe('active point passed into legend rows', () => {
     };
 
     const { legend } = await newChartLegendSpecPage({
-      viewPort: {
+      viewport: {
         yMin: 0,
         yMax: 100,
         start: new Date(2000, 0),

--- a/packages/synchro-charts/src/components/charts/sc-legend/sc-legend.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-legend/sc-legend.tsx
@@ -22,7 +22,7 @@ const noop = () => {};
 })
 export class ScLegend {
   @Prop() config!: LegendConfig;
-  @Prop() viewPort!: ViewPort;
+  @Prop() viewport!: ViewPort;
   @Prop() dataStreams!: DataStream[];
   @Prop() updateDataStreamName!: ({ streamId, name }: { streamId: string; name: string }) => void;
   @Prop() visualizesAlarms!: boolean;
@@ -54,7 +54,7 @@ export class ScLegend {
   ): ThresholdColorAndIcon | undefined => {
     const threshold = breachedThreshold({
       value: point && point.y,
-      date: this.viewPort.end,
+      date: this.viewport.end,
       dataStreams: this.dataStreams,
       dataStream,
       thresholds: this.thresholds,
@@ -65,14 +65,14 @@ export class ScLegend {
 
   render() {
     const points = activePoints({
-      viewPort: this.viewPort,
+      viewport: this.viewport,
       dataStreams: this.dataStreams,
-      selectedDate: this.viewPort.end,
+      selectedDate: this.viewport.end,
       allowMultipleDates: true,
       dataAlignment: DATA_ALIGNMENT.EITHER,
     });
 
-    const lastDate = points.length === 0 || points[0].point == null ? this.viewPort.end.getTime() : points[0].point.x;
+    const lastDate = points.length === 0 || points[0].point == null ? this.viewport.end.getTime() : points[0].point.x;
 
     return (
       <div

--- a/packages/synchro-charts/src/components/charts/sc-line-chart/chartScene.spec.ts
+++ b/packages/synchro-charts/src/components/charts/sc-line-chart/chartScene.spec.ts
@@ -4,7 +4,7 @@ import { chartScene, updateChartScene } from './chartScene';
 import { PointMesh, POINT_MESH_INDEX } from '../common/meshes/pointMesh';
 import { DataType } from '../../../utils/dataConstants';
 
-const VIEW_PORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
+const VIEWPORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
 
 const DATA_POINT_1: DataPoint = { x: new Date(2000, 0, 0).getTime(), y: 200 };
 const DATA_POINT_2: DataPoint = { x: new Date(2000, 1, 0).getTime(), y: 300 };
@@ -16,7 +16,7 @@ describe('points', () => {
     const container = document.createElement('div');
 
     const scene = chartScene({
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       container,
       chartSize: CHART_SIZE,
       dataStreams: [{ id: 'data-stream', name: 'some name', resolution: 0, data: [], dataType: DataType.NUMBER }],
@@ -30,7 +30,7 @@ describe('points', () => {
 
     const updatedScene = updateChartScene({
       scene,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       chartSize: CHART_SIZE,
       container,
       dataStreams: [
@@ -88,7 +88,7 @@ describe('lines', () => {
     const container = document.createElement('div');
 
     const scene = chartScene({
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       chartSize: CHART_SIZE,
       container,
       dataStreams: [{ id: 'data-stream', name: 'some name', resolution: 0, data: [], dataType: DataType.NUMBER }],
@@ -102,7 +102,7 @@ describe('lines', () => {
 
     const updatedScene = updateChartScene({
       scene,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       container,
       chartSize: CHART_SIZE,
       dataStreams: [

--- a/packages/synchro-charts/src/components/charts/sc-line-chart/chartScene.ts
+++ b/packages/synchro-charts/src/components/charts/sc-line-chart/chartScene.ts
@@ -16,7 +16,7 @@ export const chartScene: ChartSceneCreator = ({
   dataStreams,
   chartSize,
   container,
-  viewPort,
+  viewport,
   minBufferSize,
   bufferFactor,
   onUpdate,
@@ -24,7 +24,7 @@ export const chartScene: ChartSceneCreator = ({
   thresholds,
 }) => {
   const scene = new Scene();
-  const toClipSpace = clipSpaceConversion(viewPort);
+  const toClipSpace = clipSpaceConversion(viewport);
 
   const numberThresholds = getNumberThresholds(thresholds);
 
@@ -34,7 +34,7 @@ export const chartScene: ChartSceneCreator = ({
     toClipSpace,
     chartSize,
     dataStreams,
-    viewPort,
+    viewport,
     minBufferSize,
     bufferFactor,
     thresholdOptions,
@@ -52,7 +52,7 @@ export const chartScene: ChartSceneCreator = ({
 
   meshList.forEach(mesh => scene.add(mesh));
 
-  return constructChartScene({ scene, viewPort, container, toClipSpace, onUpdate });
+  return constructChartScene({ scene, viewport, container, toClipSpace, onUpdate });
 };
 
 const maxDataPointsRendered = (points: PointMesh): number =>
@@ -63,7 +63,7 @@ export const updateChartScene: ChartSceneUpdater = ({
   dataStreams,
   chartSize,
   container,
-  viewPort,
+  viewport,
   hasDataChanged,
   bufferFactor,
   minBufferSize,
@@ -79,12 +79,12 @@ export const updateChartScene: ChartSceneUpdater = ({
   // chart scene, we must fully recreate the chart scene. This is a costly operation.
   const isDataOverflowingBuffer = maxDataPointsRendered(points) < numDataPoints(dataStreams);
 
-  if (isDataOverflowingBuffer || needsNewClipSpace(viewPort, scene.toClipSpace) || hasAnnotationChanged) {
+  if (isDataOverflowingBuffer || needsNewClipSpace(viewport, scene.toClipSpace) || hasAnnotationChanged) {
     return chartScene({
       dataStreams,
       chartSize,
       container,
-      viewPort,
+      viewport,
       minBufferSize,
       bufferFactor,
       onUpdate,
@@ -97,7 +97,7 @@ export const updateChartScene: ChartSceneUpdater = ({
     lines,
     dataStreams,
     chartSize,
-    viewPort,
+    viewport,
     hasDataChanged,
     toClipSpace: scene.toClipSpace,
   });

--- a/packages/synchro-charts/src/components/charts/sc-line-chart/lineMesh.spec.ts
+++ b/packages/synchro-charts/src/components/charts/sc-line-chart/lineMesh.spec.ts
@@ -3,8 +3,8 @@ import { DataPoint } from '../../../utils/dataTypes';
 import { clipSpaceConversion } from '../sc-webgl-base-chart/clipSpaceConversion';
 import { DataType } from '../../../utils/dataConstants';
 
-const VIEW_PORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
-const toClipSpace = clipSpaceConversion(VIEW_PORT);
+const VIEWPORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
+const toClipSpace = clipSpaceConversion(VIEWPORT);
 
 const DATA_POINT_1: DataPoint = { x: new Date(2000, 0, 0).getTime(), y: 200 };
 const DATA_POINT_2: DataPoint = { x: new Date(2000, 1, 0).getTime(), y: 300 };
@@ -22,7 +22,7 @@ describe('create line mesh', () => {
     const mesh = lineMesh({
       dataStreams: [],
       chartSize: CHART_SIZE,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       minBufferSize: 100,
       bufferFactor: 2,
       toClipSpace,
@@ -38,7 +38,7 @@ describe('create line mesh', () => {
     const mesh = lineMesh({
       dataStreams: [],
       chartSize: CHART_SIZE,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       minBufferSize: 100,
       bufferFactor: 2,
       toClipSpace,
@@ -48,16 +48,16 @@ describe('create line mesh', () => {
       thresholds: [],
     });
     expect(mesh.material.uniforms.xPixelDensity.value).toBe(
-      (toClipSpace(VIEW_PORT.end.getTime()) - toClipSpace(VIEW_PORT.start.getTime())) / CHART_SIZE.width
+      (toClipSpace(VIEWPORT.end.getTime()) - toClipSpace(VIEWPORT.start.getTime())) / CHART_SIZE.width
     );
-    expect(mesh.material.uniforms.yPixelDensity.value).toBe((VIEW_PORT.yMax - VIEW_PORT.yMin) / CHART_SIZE.height);
+    expect(mesh.material.uniforms.yPixelDensity.value).toBe((VIEWPORT.yMax - VIEWPORT.yMin) / CHART_SIZE.height);
   });
 
   it('with an empty data set, draw no vertices', () => {
     const mesh = lineMesh({
       dataStreams: [],
       chartSize: CHART_SIZE,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       minBufferSize: 100,
       bufferFactor: 2,
       toClipSpace,
@@ -90,7 +90,7 @@ describe('create line mesh', () => {
         },
       ],
       chartSize: CHART_SIZE,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       minBufferSize: 1,
       bufferFactor: 1,
       toClipSpace,
@@ -139,7 +139,7 @@ describe('create line mesh', () => {
         { id: 'data-stream', name: 'some name', resolution: 0, data: [DATA_POINT], dataType: DataType.NUMBER },
       ],
       chartSize: CHART_SIZE,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       minBufferSize: 100,
       bufferFactor: 2,
       toClipSpace,
@@ -172,7 +172,7 @@ describe('create line mesh', () => {
         },
       ],
       chartSize: CHART_SIZE,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       minBufferSize: 100,
       bufferFactor: 2,
       toClipSpace,
@@ -230,7 +230,7 @@ describe('create line mesh', () => {
         },
       ],
       chartSize: CHART_SIZE,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       minBufferSize: 100,
       bufferFactor: 2,
       toClipSpace,
@@ -305,7 +305,7 @@ describe('update line mesh', () => {
     const lines = lineMesh({
       dataStreams: [],
       chartSize: CHART_SIZE,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       minBufferSize: 100,
       bufferFactor: 2,
       toClipSpace,
@@ -319,7 +319,7 @@ describe('update line mesh', () => {
       lines,
       dataStreams: DATA_STREAMS,
       chartSize: CHART_SIZE,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       hasDataChanged: true,
       toClipSpace,
     });
@@ -367,7 +367,7 @@ describe('update line mesh', () => {
     const lines = lineMesh({
       dataStreams: DATA_STREAMS,
       chartSize: CHART_SIZE,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       minBufferSize: 100,
       bufferFactor: 2,
       toClipSpace,
@@ -381,7 +381,7 @@ describe('update line mesh', () => {
       lines,
       dataStreams: [],
       chartSize: CHART_SIZE,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       hasDataChanged: true,
       toClipSpace,
     });
@@ -408,7 +408,7 @@ describe('update line mesh', () => {
         },
       ],
       chartSize: CHART_SIZE,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       minBufferSize: 100,
       bufferFactor: 2,
       toClipSpace,
@@ -430,7 +430,7 @@ describe('update line mesh', () => {
         },
       ],
       chartSize: CHART_SIZE,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       hasDataChanged: true,
       toClipSpace,
     });
@@ -474,7 +474,7 @@ describe('update line mesh', () => {
     const lines = lineMesh({
       dataStreams: [],
       chartSize,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       minBufferSize: 100,
       bufferFactor: 2,
       toClipSpace,
@@ -488,17 +488,15 @@ describe('update line mesh', () => {
       lines,
       dataStreams: [],
       chartSize: updatedChartSize,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       hasDataChanged: false,
       toClipSpace,
     });
 
     expect(lines.material.uniforms.xPixelDensity.value).toBe(
-      (toClipSpace(VIEW_PORT.end.getTime()) - toClipSpace(VIEW_PORT.start.getTime())) / updatedChartSize.width
+      (toClipSpace(VIEWPORT.end.getTime()) - toClipSpace(VIEWPORT.start.getTime())) / updatedChartSize.width
     );
-    expect(lines.material.uniforms.yPixelDensity.value).toBe(
-      (VIEW_PORT.yMax - VIEW_PORT.yMin) / updatedChartSize.height
-    );
+    expect(lines.material.uniforms.yPixelDensity.value).toBe((VIEWPORT.yMax - VIEWPORT.yMin) / updatedChartSize.height);
   });
 
   it('updates the color of line segments', () => {
@@ -514,7 +512,7 @@ describe('update line mesh', () => {
         },
       ],
       chartSize: CHART_SIZE,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       minBufferSize: 100,
       bufferFactor: 2,
       toClipSpace,
@@ -537,7 +535,7 @@ describe('update line mesh', () => {
         },
       ],
       chartSize: CHART_SIZE,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       hasDataChanged: true,
       toClipSpace,
     });

--- a/packages/synchro-charts/src/components/charts/sc-line-chart/lineMesh.ts
+++ b/packages/synchro-charts/src/components/charts/sc-line-chart/lineMesh.ts
@@ -154,7 +154,7 @@ const initializeGeometry = (geometry: LineBufferGeometry, bufferSize: number) =>
 };
 
 export const lineMesh = ({
-  viewPort,
+  viewport,
   dataStreams,
   chartSize,
   minBufferSize,
@@ -165,7 +165,7 @@ export const lineMesh = ({
 }: {
   chartSize: { width: number; height: number };
   dataStreams: DataStream[];
-  viewPort: ViewPort;
+  viewport: ViewPort;
   minBufferSize: number;
   bufferFactor: number;
   toClipSpace: (time: number) => number;
@@ -180,7 +180,7 @@ export const lineMesh = ({
   initializeGeometry(geometry, bufferSize);
 
   // Construct shader
-  const { x: xPixelDensity, y: yPixelDensity } = pixelDensity({ viewPort, toClipSpace, size: chartSize });
+  const { x: xPixelDensity, y: yPixelDensity } = pixelDensity({ viewport, toClipSpace, size: chartSize });
   const { showColor = true } = thresholdOptions;
 
   const lineMaterial = new RawShaderMaterial({
@@ -217,20 +217,20 @@ export const updateLineMesh = ({
   toClipSpace,
   lines,
   dataStreams,
-  viewPort,
+  viewport,
   hasDataChanged,
 }: {
   chartSize: { width: number; height: number };
   toClipSpace: (time: number) => number;
   lines: LineChartLineMesh;
   dataStreams: DataStream[];
-  viewPort: ViewPort;
+  viewport: ViewPort;
   hasDataChanged: boolean;
 }) => {
   /**
    * Update Uniforms
    */
-  const { x: xPixelDensity, y: yPixelDensity } = pixelDensity({ viewPort, toClipSpace, size: chartSize });
+  const { x: xPixelDensity, y: yPixelDensity } = pixelDensity({ viewport, toClipSpace, size: chartSize });
   lines.material.uniforms.xPixelDensity.value = xPixelDensity;
   lines.material.uniforms.yPixelDensity.value = yPixelDensity;
 

--- a/packages/synchro-charts/src/components/charts/sc-line-chart/sc-line-chart.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-line-chart/sc-line-chart.tsx
@@ -39,7 +39,7 @@ const tooltip = (props: Tooltip.Props) => (
 })
 export class ScLineChart implements ChartConfig {
   /** Chart API */
-  @Prop() viewPort!: MinimalViewPortConfig;
+  @Prop() viewport!: MinimalViewPortConfig;
   @Prop() movement?: MovementConfig;
   @Prop() scale?: ScaleConfig;
   @Prop() layout?: LayoutConfig;
@@ -83,7 +83,7 @@ export class ScLineChart implements ChartConfig {
               ...rect,
             }}
             dataStreams={this.dataStreams}
-            viewPort={this.viewPort}
+            viewport={this.viewport}
             minBufferSize={this.minBufferSize}
             bufferFactor={this.bufferFactor}
             isEditing={this.isEditing}

--- a/packages/synchro-charts/src/components/charts/sc-scatter-chart/chartScene.spec.ts
+++ b/packages/synchro-charts/src/components/charts/sc-scatter-chart/chartScene.spec.ts
@@ -3,7 +3,7 @@ import { chartScene, updateChartScene } from './chartScene';
 import { PointMesh, POINT_MESH_INDEX } from '../common/meshes/pointMesh';
 import { DataType } from '../../../utils/dataConstants';
 
-const VIEW_PORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
+const VIEWPORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
 
 const DATA_POINT_1: DataPoint = { x: new Date(2000, 0, 0).getTime(), y: 200 };
 const DATA_POINT_2: DataPoint = { x: new Date(2000, 1, 0).getTime(), y: 300 };
@@ -15,7 +15,7 @@ describe('points', () => {
     const container = document.createElement('div');
 
     const scene = chartScene({
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       container,
       chartSize: CHART_SIZE,
       dataStreams: [{ id: 'data-stream', name: 'some name', resolution: 0, data: [], dataType: DataType.NUMBER }],
@@ -29,7 +29,7 @@ describe('points', () => {
 
     const updatedScene = updateChartScene({
       scene,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       chartSize: CHART_SIZE,
       container,
       dataStreams: [

--- a/packages/synchro-charts/src/components/charts/sc-scatter-chart/chartScene.ts
+++ b/packages/synchro-charts/src/components/charts/sc-scatter-chart/chartScene.ts
@@ -14,7 +14,7 @@ import { getNumberThresholds } from '../common/annotations/utils';
 export const chartScene: ChartSceneCreator = ({
   dataStreams,
   container,
-  viewPort,
+  viewport,
   minBufferSize,
   bufferFactor,
   onUpdate,
@@ -22,7 +22,7 @@ export const chartScene: ChartSceneCreator = ({
   thresholds,
 }) => {
   const scene = new Scene();
-  const toClipSpace = clipSpaceConversion(viewPort);
+  const toClipSpace = clipSpaceConversion(viewport);
 
   const numberThresholds = getNumberThresholds(thresholds);
 
@@ -39,7 +39,7 @@ export const chartScene: ChartSceneCreator = ({
 
   meshList.forEach(mesh => scene.add(mesh));
 
-  return constructChartScene({ scene, viewPort, container, toClipSpace, onUpdate });
+  return constructChartScene({ scene, viewport, container, toClipSpace, onUpdate });
 };
 
 const maxDataPointsRendered = (points: PointMesh): number =>
@@ -50,7 +50,7 @@ export const updateChartScene: ChartSceneUpdater = ({
   dataStreams,
   chartSize,
   container,
-  viewPort,
+  viewport,
   hasDataChanged,
   bufferFactor,
   minBufferSize,
@@ -65,12 +65,12 @@ export const updateChartScene: ChartSceneUpdater = ({
   // chart scene, we must fully recreate the chart scene. This is a costly operation.
   const isDataOverflowingBuffer = maxDataPointsRendered(points) < numDataPoints(dataStreams);
 
-  if (isDataOverflowingBuffer || needsNewClipSpace(viewPort, scene.toClipSpace) || hasAnnotationChanged) {
+  if (isDataOverflowingBuffer || needsNewClipSpace(viewport, scene.toClipSpace) || hasAnnotationChanged) {
     return chartScene({
       dataStreams,
       chartSize,
       container,
-      viewPort,
+      viewport,
       minBufferSize,
       bufferFactor,
       onUpdate,

--- a/packages/synchro-charts/src/components/charts/sc-scatter-chart/sc-scatter-chart.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-scatter-chart/sc-scatter-chart.tsx
@@ -39,7 +39,7 @@ const tooltip = (props: Tooltip.Props) => (
 })
 export class ScScatterChart implements ChartConfig {
   /** Chart API */
-  @Prop() viewPort: MinimalViewPortConfig;
+  @Prop() viewport: MinimalViewPortConfig;
   @Prop() movement?: MovementConfig;
   @Prop() scale?: ScaleConfig;
   @Prop() layout?: LayoutConfig;
@@ -83,7 +83,7 @@ export class ScScatterChart implements ChartConfig {
             }}
             dataStreams={this.dataStreams}
             alarms={this.alarms}
-            viewPort={this.viewPort}
+            viewport={this.viewport}
             minBufferSize={this.minBufferSize}
             bufferFactor={this.bufferFactor}
             isEditing={this.isEditing}

--- a/packages/synchro-charts/src/components/charts/sc-status-timeline/chartScene.spec.ts
+++ b/packages/synchro-charts/src/components/charts/sc-status-timeline/chartScene.spec.ts
@@ -4,7 +4,7 @@ import { MONTH_IN_MS } from '../../../utils/time';
 import { StatusChartStatusMesh } from './statusMesh';
 import { DataType } from '../../../utils/dataConstants';
 
-const VIEW_PORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
+const VIEWPORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
 
 const TEST_DATA_POINTS: DataPoint<number>[] = Array.from({ length: 7 }, (_, index) => {
   return {
@@ -26,7 +26,7 @@ describe('statuses', () => {
         { id: 'data-stream', name: 'some name', resolution: MONTH_IN_MS, data: [], dataType: DataType.NUMBER },
       ],
       minBufferSize: 0,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       thresholdOptions: {
         showColor: false,
       },
@@ -52,7 +52,7 @@ describe('statuses', () => {
       hasDataChanged: true,
       minBufferSize: 0,
       scene,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       thresholdOptions: {
         showColor: false,
       },

--- a/packages/synchro-charts/src/components/charts/sc-status-timeline/chartScene.ts
+++ b/packages/synchro-charts/src/components/charts/sc-status-timeline/chartScene.ts
@@ -12,7 +12,7 @@ export const chartScene: ChartSceneCreator = ({
   alarms,
   dataStreams,
   container,
-  viewPort,
+  viewport,
   bufferFactor,
   minBufferSize,
   onUpdate,
@@ -21,7 +21,7 @@ export const chartScene: ChartSceneCreator = ({
   chartSize,
 }) => {
   const scene = new Scene();
-  const toClipSpace = clipSpaceConversion(viewPort);
+  const toClipSpace = clipSpaceConversion(viewport);
   scene.add(
     statusMesh({
       alarms,
@@ -34,7 +34,7 @@ export const chartScene: ChartSceneCreator = ({
       chartSize,
     })
   );
-  return constructChartScene({ scene, viewPort, container, toClipSpace, onUpdate });
+  return constructChartScene({ scene, viewport, container, toClipSpace, onUpdate });
 };
 
 export const updateChartScene: ChartSceneUpdater = ({
@@ -43,7 +43,7 @@ export const updateChartScene: ChartSceneUpdater = ({
   dataStreams,
   minBufferSize,
   bufferFactor,
-  viewPort,
+  viewport,
   container,
   onUpdate,
   chartSize,
@@ -59,13 +59,13 @@ export const updateChartScene: ChartSceneUpdater = ({
   // chart scene, we must fully recreate the chart scene. This is a costly operation.
   const isDataOverflowingBuffer = maxDataPointsRendered(statuses) < numDataPoints(dataStreams);
 
-  if (isDataOverflowingBuffer || needsNewClipSpace(viewPort, scene.toClipSpace)) {
+  if (isDataOverflowingBuffer || needsNewClipSpace(viewport, scene.toClipSpace)) {
     return chartScene({
       onUpdate,
       dataStreams,
       alarms,
       container,
-      viewPort,
+      viewport,
       minBufferSize,
       bufferFactor,
       chartSize,

--- a/packages/synchro-charts/src/components/charts/sc-status-timeline/sc-status-timeline-overlay/sc-status-timeline-overlay.spec.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-status-timeline/sc-status-timeline-overlay/sc-status-timeline-overlay.spec.tsx
@@ -5,7 +5,7 @@ import { update } from '../../common/tests/merge';
 import { ScStatusTimelineOverlay } from './sc-status-timeline-overlay';
 import { DataStream } from '../../../../utils/dataTypes';
 import { Threshold } from '../../common/types';
-import { VIEW_PORT } from '../../common/testUtil';
+import { VIEWPORT } from '../../common/testUtil';
 import { DAY_IN_MS } from '../../../../utils/time';
 import { ScStatusTimelineOverlayRow } from './sc-status-timeline-overlay-row';
 import { DATA_STREAM_2 } from '../../../../testing/__mocks__/mockWidgetProperties';
@@ -46,7 +46,7 @@ const ALARM_THRESHOLD: Threshold<string> = {
 };
 
 const WITHIN_VIEWPORT_DATE = new Date(2000, 0, 1).getTime();
-const BEFORE_VIEWPORT_DATE = VIEW_PORT.start.getTime() - DAY_IN_MS;
+const BEFORE_VIEWPORT_DATE = VIEWPORT.start.getTime() - DAY_IN_MS;
 
 const ALARM_STREAM: DataStream<string> = {
   id: 'alarm-stream',
@@ -97,7 +97,7 @@ const timelineOverlaySpecPage = async (propOverrides: Partial<Components.ScStatu
   const props: Components.ScStatusTimelineOverlay = {
     thresholds: [],
     dataStreams: [],
-    date: VIEW_PORT.end,
+    date: VIEWPORT.end,
     isEditing: false,
     widgetId: 'some-fake-widget-id',
     size: {

--- a/packages/synchro-charts/src/components/charts/sc-status-timeline/sc-status-timeline.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-status-timeline/sc-status-timeline.tsx
@@ -68,7 +68,7 @@ const tooltip = (alarms?: AlarmsConfig) => (props: Tooltip.Props) => {
 })
 export class ScStatusTimeline implements ChartConfig {
   /** Chart API */
-  @Prop() viewPort: MinimalViewPortConfig;
+  @Prop() viewport: MinimalViewPortConfig;
   @Prop() gestures: boolean = true;
   @Prop() movement?: MovementConfig;
   @Prop() scale?: ScaleConfig;
@@ -136,8 +136,8 @@ export class ScStatusTimeline implements ChartConfig {
                 size={chartSize}
                 dataStreams={this.dataStreams}
                 alarms={this.alarms}
-                viewPort={{
-                  ...this.viewPort,
+                viewport={{
+                  ...this.viewport,
                   yMin: 0,
                   yMax: HEIGHT,
                 }}
@@ -154,7 +154,7 @@ export class ScStatusTimeline implements ChartConfig {
               <sc-status-timeline-overlay
                 isEditing={this.isEditing}
                 thresholds={this.thresholds()}
-                date={this.viewPort.end || new Date()}
+                date={this.viewport.end || new Date()}
                 dataStreams={this.dataStreams}
                 size={chartSize}
                 widgetId={this.widgetId}

--- a/packages/synchro-charts/src/components/charts/sc-tooltip/sc-tooltip-rows.spec.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-tooltip/sc-tooltip-rows.spec.tsx
@@ -20,7 +20,7 @@ import {
   NUMBER_EMPTY_STREAM,
   WITHIN_VIEWPORT_DATE,
 } from '../../../testing/__mocks__/mockWidgetProperties';
-import { VIEW_PORT } from '../common/testUtil';
+import { VIEWPORT } from '../common/testUtil';
 import { DataType, StreamType, TREND_TYPE } from '../../../utils/dataConstants';
 
 import { COMPARISON_OPERATOR, DATA_ALIGNMENT, StatusIcon } from '../common/constants';
@@ -80,7 +80,7 @@ const TREND: TrendResult = {
   color: 'green',
   type: TREND_TYPE.LINEAR,
   equation: { gradient: 0, intercept: 0 },
-  startDate: VIEW_PORT.start,
+  startDate: VIEWPORT.start,
 };
 
 const newTooltipRowsSpecPage = async (propOverrides: Partial<Components.ScTooltipRows> = {}) => {
@@ -94,12 +94,12 @@ const newTooltipRowsSpecPage = async (propOverrides: Partial<Components.ScToolti
   const props: Components.ScTooltipRows = {
     dataAlignment: DATA_ALIGNMENT.EITHER,
     dataStreams: [],
-    selectedDate: VIEW_PORT.end,
+    selectedDate: VIEWPORT.end,
     showDataStreamColor: true,
     size: DEFAULT_CHART_CONFIG.size,
     thresholds: [],
     trendResults: [],
-    viewPort: VIEW_PORT,
+    viewport: VIEWPORT,
     supportString: true,
     showBlankTooltipRows: false,
     visualizesAlarms: false,

--- a/packages/synchro-charts/src/components/charts/sc-tooltip/sc-tooltip-rows.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-tooltip/sc-tooltip-rows.tsx
@@ -34,7 +34,7 @@ export class ScTooltipRows {
   @Prop() selectedDate!: Date;
   @Prop() size!: SizeConfig;
   @Prop() dataStreams!: DataStream[];
-  @Prop() viewPort!: ViewPort;
+  @Prop() viewport!: ViewPort;
   @Prop() thresholds!: Threshold[];
   @Prop() trendResults: TrendResult[] = [];
   @Prop() maxDurationFromDate?: number; // milliseconds
@@ -126,7 +126,7 @@ export class ScTooltipRows {
     const minResolution = resolutions.length > 0 ? Math.min(...resolutions) : 0;
 
     const dataPoints = activePoints({
-      viewPort: this.viewPort,
+      viewport: this.viewport,
       dataStreams: this.visualizedDataStreams(),
       dataAlignment: this.dataAlignment,
       selectedDate: this.selectedDate,
@@ -167,7 +167,7 @@ export class ScTooltipRows {
     const position = tooltipPosition({
       points,
       resolution: minResolution,
-      viewPort: this.viewPort,
+      viewport: this.viewport,
       size: this.size,
       selectedTimestamp: this.selectedDate.getTime(),
     });
@@ -204,7 +204,7 @@ export class ScTooltipRows {
         >
           <div class="awsui-util-shadow awsui-util-p-s">
             <small class={{ 'awsui-util-d-b': true, 'left-offset': !this.showDataStreamColor }}>
-              {displayDate(displayedDate, minResolution, this.viewPort)}
+              {displayDate(displayedDate, minResolution, this.viewport)}
             </small>
             {!isCrossResolution && (
               <small

--- a/packages/synchro-charts/src/components/charts/sc-tooltip/sc-tooltip.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-tooltip/sc-tooltip.tsx
@@ -17,7 +17,7 @@ export class ScTooltip {
   @Prop() size!: SizeConfig;
   @Prop() dataContainer!: HTMLElement;
   @Prop() dataStreams!: DataStream[];
-  @Prop() viewPort!: ViewPort;
+  @Prop() viewport!: ViewPort;
   @Prop() thresholds!: Threshold[];
   @Prop() trendResults: TrendResult[] = [];
   @Prop() maxDurationFromDate?: number; // milliseconds
@@ -60,12 +60,12 @@ export class ScTooltip {
 
     if (!isMouseBeingPressed && offsetX != null) {
       // Determine the date which corresponds with the mouses position.
-      const { start, end } = this.viewPort;
+      const { start, end } = this.viewport;
       const { width } = this.size;
 
       const ratio = offsetX / width;
-      const viewPortDuration = end.getTime() - start.getTime();
-      const selectedDateMS = start.getTime() + viewPortDuration * ratio;
+      const viewportDuration = end.getTime() - start.getTime();
+      const selectedDateMS = start.getTime() + viewportDuration * ratio;
 
       this.selectedDate = new Date(selectedDateMS);
     } else {
@@ -88,7 +88,7 @@ export class ScTooltip {
         trendResults={this.trendResults}
         size={this.size}
         dataStreams={this.dataStreams}
-        viewPort={this.viewPort}
+        viewport={this.viewport}
         selectedDate={this.selectedDate}
         thresholds={this.thresholds}
         maxDurationFromDate={this.maxDurationFromDate}

--- a/packages/synchro-charts/src/components/charts/sc-tooltip/tooltipPosition.spec.ts
+++ b/packages/synchro-charts/src/components/charts/sc-tooltip/tooltipPosition.spec.ts
@@ -4,15 +4,15 @@ import { POINT_TYPE } from '../sc-webgl-base-chart/activePoints';
 import { MINUTE_IN_MS } from '../../../utils/time';
 import { DataPoint } from '../../../utils/dataTypes';
 
-const VIEW_PORT = { start: new Date(2000, 0, 0), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
+const VIEWPORT = { start: new Date(2000, 0, 0), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
 const SIZE = { width: 500, height: 400 };
 
-const WITHIN_VIEW_PORT_DATE = (VIEW_PORT.start.getTime() + VIEW_PORT.end.getTime()) / 2;
+const WITHIN_VIEWPORT_DATE = (VIEWPORT.start.getTime() + VIEWPORT.end.getTime()) / 2;
 
 const STRING_TOOLTIP_POINT_1: TooltipPoint = {
   streamId: 'some-id',
   point: {
-    x: WITHIN_VIEW_PORT_DATE,
+    x: WITHIN_VIEWPORT_DATE,
     y: 'some-string',
   },
   color: 'red',
@@ -22,7 +22,7 @@ const STRING_TOOLTIP_POINT_1: TooltipPoint = {
 const DATA_TOOLTIP_POINT_1: TooltipPoint = {
   streamId: 'some-id',
   point: {
-    x: WITHIN_VIEW_PORT_DATE,
+    x: WITHIN_VIEWPORT_DATE,
     y: 12,
   },
   color: 'red',
@@ -45,7 +45,7 @@ describe('sanity test', () => {
       tooltipPosition({
         points: [],
         resolution: 0,
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         size: SIZE,
         selectedTimestamp: Date.now(),
       })
@@ -56,9 +56,9 @@ describe('sanity test', () => {
     const { x, y } = tooltipPosition({
       points: [DATA_TOOLTIP_POINT_1, TREND_TOOLTIP_POINT_1, STRING_TOOLTIP_POINT_1],
       resolution: 0,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       size: SIZE,
-      selectedTimestamp: WITHIN_VIEW_PORT_DATE,
+      selectedTimestamp: WITHIN_VIEWPORT_DATE,
     }) as { x: number; y: number };
 
     expect(x).toBeNumber();
@@ -69,9 +69,9 @@ describe('sanity test', () => {
     const { x, y } = tooltipPosition({
       points: [STRING_TOOLTIP_POINT_1],
       resolution: 0,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       size: SIZE,
-      selectedTimestamp: WITHIN_VIEW_PORT_DATE,
+      selectedTimestamp: WITHIN_VIEWPORT_DATE,
     }) as { x: number; y: number };
 
     expect(x).toBeNumber();
@@ -85,9 +85,9 @@ describe('x position', () => {
       const { x } = tooltipPosition({
         points: [DATA_TOOLTIP_POINT_1, TREND_TOOLTIP_POINT_1],
         resolution: 0,
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         size: SIZE,
-        selectedTimestamp: WITHIN_VIEW_PORT_DATE,
+        selectedTimestamp: WITHIN_VIEWPORT_DATE,
       }) as { x: number; y: number };
 
       expect(x).toBe(SIZE.width / 2);
@@ -97,9 +97,9 @@ describe('x position', () => {
       const { x } = tooltipPosition({
         points: [DATA_TOOLTIP_POINT_1, TREND_TOOLTIP_POINT_1],
         resolution: 0,
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         size: SIZE,
-        selectedTimestamp: VIEW_PORT.start.getTime(),
+        selectedTimestamp: VIEWPORT.start.getTime(),
       }) as { x: number; y: number };
 
       expect(x).toBe(0);
@@ -109,9 +109,9 @@ describe('x position', () => {
       const { x } = tooltipPosition({
         points: [DATA_TOOLTIP_POINT_1, TREND_TOOLTIP_POINT_1],
         resolution: 0,
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         size: SIZE,
-        selectedTimestamp: VIEW_PORT.end.getTime(),
+        selectedTimestamp: VIEWPORT.end.getTime(),
       }) as { x: number; y: number };
 
       expect(x).toBe(SIZE.width);
@@ -123,9 +123,9 @@ describe('x position', () => {
       const { x } = tooltipPosition({
         points: [DATA_TOOLTIP_POINT_1, TREND_TOOLTIP_POINT_1],
         resolution: MINUTE_IN_MS,
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         size: SIZE,
-        selectedTimestamp: WITHIN_VIEW_PORT_DATE,
+        selectedTimestamp: WITHIN_VIEWPORT_DATE,
       }) as { x: number; y: number };
 
       expect(x).toBe(SIZE.width / 2);
@@ -136,15 +136,15 @@ describe('x position', () => {
         ...DATA_TOOLTIP_POINT_1,
         point: {
           ...(DATA_TOOLTIP_POINT_1.point as DataPoint<number>),
-          x: VIEW_PORT.start.getTime(),
+          x: VIEWPORT.start.getTime(),
         },
       };
       const { x } = tooltipPosition({
         points: [TOOLTIP_POINT],
         resolution: MINUTE_IN_MS,
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         size: SIZE,
-        selectedTimestamp: WITHIN_VIEW_PORT_DATE,
+        selectedTimestamp: WITHIN_VIEWPORT_DATE,
       }) as { x: number; y: number };
 
       expect(x).toBe(0);
@@ -155,15 +155,15 @@ describe('x position', () => {
         ...DATA_TOOLTIP_POINT_1,
         point: {
           ...(DATA_TOOLTIP_POINT_1.point as DataPoint<number>),
-          x: VIEW_PORT.end.getTime(),
+          x: VIEWPORT.end.getTime(),
         },
       };
       const { x } = tooltipPosition({
         points: [TOOLTIP_POINT],
         resolution: MINUTE_IN_MS,
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         size: SIZE,
-        selectedTimestamp: WITHIN_VIEW_PORT_DATE,
+        selectedTimestamp: WITHIN_VIEWPORT_DATE,
       }) as { x: number; y: number };
 
       expect(x).toBe(SIZE.width);
@@ -176,9 +176,9 @@ describe('y position', () => {
     const { y } = tooltipPosition({
       points: [DATA_TOOLTIP_POINT_1, TREND_TOOLTIP_POINT_1],
       resolution: 0,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       size: SIZE,
-      selectedTimestamp: WITHIN_VIEW_PORT_DATE,
+      selectedTimestamp: WITHIN_VIEWPORT_DATE,
     }) as { x: number; y: number };
 
     expect(y).toBeGreaterThan(0);
@@ -197,9 +197,9 @@ describe('y position', () => {
         },
       ],
       resolution: 0,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       size: SIZE,
-      selectedTimestamp: WITHIN_VIEW_PORT_DATE,
+      selectedTimestamp: WITHIN_VIEWPORT_DATE,
     }) as { x: number; y: number };
 
     expect(y).toBe(0);

--- a/packages/synchro-charts/src/components/charts/sc-tooltip/tooltipPosition.ts
+++ b/packages/synchro-charts/src/components/charts/sc-tooltip/tooltipPosition.ts
@@ -9,12 +9,12 @@ const utilizedTimestamp = ({
   isRaw,
   points,
   selectedTimestamp,
-  viewPort,
+  viewport,
 }: {
   isRaw: boolean;
   points: TooltipPoint[];
   selectedTimestamp: Timestamp;
-  viewPort: ViewPort;
+  viewport: ViewPort;
 }): Timestamp => {
   if (isRaw) {
     // always use the selected date when raw. this has the impact of having the tooltip cursor always at where the cursor is
@@ -26,23 +26,23 @@ const utilizedTimestamp = ({
     return selectedTimestamp;
   }
 
-  if (pointDate < viewPort.start.getTime()) {
+  if (pointDate < viewport.start.getTime()) {
     // If the date is before the viewport, just use the start of the viewport. This has the effect of making a tooltip
     // appear flush at the left of the viewport when focusing on before-end-of-viewport positioned data.
-    return viewPort.start.getTime();
+    return viewport.start.getTime();
   }
 
   return pointDate;
 };
 
 export const tooltipPosition = ({
-  viewPort,
+  viewport,
   size: { width, height },
   points,
   resolution,
   selectedTimestamp,
 }: {
-  viewPort: ViewPort;
+  viewport: ViewPort;
   size: { width: number; height: number };
   points: TooltipPoint[];
   selectedTimestamp: Timestamp;
@@ -55,14 +55,14 @@ export const tooltipPosition = ({
   const isRaw = resolution === 0;
 
   // represents the date which corresponds with the position to render the cursor at
-  const timestamp = utilizedTimestamp({ isRaw, points, selectedTimestamp, viewPort });
+  const timestamp = utilizedTimestamp({ isRaw, points, selectedTimestamp, viewport });
 
-  const viewPortDuration = viewPort.end.getTime() - viewPort.start.getTime();
-  const datePositionRatio = (timestamp - viewPort.start.getTime()) / viewPortDuration;
+  const viewportDuration = viewport.end.getTime() - viewport.start.getTime();
+  const datePositionRatio = (timestamp - viewport.start.getTime()) / viewportDuration;
   const pixelX = width * datePositionRatio;
 
   const modelY = Math.max(...points.map(({ point }) => (point ? point.y : undefined)).filter(isNumber));
-  const pixelY = Math.max(0, height * (1 - (modelY - viewPort.yMin) / (viewPort.yMax - viewPort.yMin)));
+  const pixelY = Math.max(0, height * (1 - (modelY - viewport.yMin) / (viewport.yMax - viewport.yMin)));
 
   return { x: pixelX, y: pixelY };
 };

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/activePoints.spec.ts
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/activePoints.spec.ts
@@ -9,7 +9,7 @@ const STREAM_ID = 'stream-id';
 const STREAM_ID_2 = 'stream-id-2';
 const STREAM_ID_3 = 'stream-id-3';
 
-const VIEW_PORT: ViewPort = {
+const VIEWPORT: ViewPort = {
   start: new Date(2000, 0, 0),
   end: new Date(2001, 0, 0),
   yMin: 0,
@@ -45,7 +45,7 @@ describe('right data alignment', () => {
   it('returns no points if there is only data to the left of the selected date', () => {
     expect(
       activePoints({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataAlignment: DATA_ALIGNMENT.RIGHT,
         dataStreams: [
           {
@@ -65,7 +65,7 @@ describe('right data alignment', () => {
   it('returns data point if data point falls exactly on selected date', () => {
     expect(
       activePoints({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataAlignment: DATA_ALIGNMENT.RIGHT,
         dataStreams: [
           {
@@ -85,7 +85,7 @@ describe('right data alignment', () => {
   it('returns data point if data point is after the selected date', () => {
     expect(
       activePoints({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataAlignment: DATA_ALIGNMENT.RIGHT,
         dataStreams: [
           {
@@ -105,7 +105,7 @@ describe('right data alignment', () => {
   it('returns data point if data point is after the selected date far in the future', () => {
     expect(
       activePoints({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataAlignment: DATA_ALIGNMENT.RIGHT,
         dataStreams: [
           {
@@ -126,7 +126,7 @@ describe('right data alignment', () => {
     const MAX_DURATION_FROM_DATE = MINUTE_IN_MS;
     expect(
       activePoints({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataAlignment: DATA_ALIGNMENT.RIGHT,
         dataStreams: [
           {
@@ -148,7 +148,7 @@ describe('right data alignment', () => {
     const MAX_DURATION_FROM_DATE = MINUTE_IN_MS;
     expect(
       activePoints({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataAlignment: DATA_ALIGNMENT.RIGHT,
         dataStreams: [
           {
@@ -171,7 +171,7 @@ describe('left data alignment', () => {
   it('returns no points if there is only data to the right of the selected date', () => {
     expect(
       activePoints({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataAlignment: DATA_ALIGNMENT.LEFT,
         dataStreams: [
           {
@@ -191,7 +191,7 @@ describe('left data alignment', () => {
   it('returns data point if data point falls exactly on selected date', () => {
     expect(
       activePoints({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataAlignment: DATA_ALIGNMENT.LEFT,
         dataStreams: [
           {
@@ -211,7 +211,7 @@ describe('left data alignment', () => {
   it('returns data point if data point is before the selected date', () => {
     expect(
       activePoints({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataAlignment: DATA_ALIGNMENT.LEFT,
         dataStreams: [
           {
@@ -231,7 +231,7 @@ describe('left data alignment', () => {
   it('returns data point if data point is before the selected date far in the past', () => {
     expect(
       activePoints({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataAlignment: DATA_ALIGNMENT.LEFT,
         dataStreams: [
           {
@@ -252,7 +252,7 @@ describe('left data alignment', () => {
     const MAX_DURATION_FROM_DATE = MINUTE_IN_MS;
     expect(
       activePoints({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataAlignment: DATA_ALIGNMENT.LEFT,
         dataStreams: [
           {
@@ -274,7 +274,7 @@ describe('left data alignment', () => {
     const MAX_DURATION_FROM_DATE = MINUTE_IN_MS;
     expect(
       activePoints({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataAlignment: DATA_ALIGNMENT.LEFT,
         dataStreams: [
           {
@@ -298,7 +298,7 @@ describe('data alignment set to either side', () => {
     it('with a single point within a view port, return that point', () => {
       expect(
         activePoints({
-          viewPort: VIEW_PORT,
+          viewport: VIEWPORT,
           dataAlignment: DATA_ALIGNMENT.EITHER,
           dataStreams: [
             {
@@ -318,7 +318,7 @@ describe('data alignment set to either side', () => {
     it('with multiple points with different dates, only return the closest point', () => {
       expect(
         activePoints({
-          viewPort: VIEW_PORT,
+          viewport: VIEWPORT,
           dataAlignment: DATA_ALIGNMENT.EITHER,
           dataStreams: [
             {
@@ -342,7 +342,7 @@ describe('data alignment set to either side', () => {
 
       expect(
         activePoints({
-          viewPort: VIEW_PORT,
+          viewport: VIEWPORT,
           dataAlignment: DATA_ALIGNMENT.EITHER,
           dataStreams: [
             {
@@ -378,7 +378,7 @@ describe('data alignment set to either side', () => {
 
       expect(
         activePoints({
-          viewPort: VIEW_PORT,
+          viewport: VIEWPORT,
           dataAlignment: DATA_ALIGNMENT.EITHER,
           dataStreams: [
             {
@@ -417,7 +417,7 @@ describe('data alignment set to either side', () => {
     it('returns no active points when there are no data streams', () => {
       expect(
         activePoints({
-          viewPort: VIEW_PORT,
+          viewport: VIEWPORT,
           dataAlignment: DATA_ALIGNMENT.EITHER,
           dataStreams: [],
           selectedDate: new Date(2000, 6, 0),
@@ -430,7 +430,7 @@ describe('data alignment set to either side', () => {
       it('returns no active points when all points are after the viewport', () => {
         expect(
           activePoints({
-            viewPort: VIEW_PORT,
+            viewport: VIEWPORT,
             dataAlignment: DATA_ALIGNMENT.EITHER,
             dataStreams: [
               {
@@ -450,7 +450,7 @@ describe('data alignment set to either side', () => {
       it('returns the point which has a date exactly matching the selected date', () => {
         expect(
           activePoints({
-            viewPort: VIEW_PORT,
+            viewport: VIEWPORT,
             dataAlignment: DATA_ALIGNMENT.EITHER,
             dataStreams: [
               {
@@ -476,7 +476,7 @@ describe('data alignment set to either side', () => {
       it('returns the right most point when the selected date is equidistant from two points', () => {
         expect(
           activePoints({
-            viewPort: VIEW_PORT,
+            viewport: VIEWPORT,
             dataAlignment: DATA_ALIGNMENT.EITHER,
             dataStreams: [
               {
@@ -502,7 +502,7 @@ describe('data alignment set to either side', () => {
       it('returns the right biased point when the closest point is to the left of the selected date', () => {
         expect(
           activePoints({
-            viewPort: VIEW_PORT,
+            viewport: VIEWPORT,
             dataAlignment: DATA_ALIGNMENT.EITHER,
             dataStreams: [
               {
@@ -528,7 +528,7 @@ describe('data alignment set to either side', () => {
       it('returns the right biased point when the closest point is to the right of the selected date', () => {
         expect(
           activePoints({
-            viewPort: VIEW_PORT,
+            viewport: VIEWPORT,
             dataAlignment: DATA_ALIGNMENT.EITHER,
             dataStreams: [
               {
@@ -554,7 +554,7 @@ describe('data alignment set to either side', () => {
       it('returns the closest point within the viewport', () => {
         expect(
           activePoints({
-            viewPort: VIEW_PORT,
+            viewport: VIEWPORT,
             dataAlignment: DATA_ALIGNMENT.EITHER,
             dataStreams: [
               {
@@ -582,7 +582,7 @@ describe('data alignment set to either side', () => {
       it('returns the closest point across multiple data streams', () => {
         expect(
           activePoints({
-            viewPort: VIEW_PORT,
+            viewport: VIEWPORT,
             dataAlignment: DATA_ALIGNMENT.EITHER,
             dataStreams: [
               {
@@ -612,7 +612,7 @@ describe('data alignment set to either side', () => {
       it('returns points for each stream which has data within the viewport', () => {
         expect(
           activePoints({
-            viewPort: VIEW_PORT,
+            viewport: VIEWPORT,
             dataAlignment: DATA_ALIGNMENT.EITHER,
             dataStreams: [
               {
@@ -642,7 +642,7 @@ describe('data alignment set to either side', () => {
       it('only returns point for one data stream when points have different dates but allowMultipleDates is false', () => {
         expect(
           activePoints({
-            viewPort: VIEW_PORT,
+            viewport: VIEWPORT,
             dataAlignment: DATA_ALIGNMENT.EITHER,
             dataStreams: [
               {
@@ -673,7 +673,7 @@ describe('aggregated data', () => {
   it('does not return any active points when requesting raw data but there is only aggregated data', () => {
     expect(
       activePoints({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataAlignment: DATA_ALIGNMENT.EITHER,
         dataStreams: [
           {
@@ -692,7 +692,7 @@ describe('aggregated data', () => {
   it('does not return any active points when requesting aggregated data but there is only raw data', () => {
     expect(
       activePoints({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataAlignment: DATA_ALIGNMENT.EITHER,
         dataStreams: [
           {
@@ -711,7 +711,7 @@ describe('aggregated data', () => {
   it('does return the aggregate data when requested', () => {
     expect(
       activePoints({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataAlignment: DATA_ALIGNMENT.EITHER,
         dataStreams: [
           {
@@ -730,7 +730,7 @@ describe('aggregated data', () => {
   it('only returns aggregated data of the correct resolution', () => {
     expect(
       activePoints({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataAlignment: DATA_ALIGNMENT.EITHER,
         dataStreams: [
           {

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/activePoints.ts
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/activePoints.ts
@@ -96,14 +96,14 @@ export const closestPoint = <T extends Primitive>(
  * However if you have 10 points of different dates, only the closest point would be returned.
  */
 export const activePoints = <T extends Primitive>({
-  viewPort,
+  viewport,
   dataStreams,
   selectedDate,
   allowMultipleDates,
   dataAlignment,
   maxDurationFromDate,
 }: {
-  viewPort: { start: Date; end: Date };
+  viewport: { start: Date; end: Date };
   dataStreams: DataStream<T>[];
   selectedDate: Date;
   // Whether we allow points containing different x values (dates).
@@ -113,7 +113,7 @@ export const activePoints = <T extends Primitive>({
 }): ActivePoint<T>[] => {
   const dataStreamUtilizedData = dataStreams.map(stream => ({
     streamId: stream.id,
-    dataPoints: getDataBeforeDate(getDataPoints(stream, stream.resolution), viewPort.end),
+    dataPoints: getDataBeforeDate(getDataPoints(stream, stream.resolution), viewport.end),
   }));
   const selectedTimestamp = selectedDate.getTime();
 

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/chartDefaults.ts
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/chartDefaults.ts
@@ -4,7 +4,7 @@ import { BaseConfig } from '../../../utils/dataTypes';
 
 export const DEFAULT_BASE_CONFIG: BaseConfig = {
   widgetId: 'fake-id',
-  viewPort: {
+  viewport: {
     start: new Date(1995, 0, 0, 0),
     end: new Date(2020, 1, 0, 0),
     yMin: 0,
@@ -16,7 +16,7 @@ export const DEFAULT_BASE_CONFIG: BaseConfig = {
 
 export const DEFAULT_CHART_CONFIG: BaseChartConfig = {
   widgetId: 'fake-id',
-  viewPort: {
+  viewport: {
     start: new Date(1995, 0, 0, 0),
     end: new Date(2020, 1, 0, 0),
     yMin: 0,

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/clipSpaceConversion.spec.ts
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/clipSpaceConversion.spec.ts
@@ -5,14 +5,14 @@ const FLOATING_POINT_SIG_FIGS = 7;
 
 describe('model space conversion', () => {
   it('for a small viewport window, the distance between two converted positions is the difference in time in milliseconds', () => {
-    const viewPort = {
+    const viewport = {
       start: new Date(2020, 0, 0, 0, 0, 0),
       end: new Date(2020, 0, 0, 0, 0, 10),
       yMin: 0,
       yMax: 100,
     };
 
-    const toClipSpace = clipSpaceConversion(viewPort);
+    const toClipSpace = clipSpaceConversion(viewport);
 
     const DISTANCE_MS = 35;
     const dateA = new Date(2020, 0, 0, 0, 0, 0, 0);
@@ -44,8 +44,8 @@ describe('model space conversion', () => {
     ${new Date(2000, 0, 0, 0, 0, 0, 0).toISOString()} | ${new Date(2100, 0, 0, 0, 0, 0, 0).toISOString()}
   `('converts the time within the viewport to be representable by floating points', ({ start, end }) => {
     // NOTE: yMin and yMax don't effect the conversion
-    const viewPort = { start: new Date(start), end: new Date(end), yMin: 0, yMax: 100 };
-    const toClipSpace = clipSpaceConversion(viewPort);
+    const viewport = { start: new Date(start), end: new Date(end), yMin: 0, yMax: 100 };
+    const toClipSpace = clipSpaceConversion(viewport);
     describe.each`
       percentage
       ${-0.1}
@@ -57,9 +57,9 @@ describe('model space conversion', () => {
       ${1.1}
     `(`given viewport from ( ${start} -> ${end} )`, ({ percentage }) => {
       test(`at ${percentage * 100}% of the viewport, have the position representable by a float`, () => {
-        const pointInTime = viewPort.start.getTime() + (viewPort.start.getTime() - viewPort.end.getTime()) * percentage;
+        const pointInTime = viewport.start.getTime() + (viewport.start.getTime() - viewport.end.getTime()) * percentage;
 
-        // expect(needsNewClipSpace(viewPort, toClipSpace)).toBeFalse();
+        // expect(needsNewClipSpace(viewport, toClipSpace)).toBeFalse();
         expect(Math.abs(toClipSpace(pointInTime))).toBeLessThan(10 ** FLOATING_POINT_SIG_FIGS);
       });
     });
@@ -68,24 +68,24 @@ describe('model space conversion', () => {
 
 describe('whether we need a new clip space provided', () => {
   it('the view port used to create the model space conversion function is always in bounds', () => {
-    const viewPort = { start: new Date(2000, 0), end: new Date(2001, 0), yMin: 0, yMax: 100 };
-    const toClipSpace = clipSpaceConversion(viewPort);
+    const viewport = { start: new Date(2000, 0), end: new Date(2001, 0), yMin: 0, yMax: 100 };
+    const toClipSpace = clipSpaceConversion(viewport);
 
-    expect(needsNewClipSpace(viewPort, toClipSpace)).toBeFalse();
+    expect(needsNewClipSpace(viewport, toClipSpace)).toBeFalse();
   });
 
   it('a view port which is translated a far distance from the original view port is out of bounds', () => {
-    const viewPort = { start: new Date(2000, 0), end: new Date(2000, 0, 1), yMin: 0, yMax: 100 };
+    const viewport = { start: new Date(2000, 0), end: new Date(2000, 0, 1), yMin: 0, yMax: 100 };
     const newViewPort = { start: new Date(2010, 0), end: new Date(2010, 0, 1), yMin: 0, yMax: 100 };
-    const toClipSpace = clipSpaceConversion(viewPort);
+    const toClipSpace = clipSpaceConversion(viewport);
 
     expect(needsNewClipSpace(newViewPort, toClipSpace)).toBeTrue();
   });
 
   it('a view port which is scaled out a far distance from the original view port is out of bounds', () => {
-    const viewPort = { start: new Date(2000, 0), end: new Date(2000, 0, 1), yMin: 0, yMax: 100 };
+    const viewport = { start: new Date(2000, 0), end: new Date(2000, 0, 1), yMin: 0, yMax: 100 };
     const newViewPort = { start: new Date(1999, 0), end: new Date(2002, 0), yMin: 0, yMax: 100 };
-    const toClipSpace = clipSpaceConversion(viewPort);
+    const toClipSpace = clipSpaceConversion(viewport);
 
     expect(needsNewClipSpace(newViewPort, toClipSpace)).toBeTrue();
   });
@@ -103,14 +103,14 @@ describe('whether we need a new clip space provided', () => {
     ${30 * YEAR_IN_MS}
   `('should not need a new clip space when viewport has not changed', ({ duration }) => {
     test(`given a viewport with duration of ${duration / SECOND_IN_MS} seconds`, () => {
-      const viewPort = {
+      const viewport = {
         start: new Date(),
         end: new Date(new Date().getTime() + duration),
         yMin: 0,
         yMax: 100,
       };
-      const toClipSpace = clipSpaceConversion(viewPort);
-      expect(needsNewClipSpace(viewPort, toClipSpace)).toBeFalse();
+      const toClipSpace = clipSpaceConversion(viewport);
+      expect(needsNewClipSpace(viewport, toClipSpace)).toBeFalse();
     });
   });
 });

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/clipSpaceConversion.ts
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/clipSpaceConversion.ts
@@ -72,9 +72,9 @@ const granularity = (durationMS: number): number => {
  * Converts something from model space (millisecond representation of time) into our clip space.
  * The goal is to be able to represent the time from `start` to `end` with floating point precision (7 significant digits).
  */
-export const clipSpaceConversion = (viewPort: ViewPort): ((t: number) => number) => {
-  const durationMS = viewPort.end.getTime() - viewPort.start.getTime();
-  const anchorMS = viewPort.start.getTime() - durationMS * 0.25;
+export const clipSpaceConversion = (viewport: ViewPort): ((t: number) => number) => {
+  const durationMS = viewport.end.getTime() - viewport.start.getTime();
+  const anchorMS = viewport.start.getTime() - durationMS * 0.25;
 
   const granularityMS = granularity(durationMS);
 
@@ -98,11 +98,11 @@ const MIN_GRANULARITY = 3000;
  * 2. The granularity within the viewport mapped to the clip space is too low - i.e. if the viewport maps to [0, 10],
  *    then we can only represent 11 distinct points.
  */
-export const needsNewClipSpace = (viewPort: ViewPort, toClipSpace: (time: number) => number): boolean => {
-  const isOutOfBounds = isDateOutOfBounds(viewPort.start, toClipSpace) || isDateOutOfBounds(viewPort.end, toClipSpace);
+export const needsNewClipSpace = (viewport: ViewPort, toClipSpace: (time: number) => number): boolean => {
+  const isOutOfBounds = isDateOutOfBounds(viewport.start, toClipSpace) || isDateOutOfBounds(viewport.end, toClipSpace);
 
-  const distanceMS = viewPort.end.getTime() - viewPort.start.getTime();
-  const distanceClipSpace = toClipSpace(viewPort.end.getTime()) - toClipSpace(viewPort.start.getTime());
+  const distanceMS = viewport.end.getTime() - viewport.start.getTime();
+  const distanceClipSpace = toClipSpace(viewport.end.getTime()) - toClipSpace(viewport.start.getTime());
 
   const hasTooLowGranularity = distanceMS > distanceClipSpace && distanceClipSpace < MIN_GRANULARITY;
   return isOutOfBounds || hasTooLowGranularity;

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/renderAxis.ts
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/renderAxis.ts
@@ -11,7 +11,7 @@ import { AnySelection, Axis } from '../common/types';
 export interface AxisRendererProps {
   container: SVGElement;
   size: SizeConfig;
-  viewPort: ViewPort;
+  viewport: ViewPort;
   axis?: Axis.Options;
 }
 
@@ -26,12 +26,12 @@ const DEFAULT_AXIS_OPTIONS = {
  *
  */
 
-const scales = (size: SizeConfig, viewPort: ViewPort) => {
+const scales = (size: SizeConfig, viewport: ViewPort) => {
   const xScale = scaleTime()
-    .domain([viewPort.start.getTime(), viewPort.end.getTime()])
+    .domain([viewport.start.getTime(), viewport.end.getTime()])
     .range([0, size.width]);
   const yScale = scaleLinear()
-    .domain([viewPort.yMin, viewPort.yMax])
+    .domain([viewport.yMin, viewport.yMax])
     .range([size.height, 0]);
   return {
     xScale,
@@ -56,18 +56,18 @@ const tickCount = (size: SizeConfig) =>
  *
  */
 
-const xAxisConstructor = (size: SizeConfig, viewPort: ViewPort) => {
+const xAxisConstructor = (size: SizeConfig, viewport: ViewPort) => {
   const { xTickCount } = tickCount(size);
-  const { xScale } = scales(size, viewPort);
+  const { xScale } = scales(size, viewport);
   return axisBottom(xScale)
     .ticks(xTickCount)
     .tickPadding(TICK_PADDING)
     .tickSize(TICK_SIZE);
 };
 
-const yAxisConstructor = (size: SizeConfig, viewPort: ViewPort) => {
+const yAxisConstructor = (size: SizeConfig, viewport: ViewPort) => {
   const { yTickCount } = tickCount(size);
-  const { yScale } = scales(size, viewPort);
+  const { yScale } = scales(size, viewport);
   return axisLeft(yScale)
     .ticks(yTickCount)
     .tickSize(-size.width)
@@ -75,16 +75,16 @@ const yAxisConstructor = (size: SizeConfig, viewPort: ViewPort) => {
 };
 
 /** D3 call to construct the X Axis */
-const xAxisCall = (size: SizeConfig, viewPort: ViewPort) => (selection: AnySelection) =>
+const xAxisCall = (size: SizeConfig, viewport: ViewPort) => (selection: AnySelection) =>
   selection
     .attr('transform', `translate(${size.marginLeft}, ${size.marginTop + size.height})`)
-    .call(xAxisConstructor(size, viewPort));
+    .call(xAxisConstructor(size, viewport));
 
 /** D3 call to construct the Y Axis */
-const yAxisCall = (size: SizeConfig, viewPort: ViewPort) => (selection: AnySelection) =>
+const yAxisCall = (size: SizeConfig, viewport: ViewPort) => (selection: AnySelection) =>
   selection
     .attr('transform', `translate(${size.marginLeft}, ${size.marginTop})`)
-    .call(yAxisConstructor(size, viewPort));
+    .call(yAxisConstructor(size, viewport));
 
 export const renderAxis = () => {
   // Store axis element references to prevent re-querying DOM nodes on every render.
@@ -92,7 +92,7 @@ export const renderAxis = () => {
   let xAxisSeparator: AnySelection | null;
   let xAxis: AnySelection | null;
 
-  const axisRenderer = ({ container, viewPort, size, axis }: AxisRendererProps) => {
+  const axisRenderer = ({ container, viewport, size, axis }: AxisRendererProps) => {
     const sel = select(container);
 
     const { showX, showY, labels } = {
@@ -126,7 +126,7 @@ export const renderAxis = () => {
       sel
         .append('g')
         .attr('class', 'axis x-axis')
-        .call(xAxisCall(size, viewPort));
+        .call(xAxisCall(size, viewport));
 
       // Note: We are assuming that axis within a component aren't destroyed and recreated.
       xAxis = select(container.querySelector('.x-axis') as SVGElement);
@@ -143,7 +143,7 @@ export const renderAxis = () => {
       sel
         .append('g')
         .attr('class', 'axis y-axis')
-        .call(yAxisCall(size, viewPort));
+        .call(yAxisCall(size, viewport));
 
       // Note: We are assuming that axis within a component aren't destroyed and recreated.
       yAxis = select(container.querySelector('.y-axis') as SVGElement);
@@ -155,7 +155,7 @@ export const renderAxis = () => {
     }
 
     if (xAxis) {
-      xAxis.call(xAxisCall(size, viewPort));
+      xAxis.call(xAxisCall(size, viewport));
 
       /** Update X Axis Separator */
       if (xAxisSeparator) {
@@ -183,7 +183,7 @@ export const renderAxis = () => {
         }
       }
 
-      yAxis.call(yAxisCall(size, viewPort));
+      yAxis.call(yAxisCall(size, viewport));
     }
   };
 

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-gesture-handler.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-gesture-handler.tsx
@@ -27,7 +27,7 @@ export class ScGestureHandler {
   @Element() el: HTMLElement;
 
   @Prop() size!: SizeConfig;
-  @Prop() viewPort!: ViewPort;
+  @Prop() viewport!: ViewPort;
   @Prop() onDateRangeChange!: ({ end, start }: { start: Date; end: Date }) => void;
 
   @State() start?: number;
@@ -43,7 +43,7 @@ export class ScGestureHandler {
   private initialViewPort: ViewPort;
 
   componentDidLoad() {
-    this.initialViewPort = this.viewPort;
+    this.initialViewPort = this.viewport;
     this.setupZoom();
     this.el.addEventListener('mousedown', this.beginBrush, { capture: true });
     this.el.addEventListener('mousemove', this.moveBrush);
@@ -58,7 +58,7 @@ export class ScGestureHandler {
     this.el.removeEventListener('mouseleave', this.cancelBrush);
   }
 
-  @Watch('viewPort')
+  @Watch('viewport')
   onViewPortChange(newViewPort: ViewPort) {
     this.zoom.updateViewPort(newViewPort);
   }
@@ -122,7 +122,7 @@ export class ScGestureHandler {
 
   initiateTransform = (startPx: number, endPx: number) => {
     const xScale = scaleTime()
-      .domain([this.viewPort.start.getTime(), this.viewPort.end.getTime()])
+      .domain([this.viewport.start.getTime(), this.viewport.end.getTime()])
       .range([0, this.size.width]);
     const xScaleOriginal = scaleTime()
       .domain([this.initialViewPort.start.getTime(), this.initialViewPort.end.getTime()])
@@ -141,7 +141,7 @@ export class ScGestureHandler {
   };
 
   scales() {
-    const { yMin, yMax, start, end } = this.viewPort;
+    const { yMin, yMax, start, end } = this.viewport;
     const { width, height } = this.size;
     const xScale = scaleTime()
       .domain([start.getTime(), end.getTime()])

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-axis.spec.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-axis.spec.tsx
@@ -45,7 +45,7 @@ const axisSpecPage = async (axisRendererProps?: Partial<AxisRendererProps>) => {
   axisRenderer({
     container: axis.querySelector('svg.axis') as SVGElement,
     size: SIZE_CONFIG,
-    viewPort: VIEWPORT,
+    viewport: VIEWPORT,
     ...axisRendererProps,
   });
 
@@ -208,7 +208,7 @@ describe('updated correctly', () => {
     axisRenderer({
       container: axis.querySelector('svg.axis') as SVGElement,
       size: SIZE_CONFIG,
-      viewPort: {
+      viewport: {
         ...VIEWPORT,
         start: new Date(1995, 0, 0),
         end: new Date(1997, 0, 0),
@@ -233,7 +233,7 @@ describe('updated correctly', () => {
     axisRenderer({
       container: axis.querySelector('svg.axis') as SVGElement,
       size: SIZE_CONFIG,
-      viewPort: {
+      viewport: {
         ...VIEWPORT,
         yMin: 4000,
         yMax: 5000,
@@ -262,7 +262,7 @@ describe('updated correctly', () => {
     axisRenderer({
       container: axis.querySelector('svg.axis') as SVGElement,
       size: SIZE_CONFIG,
-      viewPort: {
+      viewport: {
         ...VIEWPORT,
         yMin: 4000,
         yMax: 5000,

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.spec.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.spec.tsx
@@ -20,7 +20,7 @@ import { ScWebglAxis } from './sc-webgl-axis';
 import { chartScene, updateChartScene } from '../sc-line-chart/chartScene';
 import { DATA_ALIGNMENT, LEGEND_POSITION } from '../common/constants';
 
-const VIEW_PORT: ViewPort = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
+const VIEWPORT: ViewPort = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
 
 const STREAM: DataStream<number> = {
   id: 'stream-id',
@@ -53,7 +53,7 @@ const newChartSpecPage = async (props: Partial<Components.ScWebglBaseChart>) => 
     yRangeStartFromZero: false,
     displaysError: true,
     createChartScene: chartScene,
-    viewPort: VIEW_PORT,
+    viewport: VIEWPORT,
     gestures: true,
     size: {
       ...CHART_CONFIG.size,
@@ -127,12 +127,12 @@ describe('legend', () => {
         position: LEGEND_POSITION.BOTTOM,
         width: 200,
       },
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
     });
 
     const legend = chart.querySelector('sc-legend') as HTMLScLegendElement;
 
-    expect(legend.viewPort).toEqual(VIEW_PORT);
+    expect(legend.viewport).toEqual(VIEWPORT);
   });
 });
 
@@ -149,7 +149,7 @@ describe('chart scene management', () => {
       dataType: DataType.NUMBER,
       data: [
         {
-          x: VIEW_PORT.end.getTime(),
+          x: VIEWPORT.end.getTime(),
           y: 50,
         },
       ],
@@ -164,7 +164,7 @@ describe('chart scene management', () => {
       dataType: DataType.NUMBER,
       color: 'red',
       streamType: StreamType.ALARM,
-      data: [{ x: VIEW_PORT.end.getTime(), y: 100 }],
+      data: [{ x: VIEWPORT.end.getTime(), y: 100 }],
     };
 
     it('does not pass any alarm data when visualizesAlarm is true, but there are no data streams', async () => {
@@ -175,7 +175,7 @@ describe('chart scene management', () => {
         createChartScene: mockCreateChartScene,
         updateChartScene: mockUpdateChartScene,
         visualizesAlarms: true,
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataStreams: [],
       });
 
@@ -202,7 +202,7 @@ describe('chart scene management', () => {
         createChartScene: mockCreateChartScene,
         updateChartScene: mockUpdateChartScene,
         visualizesAlarms: true,
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataStreams: DATA,
       });
 
@@ -227,7 +227,7 @@ describe('chart scene management', () => {
         createChartScene: mockCreateChartScene,
         updateChartScene: mockUpdateChartScene,
         visualizesAlarms: true,
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataStreams: [ALARM_DATA_STREAM],
       });
 
@@ -252,7 +252,7 @@ describe('chart scene management', () => {
         createChartScene: mockCreateChartScene,
         updateChartScene: mockUpdateChartScene,
         visualizesAlarms: false,
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataStreams: [ALARM_DATA_STREAM],
       });
 
@@ -277,7 +277,7 @@ describe('chart scene management', () => {
     await newChartSpecPage({
       createChartScene: mockCreateChartScene,
       updateChartScene: mockUpdateChartScene,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       minBufferSize: MIN_BUFFER_SIZE,
       bufferFactor: BUFFER_FACTOR,
       dataStreams: DATA_STREAMS,
@@ -287,7 +287,7 @@ describe('chart scene management', () => {
     expect(mockCreateChartScene).toBeCalledTimes(1);
     expect(mockCreateChartScene).toBeCalledWith(
       expect.objectContaining({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         minBufferSize: MIN_BUFFER_SIZE,
         bufferFactor: BUFFER_FACTOR,
         dataStreams: DATA_STREAMS,
@@ -299,8 +299,8 @@ describe('chart scene management', () => {
     expect(mockOnUpdateLifeCycle).toBeCalledTimes(1);
     expect(mockOnUpdateLifeCycle).toBeCalledWith(
       expect.objectContaining({
-        start: VIEW_PORT.start,
-        end: VIEW_PORT.end,
+        start: VIEWPORT.start,
+        end: VIEWPORT.end,
       })
     );
   });
@@ -308,7 +308,7 @@ describe('chart scene management', () => {
   it('calls onUpdate when data is changed', async () => {
     const mockOnUpdateLifeCycle = jest.fn();
     const { chart, page } = await newChartSpecPage({
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       dataStreams: DATA_STREAMS,
       onUpdateLifeCycle: mockOnUpdateLifeCycle,
     });
@@ -320,8 +320,8 @@ describe('chart scene management', () => {
     await page.waitForChanges();
     expect(mockOnUpdateLifeCycle).toBeCalledWith(
       expect.objectContaining({
-        start: VIEW_PORT.start,
-        end: VIEW_PORT.end,
+        start: VIEWPORT.start,
+        end: VIEWPORT.end,
       })
     );
   });
@@ -331,7 +331,7 @@ describe('chart scene management', () => {
     const { chart, page } = await newChartSpecPage({
       createChartScene: chartScene,
       updateChartScene,
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       minBufferSize: MIN_BUFFER_SIZE,
       bufferFactor: BUFFER_FACTOR,
       dataStreams: DATA_STREAMS,
@@ -343,9 +343,9 @@ describe('chart scene management', () => {
     // Update view port
     const UPDATED_START = new Date(1919, 0, 0);
     const UPDATED_END = new Date(1985, 0, 0);
-    chart.viewPort = {
-      yMax: chart.viewPort.yMax,
-      yMin: chart.viewPort.yMin,
+    chart.viewport = {
+      yMax: chart.viewport.yMax,
+      yMin: chart.viewport.yMin,
       lastUpdatedBy: undefined,
       start: UPDATED_START,
       end: UPDATED_END,
@@ -372,7 +372,7 @@ describe('loading status', () => {
       resolution: 0,
       data: [
         {
-          x: VIEW_PORT.end.getTime(),
+          x: VIEWPORT.end.getTime(),
           y: 50,
         },
       ],

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
@@ -76,7 +76,7 @@ export class ScWebglBaseChart {
   @Prop() dataStreams!: DataStream[];
   @Prop() updateChartScene!: ChartSceneUpdater;
   @Prop() createChartScene!: ChartSceneCreator;
-  @Prop() viewPort!: MinimalViewPortConfig;
+  @Prop() viewport!: MinimalViewPortConfig;
   @Prop() gestures!: boolean;
   @Prop() size!: SizePositionConfig;
   @Prop() isEditing: boolean = false;
@@ -100,7 +100,7 @@ export class ScWebglBaseChart {
   @Prop() requestData?: RequestDataFn;
 
   /** Optionally hooks to integrate custom logic into the base chart */
-  @Prop() onUpdateLifeCycle?: (viewPort: ViewPortConfig) => void;
+  @Prop() onUpdateLifeCycle?: (viewport: ViewPortConfig) => void;
 
   @Prop() messageOverrides?: MessageOverrides;
 
@@ -113,11 +113,11 @@ export class ScWebglBaseChart {
   /**
    * Active View Port Config
    */
-  @State() yMin: number = this.viewPort.yMin || 0;
-  @State() yMax: number = this.viewPort.yMax || 100;
+  @State() yMin: number = this.viewport.yMin || 0;
+  @State() yMax: number = this.viewport.yMax || 100;
   // NOTE: If a start and end date are not provided, that means we are in 'live' mode
-  @State() start: Date = this.viewPort.start || new Date(Date.now() - (this.viewPort.duration as number));
-  @State() end: Date = this.viewPort.end || new Date();
+  @State() start: Date = this.viewport.start || new Date(Date.now() - (this.viewport.duration as number));
+  @State() end: Date = this.viewport.end || new Date();
 
   @State() trendResults: TrendResult[] = [];
 
@@ -199,7 +199,7 @@ export class ScWebglBaseChart {
     return this.dataStreams.filter(({ streamType }) => streamType !== StreamType.ALARM);
   }
 
-  @Watch('viewPort')
+  @Watch('viewport')
   onViewPortChange(newViewPort: ViewPortConfig, oldViewPort: ViewPortConfig) {
     if (this.scene && !isEqual(newViewPort, oldViewPort)) {
       const hasYRangeChanged = newViewPort.yMin !== oldViewPort.yMin || newViewPort.yMax !== oldViewPort.yMax;
@@ -274,13 +274,13 @@ export class ScWebglBaseChart {
 
   @Watch('axis')
   onAxisChange(newProp: Axis.Options, oldProp: Axis.Options) {
-    const viewPort = this.activeViewPort();
+    const viewport = this.activeViewPort();
     const size = this.chartSizeConfig();
 
     if (!isEqual(newProp, oldProp)) {
       this.axisRenderer({
         container: this.getAxisContainer(),
-        viewPort,
+        viewport,
         size,
         axis: this.axis,
       });
@@ -328,7 +328,7 @@ export class ScWebglBaseChart {
     end: this.end,
     yMin: this.yMin,
     yMax: this.yMax,
-    group: this.viewPort.group,
+    group: this.viewport.group,
   });
 
   handleCameraEvent = ({ start, end }: { start: Date; end: Date }) => {
@@ -337,7 +337,7 @@ export class ScWebglBaseChart {
       webGLRenderer.updateViewPorts({ start, end, manager: this.scene });
 
       // Emit date range change to allow other non-webgl based components to sync the new date range
-      this.onDateRangeChange([start, end, this.viewPort.group]);
+      this.onDateRangeChange([start, end, this.viewport.group]);
     }
   };
 
@@ -362,8 +362,8 @@ export class ScWebglBaseChart {
     });
 
     /** Update active viewport. */
-    this.yMin = this.viewPort.yMin != null ? this.viewPort.yMin : yMin;
-    this.yMax = this.viewPort.yMax != null ? this.viewPort.yMax : yMax;
+    this.yMin = this.viewport.yMin != null ? this.viewport.yMin : yMin;
+    this.yMax = this.viewport.yMax != null ? this.viewport.yMax : yMax;
 
     this.applyYRangeChanges();
   };
@@ -440,7 +440,7 @@ export class ScWebglBaseChart {
 
   setupChartScene() {
     this.scene = this.createChartScene({
-      viewPort: this.activeViewPort(),
+      viewport: this.activeViewPort(),
       chartSize: this.chartSizeConfig(),
       dataStreams: this.visualizedDataStreams(),
       alarms: this.alarms,
@@ -511,7 +511,7 @@ export class ScWebglBaseChart {
     this.updateAndRegisterChartScene({ hasDataChanged, hasSizeChanged, hasAnnotationChanged });
 
     // settings to utilize in all feature updates.
-    const viewPort = this.activeViewPort();
+    const viewport = this.activeViewPort();
     const size = this.chartSizeConfig();
 
     if (this.onUpdateLifeCycle) {
@@ -538,7 +538,7 @@ export class ScWebglBaseChart {
       renderAnnotations({
         container: this.getThresholdContainer(),
         annotations: numberAnnotations,
-        viewPort,
+        viewport,
         size,
         // TODO: Revisit this.
         // If no data streams are present we will fallback to a resolution of 0, i.e. 'raw' data
@@ -553,10 +553,10 @@ export class ScWebglBaseChart {
      */
     if (!this.supportString) {
       const dataStreamsWithTrends = this.visualizedDataStreams().filter(isNumberDataStream);
-      this.trendResults = getAllTrendResults(viewPort, dataStreamsWithTrends, this.trends);
+      this.trendResults = getAllTrendResults(viewport, dataStreamsWithTrends, this.trends);
       renderTrendLines({
         container: this.getTrendContainer(),
-        viewPort,
+        viewport,
         size,
         dataStreams: this.visualizedDataStreams(),
         trendResults: this.trendResults,
@@ -568,7 +568,7 @@ export class ScWebglBaseChart {
      */
     this.axisRenderer({
       container: this.getAxisContainer(),
-      viewPort,
+      viewport,
       size,
       axis: this.axis,
     });
@@ -604,7 +604,7 @@ export class ScWebglBaseChart {
         dataStreams: this.visualizedDataStreams(),
         alarms: this.alarms,
         container,
-        viewPort: this.activeViewPort(),
+        viewport: this.activeViewPort(),
         minBufferSize: this.minBufferSize,
         bufferFactor: this.bufferFactor,
         onUpdate: this.onUpdate,
@@ -691,7 +691,7 @@ export class ScWebglBaseChart {
       size: this.chartSizeConfig(),
       style: { marginLeft: `${marginLeft}px`, marginTop: `${marginTop}px` },
       dataStreams: this.dataStreams,
-      viewPort: this.activeViewPort(),
+      viewport: this.activeViewPort(),
       dataContainer: this.getDataContainer(),
       thresholds,
       trendResults: this.trendResults,
@@ -712,7 +712,7 @@ export class ScWebglBaseChart {
       if (points.length === 0) {
         return true;
       }
-      // Check the latest datapoint to see if its before the start of viewPort
+      // Check the latest datapoint to see if its before the start of viewport
       const isDataOutOfRange = points[points.length - 1].x < this.start.getTime();
       return isDataOutOfRange;
     });
@@ -741,7 +741,7 @@ export class ScWebglBaseChart {
             <sc-gesture-handler
               onDateRangeChange={this.handleCameraEvent}
               size={chartSizeConfig}
-              viewPort={this.activeViewPort()}
+              viewport={this.activeViewPort()}
             />
           )}
         </DataContainer>
@@ -752,7 +752,7 @@ export class ScWebglBaseChart {
               dataStreams={this.dataStreams}
               visualizesAlarms={this.visualizesAlarms}
               updateDataStreamName={this.updateDataStreamName}
-              viewPort={this.activeViewPort()}
+              viewport={this.activeViewPort()}
               isEditing={this.isEditing}
               isLoading={shouldDisplayAsLoading}
               thresholds={thresholds}

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/scaleUtil.ts
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/scaleUtil.ts
@@ -34,11 +34,11 @@ const getScale = (scaleType: ScaleType): Scale => {
  * them will always be the range.
  */
 export const createScales = ({
-  viewPort: { start, end, yMin, yMax },
+  viewport: { start, end, yMin, yMax },
   size: { width, height },
   scale: { xScaleType, yScaleType },
 }: {
-  viewPort: ViewPort;
+  viewport: ViewPort;
   size: SizeConfig;
   scale: ScaleConfig;
 }): {

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/scaleUtils.spec.ts
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/scaleUtils.spec.ts
@@ -1,7 +1,7 @@
 import { zoomIdentity } from 'd3-zoom';
 import { scaleLinear } from 'd3-scale';
 import { createScales, transformScales } from './scaleUtil';
-import { VIEW_PORT, CHART_CONFIG } from '../common/testUtil';
+import { VIEWPORT, CHART_CONFIG } from '../common/testUtil';
 import { ScaleType } from '../common/constants';
 
 describe('scale transformations', () => {
@@ -130,7 +130,7 @@ const createConfig = ({
     width: xRange[1] - xRange[0],
     height: yRange[1] - yRange[0],
   },
-  viewPort: {
+  viewport: {
     start: xDomain[0],
     end: xDomain[1],
     yMin: yDomain[0],
@@ -179,7 +179,7 @@ describe('create scales', () => {
     expect(() =>
       createScales({
         size: CHART_CONFIG.size,
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         scale: {
           ...CHART_CONFIG.scale,
           xScaleType: 'fake-scale-type' as ScaleType,

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/types.ts
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/types.ts
@@ -13,7 +13,7 @@ export type ChartSceneCreator = (options: {
   alarms?: AlarmsConfig;
   container: HTMLElement;
   chartSize: { width: number; height: number };
-  viewPort: ViewPort;
+  viewport: ViewPort;
 
   // The minimum number of points the buffer must be able to fit. The smaller this number is, the
   // less memory upfront is allocated to the buffers which improves performance.
@@ -44,7 +44,7 @@ export type ChartSceneUpdater = (options: {
   dataStreams: DataStream[];
   alarms?: AlarmsConfig;
   container: HTMLElement;
-  viewPort: ViewPort;
+  viewport: ViewPort;
   chartSize: { width: number; height: number };
   bufferFactor: number;
   minBufferSize: number;

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/utils.spec.ts
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/utils.spec.ts
@@ -16,12 +16,12 @@ describe('construct chart scene', () => {
   const X_MAX = new Date(2001, 0, 0);
   const Y_MIN = 100;
   const Y_MAX = 5000;
-  const VIEW_PORT = { start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX };
+  const VIEWPORT = { start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX };
 
   it('onUpdate is called when viewport is updated with the new viewport dates', () => {
     const onUpdate = jest.fn();
     const scene = constructChartScene({
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       container: document.createElement('div'),
       scene: new Scene(),
       toClipSpace: z => z,
@@ -40,7 +40,7 @@ describe('construct chart scene', () => {
 
   it('initializes the camera with the correct view port based on the x and y domains', () => {
     const scene = constructChartScene({
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       container: document.createElement('div'),
       scene: new Scene(),
       toClipSpace: z => z,
@@ -53,13 +53,13 @@ describe('construct chart scene', () => {
 
   it('creates a unique id', () => {
     const scene1 = constructChartScene({
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       container: document.createElement('div'),
       scene: new Scene(),
       toClipSpace: z => z,
     });
     const scene2 = constructChartScene({
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       container: document.createElement('div'),
       scene: new Scene(),
       toClipSpace: z => z,
@@ -70,7 +70,7 @@ describe('construct chart scene', () => {
   describe('disposal of scene', () => {
     it('disposes top level scene', () => {
       const chartScene = constructChartScene({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         container: document.createElement('div'),
         scene: new Scene(),
         toClipSpace: z => z,
@@ -82,7 +82,7 @@ describe('construct chart scene', () => {
 
     it('disposes of a single mesh correctly', () => {
       const chartScene = constructChartScene({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         container: document.createElement('div'),
         scene: new Scene(),
         toClipSpace: z => z,
@@ -108,7 +108,7 @@ describe('construct chart scene', () => {
         dataStreams: [],
         minBufferSize: 100,
         bufferFactor: 2,
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         container: document.createElement('div'),
         chartSize: CHART_SIZE,
         thresholdOptions: {

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/utils.ts
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/utils.ts
@@ -71,22 +71,22 @@ const dispose = (scene: Scene) => {
 export const constructChartScene = ({
   scene,
   container,
-  viewPort,
+  viewport,
   toClipSpace,
   onUpdate,
 }: {
   scene: Scene;
   container: HTMLElement;
-  viewPort: ViewPort;
+  viewport: ViewPort;
   toClipSpace: (time: number) => number;
   onUpdate?: ({ start, end }: { start: Date; end: Date }) => void;
 }): ChartScene => {
   // Create a camera pointed at our viewport - this determines which part of the mesh we see.
   const camera = new OrthographicCamera(
-    toClipSpace(viewPort.start.getTime()),
-    toClipSpace(viewPort.end.getTime()),
-    viewPort.yMax,
-    viewPort.yMin,
+    toClipSpace(viewport.start.getTime()),
+    toClipSpace(viewport.end.getTime()),
+    viewport.yMax,
+    viewport.yMin,
     NEAR,
     FAR
   );
@@ -102,14 +102,14 @@ export const constructChartScene = ({
     dispose: () => dispose(scene),
 
     /**
-     * A Unique identifier for the grouping of viewPorts which this chart syncs with.
+     * A Unique identifier for the grouping of viewports which this chart syncs with.
      *
      * Whenever any of the viewports are altered within a viewport group, all of the charts
      * within the view port group will have their viewport start and end dates synced.
      *
-     * A lack of a viewPortGroup means that the chart is not synced with any of charts.
+     * A lack of a viewportGroup means that the chart is not synced with any of charts.
      */
-    viewPortGroup: viewPort.group,
+    viewportGroup: viewport.group,
 
     updateViewPort: ({ start, end }: { start: Date; end: Date }) => {
       /**

--- a/packages/synchro-charts/src/components/sc-kpi/sc-kpi-base/sc-kpi-base.spec.ts
+++ b/packages/synchro-charts/src/components/sc-kpi/sc-kpi-base/sc-kpi-base.spec.ts
@@ -7,7 +7,7 @@ import { Components } from '../../../components.d';
 import { ScKpiBase } from './sc-kpi-base';
 import { DataStream, DataStreamInfo, DEFAULT_MESSAGE_OVERRIDES } from '../../../utils/dataTypes';
 
-import { VIEW_PORT } from '../../charts/common/testUtil';
+import { VIEWPORT } from '../../charts/common/testUtil';
 import { HOUR_IN_MS, YEAR_IN_MS } from '../../../utils/time';
 import { NO_VALUE_PRESENT } from '../../common/terms';
 import { DATA_STREAM, THRESHOLD } from '../../../testing/__mocks__/mockWidgetProperties';
@@ -44,7 +44,7 @@ const newValueSpecPage = async (propOverrides: Partial<Components.ScKpiBase> = {
     messageOverrides: {},
     trendStream: undefined,
     propertyStream: DATA_STREAM,
-    viewPort: VIEW_PORT,
+    viewport: VIEWPORT,
     miniVersion: false,
     onChangeLabel: () => null,
     ...propOverrides,
@@ -64,7 +64,7 @@ describe('disabled', () => {
   it('renders placeholder text when point is within viewport', async () => {
     const { chart } = await newValueSpecPage({
       isEnabled: false,
-      viewPort: {
+      viewport: {
         start: new Date(1999, 0, 0),
         end: new Date(2001, 0, 0),
         duration: YEAR_IN_MS,
@@ -100,9 +100,9 @@ describe('messageOverrides', () => {
 });
 
 describe('latest value', () => {
-  it('renders single data points value which is within the viewPort', async () => {
+  it('renders single data points value which is within the viewport', async () => {
     const { chart } = await newValueSpecPage({
-      viewPort: {
+      viewport: {
         start: new Date(1999, 0, 0),
         end: new Date(2001, 0, 0),
         duration: HOUR_IN_MS,
@@ -127,7 +127,7 @@ describe('latest value', () => {
   it('renders data for a single datapoint that is outside of the date range', async () => {
     const LATEST_VALUE = 1298;
     const { chart } = await newValueSpecPage({
-      viewPort: {
+      viewport: {
         start: new Date(2000, 0, 0),
         end: new Date(2001, 0, 0),
       },
@@ -145,7 +145,7 @@ describe('latest value', () => {
     const LATEST_VALUE = 8910;
 
     const { chart } = await newValueSpecPage({
-      viewPort: { duration: YEAR_IN_MS },
+      viewport: { duration: YEAR_IN_MS },
       propertyPoint: { x: new Date(1994, 0, 0).getTime(), y: LATEST_VALUE },
       propertyStream: DATA_STREAM,
     });
@@ -179,14 +179,14 @@ describe('trend', () => {
     expect(valueContainer.textContent).toEqual(EXPECTED_PERCENTAGE);
   });
 
-  it('displays the previous value from a given set of data partially within the viewPort', async () => {
+  it('displays the previous value from a given set of data partially within the viewport', async () => {
     const Y_VALUE_1 = 100;
     const Y_VALUE_2 = 150;
     const Y_VALUE_3 = 125;
     const EXPECTED_PERCENTAGE = '16.7%';
 
     const { chart } = await newValueSpecPage({
-      viewPort: {
+      viewport: {
         duration: 5 * YEAR_IN_MS,
       },
       trendStream: {
@@ -210,7 +210,7 @@ describe('trend', () => {
 
   it('displays the trend as 0% when value and prevValue are both 0', async () => {
     const { chart } = await newValueSpecPage({
-      viewPort: {
+      viewport: {
         duration: 5 * YEAR_IN_MS,
       },
       trendStream: {
@@ -231,7 +231,7 @@ describe('trend', () => {
 
   it('displays no previous value on trend when previous value is 0 but current value is positive', async () => {
     const { chart } = await newValueSpecPage({
-      viewPort: {
+      viewport: {
         duration: 5 * YEAR_IN_MS,
       },
       trendStream: {
@@ -252,7 +252,7 @@ describe('trend', () => {
 
   it('displays no previous value on trend when previous value is 0 but current value is negative', async () => {
     const { chart } = await newValueSpecPage({
-      viewPort: {
+      viewport: {
         duration: 5 * YEAR_IN_MS,
       },
       trendStream: {

--- a/packages/synchro-charts/src/components/sc-kpi/sc-kpi-base/sc-kpi-base.tsx
+++ b/packages/synchro-charts/src/components/sc-kpi/sc-kpi-base/sc-kpi-base.tsx
@@ -32,7 +32,7 @@ export class ScKpiBase {
 
   @Prop() messageOverrides!: MessageOverrides;
 
-  @Prop() viewPort!: MinimalViewPortConfig;
+  @Prop() viewport!: MinimalViewPortConfig;
   @Prop() trendStream!: DataStream | undefined;
   @Prop() isEditing: boolean = false;
   @Prop() isEnabled: boolean = true;

--- a/packages/synchro-charts/src/components/sc-kpi/sc-kpi.spec.ts
+++ b/packages/synchro-charts/src/components/sc-kpi/sc-kpi.spec.ts
@@ -20,8 +20,8 @@ import { ScWidgetGrid } from '../sc-widget-grid/sc-widget-grid';
 import { ScGridTooltip } from '../sc-widget-grid/sc-grid-tooltip';
 import { DataPoint } from '../../utils/dataTypes';
 
-const VIEW_PORT = {
-  ...DEFAULT_CHART_CONFIG.viewPort,
+const VIEWPORT = {
+  ...DEFAULT_CHART_CONFIG.viewport,
   duration: MINUTE_IN_MS,
 };
 
@@ -36,7 +36,7 @@ const newValueSpecPage = async (propOverrides: Partial<Components.ScKpi> = {}) =
     widgetId: 'test-kpi-widget',
     isEditing: false,
     dataStreams: DATA_STREAMS,
-    viewPort: VIEW_PORT,
+    viewport: VIEWPORT,
     ...propOverrides,
   };
   update(kpi, props);
@@ -155,15 +155,15 @@ describe('when enabled', () => {
 
 describe('when disabled', () => {
   it('renders base kpi per data stream', async () => {
-    const NON_LIVE_VIEW_PORT = {
-      ...VIEW_PORT,
+    const NON_LIVE_VIEWPORT = {
+      ...VIEWPORT,
       duration: undefined,
     };
 
     const dataStreams = [STRING_STREAM_1, STRING_STREAM_2, DATA_STREAM, ALARM_STREAM];
 
     const { kpi } = await newValueSpecPage({
-      viewPort: NON_LIVE_VIEW_PORT,
+      viewport: NON_LIVE_VIEWPORT,
       dataStreams,
     });
 
@@ -172,13 +172,13 @@ describe('when disabled', () => {
   });
 
   it('renders a help icon', async () => {
-    const NON_LIVE_VIEW_PORT = {
-      ...VIEW_PORT,
+    const NON_LIVE_VIEWPORT = {
+      ...VIEWPORT,
       duration: undefined,
     };
 
     const { kpi } = await newValueSpecPage({
-      viewPort: NON_LIVE_VIEW_PORT,
+      viewport: NON_LIVE_VIEWPORT,
     });
 
     expect(kpi.querySelector('sc-help-tooltip')).not.toBeNull();

--- a/packages/synchro-charts/src/components/sc-kpi/sc-kpi.tsx
+++ b/packages/synchro-charts/src/components/sc-kpi/sc-kpi.tsx
@@ -15,7 +15,7 @@ const renderCell: RenderCell = props => <sc-kpi-base {...props} />;
   shadow: false,
 })
 export class ScKpi implements ChartConfig {
-  @Prop() viewPort: MinimalViewPortConfig;
+  @Prop() viewport: MinimalViewPortConfig;
   @Prop() widgetId!: string;
   @Prop() dataStreams!: DataStream[];
   @Prop() annotations: Annotations;
@@ -24,10 +24,10 @@ export class ScKpi implements ChartConfig {
   @Prop() messageOverrides: MessageOverrides = {};
 
   render() {
-    const { viewPort, widgetId, dataStreams, annotations, liveModeOnlyMessage, isEditing, messageOverrides } = this;
+    const { viewport, widgetId, dataStreams, annotations, liveModeOnlyMessage, isEditing, messageOverrides } = this;
     return (
       <sc-widget-grid
-        viewPort={viewPort}
+        viewport={viewport}
         widgetId={widgetId}
         dataStreams={dataStreams}
         annotations={annotations}

--- a/packages/synchro-charts/src/components/sc-status-grid/sc-status-grid.spec.tsx
+++ b/packages/synchro-charts/src/components/sc-status-grid/sc-status-grid.spec.tsx
@@ -14,8 +14,8 @@ import { ScWidgetGrid } from '../sc-widget-grid/sc-widget-grid';
 import { ScGridTooltip } from '../sc-widget-grid/sc-grid-tooltip';
 import { DataType, StreamType } from '../../utils/dataConstants';
 
-const VIEW_PORT = {
-  ...DEFAULT_CHART_CONFIG.viewPort,
+const VIEWPORT = {
+  ...DEFAULT_CHART_CONFIG.viewport,
   duration: MINUTE_IN_MS,
 };
 
@@ -49,7 +49,7 @@ const statusGridSpecPage = async (propOverrides: Partial<Components.ScStatusGrid
   const props: Partial<Components.ScStatusGrid> = {
     widgetId: WIDGET_ID,
     dataStreams: DATA_STREAMS,
-    viewPort: VIEW_PORT,
+    viewport: VIEWPORT,
     labelsConfig: {
       showValue: true,
       showName: true,
@@ -109,7 +109,7 @@ describe('when enabled', () => {
 
   it('renders on cell for an alarm plus a property info, when associated', async () => {
     const point: DataPoint<number> = {
-      x: (VIEW_PORT.end as Date).getTime(),
+      x: (VIEWPORT.end as Date).getTime(),
       y: 100,
     };
     const ASSOCIATED_DATA_STREAM: DataStream<number> = {
@@ -184,13 +184,13 @@ describe('alarms', () => {
 
 describe('when disabled', () => {
   it('renders cell per data stream', async () => {
-    const NON_LIVE_VIEW_PORT = {
-      ...VIEW_PORT,
+    const NON_LIVE_VIEWPORT = {
+      ...VIEWPORT,
       duration: undefined,
     };
 
     const { statusGrid } = await statusGridSpecPage({
-      viewPort: NON_LIVE_VIEW_PORT,
+      viewport: NON_LIVE_VIEWPORT,
       dataStreams: [NUMBER_STREAM, STRING_STREAM],
     });
 
@@ -199,13 +199,13 @@ describe('when disabled', () => {
   });
 
   it('renders a help icon', async () => {
-    const NON_LIVE_VIEW_PORT = {
-      ...VIEW_PORT,
+    const NON_LIVE_VIEWPORT = {
+      ...VIEWPORT,
       duration: undefined,
     };
 
     const { statusGrid } = await statusGridSpecPage({
-      viewPort: NON_LIVE_VIEW_PORT,
+      viewport: NON_LIVE_VIEWPORT,
     });
 
     expect(statusGrid.querySelector('sc-help-tooltip')).not.toBeNull();

--- a/packages/synchro-charts/src/components/sc-status-grid/sc-status-grid.tsx
+++ b/packages/synchro-charts/src/components/sc-status-grid/sc-status-grid.tsx
@@ -25,7 +25,7 @@ const MSG =
 export class ScStatusGrid implements ChartConfig {
   /** Status Grid Specific configuration */
   @Prop() labelsConfig: LabelsConfig;
-  @Prop() viewPort: MinimalViewPortConfig;
+  @Prop() viewport: MinimalViewPortConfig;
   @Prop() widgetId!: string;
   @Prop() dataStreams!: DataStream[];
   @Prop() annotations: Annotations;
@@ -35,7 +35,7 @@ export class ScStatusGrid implements ChartConfig {
 
   render() {
     const {
-      viewPort,
+      viewport,
       widgetId,
       dataStreams,
       annotations,
@@ -47,7 +47,7 @@ export class ScStatusGrid implements ChartConfig {
     return (
       <sc-widget-grid
         labelsConfig={labelsConfig}
-        viewPort={viewPort}
+        viewport={viewport}
         widgetId={widgetId}
         dataStreams={dataStreams}
         annotations={annotations}

--- a/packages/synchro-charts/src/components/sc-table/sc-table.spec.tsx
+++ b/packages/synchro-charts/src/components/sc-table/sc-table.spec.tsx
@@ -45,8 +45,8 @@ const TABLE_COLUMNS: TableColumn[] = [
   { header: 'Alarm', rows: [STREAM_3.id] },
 ];
 
-const VIEW_PORT = {
-  ...DEFAULT_CHART_CONFIG.viewPort,
+const VIEWPORT = {
+  ...DEFAULT_CHART_CONFIG.viewport,
   duration: MINUTE_IN_MS,
 };
 const WIDGET_ID = 'test-widget-it';
@@ -63,7 +63,7 @@ const tableSpecPage = async (propOverrides: Partial<Components.ScTable> = {}) =>
     dataStreams: [],
     tableColumns: [],
     widgetId: WIDGET_ID,
-    viewPort: VIEW_PORT,
+    viewport: VIEWPORT,
     annotations: {},
     trends: [],
     ...propOverrides,
@@ -268,15 +268,15 @@ describe('rendering', () => {
   });
 
   it('while in a historical time frame, only display table header and disable status', async () => {
-    const NON_LIVE_VIEW_PORT = {
-      ...VIEW_PORT,
+    const NON_LIVE_VIEWPORT = {
+      ...VIEWPORT,
       duration: undefined,
     };
 
     const { table } = await tableSpecPage({
       dataStreams: [],
       tableColumns: TABLE_COLUMNS,
-      viewPort: NON_LIVE_VIEW_PORT,
+      viewport: NON_LIVE_VIEWPORT,
     });
 
     const headers = table.querySelectorAll('th');
@@ -287,15 +287,15 @@ describe('rendering', () => {
   });
 
   it('while in a historical time frame, only display `liveModeOnlyMessage` for disable status', async () => {
-    const NON_LIVE_VIEW_PORT = {
-      ...VIEW_PORT,
+    const NON_LIVE_VIEWPORT = {
+      ...VIEWPORT,
       duration: undefined,
     };
     const LIVE_MODE_MSG = 'liveModeOnlyMessage';
     const { table } = await tableSpecPage({
       dataStreams: [],
       tableColumns: TABLE_COLUMNS,
-      viewPort: NON_LIVE_VIEW_PORT,
+      viewport: NON_LIVE_VIEWPORT,
       liveModeOnlyMessage: LIVE_MODE_MSG,
     });
 

--- a/packages/synchro-charts/src/components/sc-table/sc-table.tsx
+++ b/packages/synchro-charts/src/components/sc-table/sc-table.tsx
@@ -5,7 +5,7 @@ import { Trend } from '../charts/common/trends/types';
 import { Annotations, ChartConfig, Threshold } from '../charts/common/types';
 import { webGLRenderer } from '../sc-webgl-context/webglContext';
 import { constructTableData, Row } from './constructTableData';
-import { viewPortEndDate, viewPortStartDate } from '../../utils/viewPort';
+import { viewportEndDate, viewportStartDate } from '../../utils/viewPort';
 
 const MSG =
   'This visualization displays only live data. Choose a live time frame to display data in this visualization.';
@@ -15,7 +15,7 @@ const MSG =
   shadow: false,
 })
 export class ScTable implements ChartConfig {
-  @Prop() viewPort: MinimalViewPortConfig;
+  @Prop() viewport: MinimalViewPortConfig;
   @Prop() widgetId!: string;
   @Prop() dataStreams!: DataStream[];
   @Prop() annotations: Annotations;
@@ -27,16 +27,16 @@ export class ScTable implements ChartConfig {
   @Prop() tableColumns: TableColumn[];
 
   /** Active Viewport */
-  @State() start: Date = viewPortStartDate(this.viewPort);
-  @State() end: Date = viewPortEndDate(this.viewPort);
-  @State() duration?: number = this.viewPort.duration;
+  @State() start: Date = viewportStartDate(this.viewport);
+  @State() end: Date = viewportEndDate(this.viewport);
+  @State() duration?: number = this.viewport.duration;
 
-  @Watch('viewPort')
+  @Watch('viewport')
   onViewPortChange(newViewPort: MinimalViewPortConfig) {
     this.onUpdate({
       ...newViewPort,
-      start: viewPortStartDate(this.viewPort),
-      end: viewPortEndDate(this.viewPort),
+      start: viewportStartDate(this.viewport),
+      end: viewportEndDate(this.viewport),
     });
   }
 
@@ -50,7 +50,7 @@ export class ScTable implements ChartConfig {
   componentDidLoad() {
     webGLRenderer.addChartScene({
       id: this.widgetId,
-      viewPortGroup: this.viewPort.group,
+      viewportGroup: this.viewport.group,
       dispose: () => {},
       updateViewPort: this.onUpdate,
     });

--- a/packages/synchro-charts/src/components/sc-webgl-context/handleCameraEvent.spec.ts
+++ b/packages/synchro-charts/src/components/sc-webgl-context/handleCameraEvent.spec.ts
@@ -11,7 +11,7 @@ const Y_MAX = 300;
 
 it('updates camera position for associated scene info', () => {
   const scene = chartScene({
-    viewPort: {
+    viewport: {
       start: X_MIN,
       end: X_MAX,
       yMin: Y_MIN,
@@ -43,7 +43,7 @@ it('updates camera position for associated scene info', () => {
 it('updates all cameras x positions', () => {
   const chartScenes: ChartScene[] = [
     chartScene({
-      viewPort: {
+      viewport: {
         start: X_MIN,
         end: X_MAX,
         yMin: Y_MIN,
@@ -60,7 +60,7 @@ it('updates all cameras x positions', () => {
       thresholds: [],
     }),
     chartScene({
-      viewPort: {
+      viewport: {
         start: X_MIN,
         end: X_MAX,
         yMin: Y_MIN,
@@ -98,7 +98,7 @@ it('updates all cameras x positions', () => {
 it('does not update camera position when there is no associated scene info', () => {
   const scenes: ChartScene[] = [
     chartScene({
-      viewPort: {
+      viewport: {
         start: X_MIN,
         end: X_MAX,
         yMin: Y_MIN,

--- a/packages/synchro-charts/src/components/sc-webgl-context/types.ts
+++ b/packages/synchro-charts/src/components/sc-webgl-context/types.ts
@@ -18,9 +18,9 @@ export interface WriteableInstancedBufferAttribute extends InstancedBufferAttrib
 
 export interface ViewPortManager {
   id: string;
-  viewPortGroup?: string;
+  viewportGroup?: string;
   // Hook which is called with viewport is updated
-  updateViewPort: (viewPortUpdate: { start: Date; end: Date }) => void;
+  updateViewPort: (viewportUpdate: { start: Date; end: Date }) => void;
   // Disposes of all all scene, it's geometries, and any materials that are specific to the scene.
   // Dispose should be called whenever a chart scene is no longer used, otherwise the application
   // will leak memory

--- a/packages/synchro-charts/src/components/sc-webgl-context/viewPortHandler.spec.ts
+++ b/packages/synchro-charts/src/components/sc-webgl-context/viewPortHandler.spec.ts
@@ -1,22 +1,22 @@
 import uuid from 'uuid/v4';
 
-import { ViewPortHandler } from './viewPortHandler';
+import { ViewportHandler } from './viewPortHandler';
 import { ViewPortManager } from './types';
 
-const viewportManager = (viewPortGroup?: string): ViewPortManager => ({
+const viewportManager = (viewportGroup?: string): ViewPortManager => ({
   id: uuid(),
   updateViewPort: jest.fn(),
-  viewPortGroup,
+  viewportGroup,
   dispose: jest.fn(),
 });
 
 it('has no managers when initially created', () => {
-  const groups = new ViewPortHandler();
+  const groups = new ViewportHandler();
   expect(groups.managers()).toBeEmpty();
 });
 
 it('appends manager when added', () => {
-  const groups = new ViewPortHandler();
+  const groups = new ViewportHandler();
   const manager = viewportManager();
 
   groups.add(manager);
@@ -25,7 +25,7 @@ it('appends manager when added', () => {
 });
 
 it('is empty after removing all managers from the group', () => {
-  const groups = new ViewPortHandler();
+  const groups = new ViewportHandler();
   const manager = viewportManager();
 
   groups.add(manager);
@@ -35,7 +35,7 @@ it('is empty after removing all managers from the group', () => {
 });
 
 it('disposes of all managers when the group is disposed', () => {
-  const groups = new ViewPortHandler();
+  const groups = new ViewportHandler();
 
   const manager1 = viewportManager();
   const manager2 = viewportManager();
@@ -52,7 +52,7 @@ it('disposes of all managers when the group is disposed', () => {
 
 describe('syncing managers', () => {
   it('updates all managers with the same view port group', () => {
-    const groups = new ViewPortHandler();
+    const groups = new ViewportHandler();
 
     const START = new Date(2000, 0, 0);
     const END = new Date(2001, 0, 0);
@@ -77,7 +77,7 @@ describe('syncing managers', () => {
   });
 
   it('does not update any managers when propagate event is true', () => {
-    const groups = new ViewPortHandler();
+    const groups = new ViewportHandler();
 
     const START = new Date(2000, 0, 0);
     const END = new Date(2001, 0, 0);
@@ -97,7 +97,7 @@ describe('syncing managers', () => {
   });
 
   it('does not update manager not in same view port group', () => {
-    const groups = new ViewPortHandler();
+    const groups = new ViewportHandler();
 
     const START = new Date(2000, 0, 0);
     const END = new Date(2001, 0, 0);
@@ -120,7 +120,7 @@ describe('syncing managers', () => {
   });
 
   it('a manager in no view port group does not sync to any other managers', () => {
-    const groups = new ViewPortHandler();
+    const groups = new ViewportHandler();
 
     const START = new Date(2000, 0, 0);
     const END = new Date(2001, 0, 0);
@@ -140,7 +140,7 @@ describe('syncing managers', () => {
   });
 
   it('a manager added to an existing view port group that has had view ports updated, will have the managers viewport updated to match the existing managers view ports', () => {
-    const groups = new ViewPortHandler();
+    const groups = new ViewportHandler();
 
     const VIEWPORT_GROUP = 'view-port-group';
     const START = new Date(2000, 0, 0);
@@ -161,7 +161,7 @@ describe('syncing managers', () => {
   });
 
   it('will not update viewport when syncUpdate is false', () => {
-    const groups = new ViewPortHandler();
+    const groups = new ViewportHandler();
 
     const VIEWPORT_GROUP = 'view-port-group';
     const START = new Date(2000, 0, 0);
@@ -181,7 +181,7 @@ describe('syncing managers', () => {
   });
 
   it('a manager added to a non existing view port group does not have its view port updated', () => {
-    const groups = new ViewPortHandler();
+    const groups = new ViewportHandler();
 
     const VIEWPORT_GROUP_1 = 'view-port-group-1';
     const VIEWPORT_GROUP_2 = 'view-port-group-2';

--- a/packages/synchro-charts/src/components/sc-webgl-context/viewPortHandler.ts
+++ b/packages/synchro-charts/src/components/sc-webgl-context/viewPortHandler.ts
@@ -8,35 +8,35 @@ import { ViewPortManager } from './types';
  *
  * This allows us to have performant syncing of charts.
  */
-export class ViewPortHandler<T extends ViewPortManager> {
-  private viewPortManagers: T[] = [];
-  private viewPortMap: {
-    [viewPortGroup: string]: { start: Date; end: Date };
+export class ViewportHandler<T extends ViewPortManager> {
+  private viewportManagers: T[] = [];
+  private viewportMap: {
+    [viewportGroup: string]: { start: Date; end: Date };
   } = {};
 
   managers = (): T[] => {
     // NOTE: Providing new reference to a array to prevent manipulation of the internal array from the outside.
-    return [...this.viewPortManagers];
+    return [...this.viewportManagers];
   };
 
   dispose = () => {
-    this.viewPortManagers.forEach(({ id }) => this.remove(id));
+    this.viewportManagers.forEach(({ id }) => this.remove(id));
   };
 
   add = (v: T, shouldSync = true) => {
-    this.viewPortManagers = [...this.viewPortManagers, v];
+    this.viewportManagers = [...this.viewportManagers, v];
 
     /**
      * If the added chart scene is part of a view port group, sync it's viewport to
      * the current viewport groups time span.
      */
-    if (v.viewPortGroup && this.viewPortMap[v.viewPortGroup] && shouldSync) {
-      v.updateViewPort(this.viewPortMap[v.viewPortGroup]);
+    if (v.viewportGroup && this.viewportMap[v.viewportGroup] && shouldSync) {
+      v.updateViewPort(this.viewportMap[v.viewportGroup]);
     }
   };
 
   remove = (managerId: string) => {
-    const v = this.viewPortManagers.find(({ id }) => id === managerId);
+    const v = this.viewportManagers.find(({ id }) => id === managerId);
 
     // Dispose of the chart scene to ensure that the memory is released
     if (v) {
@@ -44,7 +44,7 @@ export class ViewPortHandler<T extends ViewPortManager> {
     }
 
     // Remove manager from list of registered view port managers
-    this.viewPortManagers = this.viewPortManagers.filter(({ id }) => id !== managerId);
+    this.viewportManagers = this.viewportManagers.filter(({ id }) => id !== managerId);
   };
 
   /**
@@ -65,8 +65,8 @@ export class ViewPortHandler<T extends ViewPortManager> {
     manager: T;
     preventPropagation?: boolean;
   }) => {
-    if (manager.viewPortGroup) {
-      this.viewPortMap[manager.viewPortGroup] = { start, end };
+    if (manager.viewportGroup) {
+      this.viewportMap[manager.viewportGroup] = { start, end };
     }
 
     if (!preventPropagation) {
@@ -74,9 +74,9 @@ export class ViewPortHandler<T extends ViewPortManager> {
         v.updateViewPort({ start, end });
       };
 
-      if (manager.viewPortGroup) {
+      if (manager.viewportGroup) {
         /** Get all of the groups which belong within the viewport group */
-        const managers = this.viewPortManagers.filter(({ viewPortGroup: group }) => manager.viewPortGroup === group);
+        const managers = this.viewportManagers.filter(({ viewportGroup: group }) => manager.viewportGroup === group);
 
         /**  Sync all of the chart scenes within the viewport group. */
         managers.forEach(updateViewPort);

--- a/packages/synchro-charts/src/components/sc-webgl-context/webglContext.spec.ts
+++ b/packages/synchro-charts/src/components/sc-webgl-context/webglContext.spec.ts
@@ -2,7 +2,7 @@ import 'webgl-mock-threejs';
 import { Scene } from 'three';
 import { createWebGLRenderer } from './webglContext';
 import { constructChartScene } from '../charts/sc-webgl-base-chart/utils';
-import { VIEW_PORT } from '../charts/common/testUtil';
+import { VIEWPORT } from '../charts/common/testUtil';
 import { rectScrollFixed } from '../common/webGLPositioning';
 
 const testDomRect: DOMRect = {
@@ -32,12 +32,12 @@ export const createTestWebglRenderer = (domRect: DOMRect, skipInit = false) => {
   return webGLRenderer;
 };
 
-const createTestChartScene = (viewPortGroup?: string) => {
+const createTestChartScene = (viewportGroup?: string) => {
   const container = document.createElement('div');
   const chartScene = constructChartScene({
     scene: new Scene(),
     container,
-    viewPort: { ...VIEW_PORT, group: viewPortGroup },
+    viewport: { ...VIEWPORT, group: viewportGroup },
     toClipSpace: x => x,
   });
 
@@ -47,7 +47,7 @@ const createTestChartScene = (viewPortGroup?: string) => {
   return chartScene;
 };
 
-const VIEW_PORT_GROUP = 'view-port-group';
+const VIEWPORT_GROUP = 'view-port-group';
 
 describe('sync chart scene cameras', () => {
   it('syncs a single cameras viewport', () => {
@@ -67,8 +67,8 @@ describe('sync chart scene cameras', () => {
   it('syncs multiple cameras viewport', () => {
     const webGLRenderer = createTestWebglRenderer(testDomRect);
 
-    const chartScene1 = createTestChartScene(VIEW_PORT_GROUP);
-    const chartScene2 = createTestChartScene(VIEW_PORT_GROUP);
+    const chartScene1 = createTestChartScene(VIEWPORT_GROUP);
+    const chartScene2 = createTestChartScene(VIEWPORT_GROUP);
 
     webGLRenderer.addChartScene(chartScene1);
     webGLRenderer.addChartScene(chartScene2);
@@ -85,8 +85,8 @@ describe('sync chart scene cameras', () => {
   it('does not sync camera of removed chart scene', () => {
     const webGLRenderer = createTestWebglRenderer(testDomRect);
 
-    const chartScene1 = createTestChartScene(VIEW_PORT_GROUP);
-    const chartScene2 = createTestChartScene(VIEW_PORT_GROUP);
+    const chartScene1 = createTestChartScene(VIEWPORT_GROUP);
+    const chartScene2 = createTestChartScene(VIEWPORT_GROUP);
 
     webGLRenderer.addChartScene(chartScene1);
     webGLRenderer.addChartScene(chartScene2);

--- a/packages/synchro-charts/src/components/sc-webgl-context/webglContext.ts
+++ b/packages/synchro-charts/src/components/sc-webgl-context/webglContext.ts
@@ -3,7 +3,7 @@ import { WebGLRenderer } from 'three';
 import { ChartScene, ViewPortManager } from './types';
 import { ClipSpaceRect, ClipSpaceRectMap } from '../common/webGLPositioning';
 import { RectScrollFixed } from '../../utils/types';
-import { ViewPortHandler } from './viewPortHandler';
+import { ViewportHandler } from './viewPortHandler';
 import { isValid } from '../../utils/predicates';
 
 const isChartScene = isValid((v: Partial<ChartScene>) => v.camera != null);
@@ -56,7 +56,7 @@ function resizeRendererToDisplaySize(renderer: WebGLRenderer): boolean {
  */
 export const createWebGLRenderer = () => {
   let rectMap: ClipSpaceRectMap;
-  const sceneManager: ViewPortHandler<ViewPortManager> = new ViewPortHandler();
+  const sceneManager: ViewportHandler<ViewPortManager> = new ViewportHandler();
 
   /**
    * Add Chart Scene

--- a/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.spec.ts
+++ b/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.spec.ts
@@ -22,8 +22,8 @@ const mockCurrentTime = (mockedDate: Date) => {
   Date.now = jest.spyOn(Date, 'now').mockImplementation(() => mockedDate.getTime());
 };
 
-const VIEW_PORT: MinimalViewPortConfig = {
-  ...DEFAULT_CHART_CONFIG.viewPort,
+const VIEWPORT: MinimalViewPortConfig = {
+  ...DEFAULT_CHART_CONFIG.viewport,
   duration: MINUTE_IN_MS,
 };
 
@@ -45,7 +45,7 @@ const widgetGridSpecPage = async (propOverrides: Partial<Components.ScWidgetGrid
     widgetId: 'sc-status-grid-widget-id',
     isEditing: false,
     dataStreams: DATA_STREAMS,
-    viewPort: VIEW_PORT,
+    viewport: VIEWPORT,
     renderCell,
     ...propOverrides,
   };
@@ -94,11 +94,11 @@ describe('when enabled', () => {
 
 describe('updating the viewport', () => {
   it('updates the viewport and renders a cell with the data point that was previously outside of the viewport', async () => {
-    const laterDate = new Date(VIEW_PORT.end!.getTime() + MINUTE_IN_MS);
+    const laterDate = new Date(VIEWPORT.end!.getTime() + MINUTE_IN_MS);
     const SOME_LATER_POINT: DataPoint<number> = { y: 111, x: laterDate.getTime() };
 
     const { renderCell, widgetGrid, page } = await widgetGridSpecPage({
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
       dataStreams: [
         {
           ...DATA_STREAM,
@@ -114,8 +114,8 @@ describe('updating the viewport', () => {
     );
 
     update(widgetGrid, {
-      viewPort: {
-        ...VIEW_PORT,
+      viewport: {
+        ...VIEWPORT,
         end: laterDate,
       },
     });
@@ -134,11 +134,11 @@ describe('updating the viewport', () => {
     mockCurrentTime(DATE_NOW);
 
     const { renderCell, widgetGrid, page } = await widgetGridSpecPage({
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
     });
 
     update(widgetGrid, {
-      viewPort: {
+      viewport: {
         duration: DAY_IN_MS,
       },
     });
@@ -147,7 +147,7 @@ describe('updating the viewport', () => {
 
     expect(renderCell).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        viewPort: {
+        viewport: {
           start: new Date(DATE_NOW.getTime() - DAY_IN_MS),
           end: DATE_NOW,
         },
@@ -157,13 +157,13 @@ describe('updating the viewport', () => {
 
   it('updates the viewport based on duration and a start date', async () => {
     const { renderCell, widgetGrid, page } = await widgetGridSpecPage({
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
     });
 
     const startDate = new Date(2000, 0, 0);
 
     update(widgetGrid, {
-      viewPort: {
+      viewport: {
         duration: DAY_IN_MS,
         start: startDate,
       },
@@ -173,7 +173,7 @@ describe('updating the viewport', () => {
 
     expect(renderCell).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        viewPort: {
+        viewport: {
           start: startDate,
           end: new Date(startDate.getTime() + DAY_IN_MS),
         },
@@ -183,13 +183,13 @@ describe('updating the viewport', () => {
 
   it('updates the viewport based on duration and a end date', async () => {
     const { renderCell, widgetGrid, page } = await widgetGridSpecPage({
-      viewPort: VIEW_PORT,
+      viewport: VIEWPORT,
     });
 
     const endDate = new Date(2000, 0, 0);
 
     update(widgetGrid, {
-      viewPort: {
+      viewport: {
         duration: DAY_IN_MS,
         end: endDate,
       },
@@ -199,7 +199,7 @@ describe('updating the viewport', () => {
 
     expect(renderCell).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        viewPort: {
+        viewport: {
           start: new Date(endDate.getTime() - DAY_IN_MS),
           end: endDate,
         },
@@ -209,8 +209,8 @@ describe('updating the viewport', () => {
 });
 
 describe('live time frame', () => {
-  const POINT: DataPoint<number> = { x: (VIEW_PORT.end as Date).getTime(), y: 100 };
-  const STRING_POINT: DataPoint<string> = { x: (VIEW_PORT.end as Date).getTime(), y: 'im a string!' };
+  const POINT: DataPoint<number> = { x: (VIEWPORT.end as Date).getTime(), y: 100 };
+  const STRING_POINT: DataPoint<string> = { x: (VIEWPORT.end as Date).getTime(), y: 'im a string!' };
 
   it('does render cell with string data', async () => {
     const stream = { ...STRING_STREAM_1, data: [STRING_POINT] };
@@ -251,7 +251,7 @@ describe('live time frame', () => {
     const stream = {
       ...DATA_STREAM,
       // Shift point to be one minute past the end of the viewport
-      data: [{ ...POINT, x: (VIEW_PORT.end as Date).getTime() + MINUTE_IN_MS }],
+      data: [{ ...POINT, x: (VIEWPORT.end as Date).getTime() + MINUTE_IN_MS }],
     };
 
     const { renderCell } = await widgetGridSpecPage({
@@ -376,14 +376,14 @@ describe('live time frame', () => {
 });
 
 describe('historical time frame', () => {
-  const NON_LIVE_VIEW_PORT: MinimalViewPortConfig = {
-    ...VIEW_PORT,
+  const NON_LIVE_VIEWPORT: MinimalViewPortConfig = {
+    ...VIEWPORT,
     duration: undefined,
   };
 
   it('renders cell as disabled', async () => {
     const { renderCell } = await widgetGridSpecPage({
-      viewPort: NON_LIVE_VIEW_PORT,
+      viewport: NON_LIVE_VIEWPORT,
       dataStreams: [DATA_STREAM],
     });
 
@@ -399,7 +399,7 @@ describe('historical time frame', () => {
 
   it('renders a help icon', async () => {
     const { widgetGrid } = await widgetGridSpecPage({
-      viewPort: NON_LIVE_VIEW_PORT,
+      viewport: NON_LIVE_VIEWPORT,
     });
 
     expect(widgetGrid.querySelector('sc-help-tooltip')).not.toBeNull();

--- a/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.tsx
+++ b/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.tsx
@@ -8,7 +8,7 @@ import { webGLRenderer } from '../sc-webgl-context/webglContext';
 import { breachedThreshold } from '../charts/common/annotations/breachedThreshold';
 import { streamPairs } from '../../utils/streamPairs';
 import { RenderCell } from './types';
-import { viewPortEndDate, viewPortStartDate } from '../../utils/viewPort';
+import { viewportEndDate, viewportStartDate } from '../../utils/viewPort';
 import { Annotations, ChartConfig, Threshold, WidgetConfigurationUpdate } from '../charts/common/types';
 import { LabelsConfig } from '../common/types';
 import { DATA_ALIGNMENT } from '../charts/common/constants';
@@ -43,7 +43,7 @@ export class ScWidgetGrid implements ChartConfig {
 
   /** Chart API */
   @Prop() labelsConfig?: LabelsConfig;
-  @Prop() viewPort: MinimalViewPortConfig;
+  @Prop() viewport: MinimalViewPortConfig;
   @Prop() widgetId!: string;
   @Prop() dataStreams!: DataStream[];
   @Prop() annotations: Annotations;
@@ -56,9 +56,9 @@ export class ScWidgetGrid implements ChartConfig {
   @State() names: NameValue[] = [];
 
   /** Active Viewport */
-  @State() start: Date = viewPortStartDate(this.viewPort);
-  @State() end: Date = viewPortEndDate(this.viewPort);
-  @State() duration?: number = this.viewPort.duration;
+  @State() start: Date = viewportStartDate(this.viewport);
+  @State() end: Date = viewportEndDate(this.viewport);
+  @State() duration?: number = this.viewport.duration;
 
   @Event()
   widgetUpdated: EventEmitter<WidgetConfigurationUpdate>;
@@ -66,18 +66,18 @@ export class ScWidgetGrid implements ChartConfig {
   componentDidLoad() {
     webGLRenderer.addChartScene({
       id: this.widgetId,
-      viewPortGroup: this.viewPort.group,
+      viewportGroup: this.viewport.group,
       dispose: () => {},
       updateViewPort: this.onUpdate,
     });
   }
 
-  @Watch('viewPort')
+  @Watch('viewport')
   onViewPortChange(newViewPort: MinimalViewPortConfig) {
     this.onUpdate({
       ...newViewPort,
-      start: viewPortStartDate(this.viewPort),
-      end: viewPortEndDate(this.viewPort),
+      start: viewportStartDate(this.viewport),
+      end: viewportEndDate(this.viewport),
     });
   }
 
@@ -123,7 +123,7 @@ export class ScWidgetGrid implements ChartConfig {
 
   getPoints = (): ActivePoint<Primitive>[] =>
     activePoints({
-      viewPort: {
+      viewport: {
         start: this.start,
         end: this.end,
       },
@@ -136,7 +136,7 @@ export class ScWidgetGrid implements ChartConfig {
   getBreachedThreshold = (point: DataPoint | undefined, dataStream: DataStream): Threshold | undefined =>
     breachedThreshold({
       value: point && point.y,
-      date: this.viewPort.end || new Date(),
+      date: this.viewport.end || new Date(),
       dataStreams: this.dataStreams,
       dataStream,
       thresholds: getThresholds(this.annotations),
@@ -199,7 +199,7 @@ export class ScWidgetGrid implements ChartConfig {
                   alarmPoint,
                   breachedThreshold: threshold,
                   isEditing: this.isEditing,
-                  viewPort: { start: this.start, end: this.end },
+                  viewport: { start: this.start, end: this.end },
                   miniVersion: isMiniVersion,
                   onChangeLabel: this.onChangeLabel,
                   messageOverrides: this.messageOverrides,

--- a/packages/synchro-charts/src/components/sc-widget-grid/types.ts
+++ b/packages/synchro-charts/src/components/sc-widget-grid/types.ts
@@ -22,7 +22,7 @@ export type CellOptions = {
   propertyStream?: DataStream;
   trendStream: DataStream | undefined;
   valueColor?: string;
-  viewPort: MinimalViewPortConfig;
+  viewport: MinimalViewPortConfig;
 };
 
 export type RenderCell = (cellOptions: CellOptions) => void;

--- a/packages/synchro-charts/src/testing/__mocks__/mockWidgetProperties.ts
+++ b/packages/synchro-charts/src/testing/__mocks__/mockWidgetProperties.ts
@@ -1,6 +1,6 @@
 import { DataStream, DataStreamInfo } from '../../utils/dataTypes';
 import { Threshold } from '../../components/charts/common/types';
-import { VIEW_PORT } from '../../components/charts/common/testUtil';
+import { VIEWPORT } from '../../components/charts/common/testUtil';
 import { DAY_IN_MS } from '../../utils/time';
 import { DataType, StreamType } from '../../utils/dataConstants';
 import { COMPARISON_OPERATOR, StatusIcon } from '../../components/charts/common/constants';
@@ -215,7 +215,7 @@ export const DATA_WITH_ALARM_INFO: DataStreamInfo = {
 };
 
 export const WITHIN_VIEWPORT_DATE = new Date(2000, 0, 1);
-export const BEFORE_VIEWPORT_DATE = new Date(VIEW_PORT.start.getTime() - DAY_IN_MS);
+export const BEFORE_VIEWPORT_DATE = new Date(VIEWPORT.start.getTime() - DAY_IN_MS);
 
 export const ALARM_STREAM: DataStream<string> = {
   id: 'alarm-stream',

--- a/packages/synchro-charts/src/testing/chartDescriptions/describeLegend.tsx
+++ b/packages/synchro-charts/src/testing/chartDescriptions/describeLegend.tsx
@@ -2,7 +2,7 @@ import { ChartSpecPage } from './newChartSpecPage';
 import { Threshold } from '../../components/charts/common/types';
 import { COMPARISON_OPERATOR, LEGEND_POSITION } from '../../components/charts/common/constants';
 
-const VIEW_PORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
+const VIEWPORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
 
 export const describeLegend = (newChartSpecPage: ChartSpecPage) => {
   describe('legend', () => {
@@ -37,12 +37,12 @@ export const describeLegend = (newChartSpecPage: ChartSpecPage) => {
           position: LEGEND_POSITION.BOTTOM,
           width: 200,
         },
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
       });
 
       const legend = chart.querySelector('sc-legend') as HTMLScLegendElement;
 
-      expect(legend.viewPort).toMatchObject({ start: VIEW_PORT.start, end: VIEW_PORT.end });
+      expect(legend.viewport).toMatchObject({ start: VIEWPORT.start, end: VIEWPORT.end });
     });
 
     /**

--- a/packages/synchro-charts/src/testing/chartDescriptions/describeLoadingStatus.ts
+++ b/packages/synchro-charts/src/testing/chartDescriptions/describeLoadingStatus.ts
@@ -3,7 +3,7 @@ import { DataStream } from '../../utils/dataTypes';
 import { LOADING_SPINNER_SELECTOR } from '../selectors';
 import { DataType } from '../../utils/dataConstants';
 
-const VIEW_PORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
+const VIEWPORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
 
 const DATA_STREAM: DataStream<number> = {
   id: 'stream-id',
@@ -13,7 +13,7 @@ const DATA_STREAM: DataStream<number> = {
   resolution: 0,
   data: [
     {
-      x: VIEW_PORT.end.getTime(),
+      x: VIEWPORT.end.getTime(),
       y: 50,
     },
   ],

--- a/packages/synchro-charts/src/testing/chartDescriptions/describePassedInProps.tsx
+++ b/packages/synchro-charts/src/testing/chartDescriptions/describePassedInProps.tsx
@@ -55,20 +55,20 @@ export const describePassedInProps = (newChartSpecPage: ChartSpecPage, disableLi
     if (!disableList.viewport) {
       describe('View Port', () => {
         it('sets the provided viewport, and has a y range set when viewport has none provided', async () => {
-          const VIEW_PORT = {
+          const VIEWPORT = {
             start: new Date(2000, 0, 0),
             end: new Date(2001, 0, 0),
           };
 
-          const { chart } = await newChartSpecPage({ viewPort: VIEW_PORT });
+          const { chart } = await newChartSpecPage({ viewport: VIEWPORT });
           const baseChart = chart.querySelector('sc-webgl-base-chart') as HTMLScWebglBaseChartElement;
 
           /** Start and end date is equal to what was provided */
-          expect(baseChart.viewPort).toEqual(expect.objectContaining(VIEW_PORT));
+          expect(baseChart.viewport).toEqual(expect.objectContaining(VIEWPORT));
 
           /** Y Range set since viewport had none provided */
-          expect(baseChart.viewPort.yMin).not.toBeDefined();
-          expect(baseChart.viewPort.yMax).not.toBeDefined();
+          expect(baseChart.viewport.yMin).not.toBeDefined();
+          expect(baseChart.viewport.yMax).not.toBeDefined();
         });
       });
     }

--- a/packages/synchro-charts/src/testing/chartDescriptions/describeTrendLines.ts
+++ b/packages/synchro-charts/src/testing/chartDescriptions/describeTrendLines.ts
@@ -2,7 +2,7 @@ import { ChartSpecPage } from './newChartSpecPage';
 import { DataStream } from '../../utils/dataTypes';
 import { DataType, TREND_TYPE } from '../../utils/dataConstants';
 
-const VIEW_PORT = {
+const VIEWPORT = {
   start: new Date(2019, 0, 0),
   end: new Date(2020, 0, 0),
   yMin: -50,
@@ -49,7 +49,7 @@ export const describeTrendLines = (newChartSpecPage: ChartSpecPage) => {
   describe('regression', () => {
     it('chart renders regression with the correct properties', async () => {
       const { chart } = await newChartSpecPage({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         dataStreams: DATA_STREAMS,
         trends: [
           {

--- a/packages/synchro-charts/src/testing/chartDescriptions/describeYRange.ts
+++ b/packages/synchro-charts/src/testing/chartDescriptions/describeYRange.ts
@@ -1,16 +1,16 @@
 import { ChartSpecPage } from './newChartSpecPage';
 
-const VIEW_PORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
+const VIEWPORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
 
 export const describeYRange = (newChartSpecPage: ChartSpecPage) => {
-  describe('viewPort', () => {
+  describe('viewport', () => {
     it('sets the provided viewport', async () => {
-      const { chart } = await newChartSpecPage({ viewPort: VIEW_PORT });
+      const { chart } = await newChartSpecPage({ viewport: VIEWPORT });
 
       const baseChart = chart.querySelector('sc-webgl-base-chart') as HTMLScWebglBaseChartElement;
 
-      expect(baseChart.viewPort.yMin).toBe(VIEW_PORT.yMin);
-      expect(baseChart.viewPort.yMax).toBe(VIEW_PORT.yMax);
+      expect(baseChart.viewport.yMin).toBe(VIEWPORT.yMin);
+      expect(baseChart.viewport.yMax).toBe(VIEWPORT.yMax);
     });
 
     it.skip('ensures chart displays all y annotations when no y range provided in viewport', async () => {
@@ -18,8 +18,8 @@ export const describeYRange = (newChartSpecPage: ChartSpecPage) => {
       const SMALL_Y = -9999;
 
       const { chart } = await newChartSpecPage({
-        viewPort: {
-          ...VIEW_PORT,
+        viewport: {
+          ...VIEWPORT,
           yMin: undefined,
           yMax: undefined,
         },
@@ -33,8 +33,8 @@ export const describeYRange = (newChartSpecPage: ChartSpecPage) => {
 
       const baseChart = chart.querySelector('sc-webgl-base-chart') as HTMLScWebglBaseChartElement;
 
-      expect(baseChart.viewPort.yMin).toBeLessThanOrEqual(SMALL_Y);
-      expect(baseChart.viewPort.yMax).toBeGreaterThanOrEqual(LARGE_Y);
+      expect(baseChart.viewport.yMin).toBeLessThanOrEqual(SMALL_Y);
+      expect(baseChart.viewport.yMax).toBeGreaterThanOrEqual(LARGE_Y);
     });
 
     it('ignores annotations when viewport y range provided', async () => {
@@ -42,7 +42,7 @@ export const describeYRange = (newChartSpecPage: ChartSpecPage) => {
       const SMALL_Y = -9999;
 
       const { chart } = await newChartSpecPage({
-        viewPort: VIEW_PORT,
+        viewport: VIEWPORT,
         annotations: {
           y: [
             { value: LARGE_Y, color: 'red' },
@@ -53,8 +53,8 @@ export const describeYRange = (newChartSpecPage: ChartSpecPage) => {
 
       const baseChart = chart.querySelector('sc-webgl-base-chart') as HTMLScWebglBaseChartElement;
 
-      expect(baseChart.viewPort.yMin).toBe(VIEW_PORT.yMin);
-      expect(baseChart.viewPort.yMax).toBe(VIEW_PORT.yMax);
+      expect(baseChart.viewport.yMin).toBe(VIEWPORT.yMin);
+      expect(baseChart.viewport.yMax).toBe(VIEWPORT.yMax);
     });
   });
 };

--- a/packages/synchro-charts/src/testing/chartDescriptions/newChartSpecPage.ts
+++ b/packages/synchro-charts/src/testing/chartDescriptions/newChartSpecPage.ts
@@ -19,7 +19,7 @@ import { ScStatusTimelineOverlayRow } from '../../components/charts/sc-status-ti
 import { ScStatusTimelineOverlay } from '../../components/charts/sc-status-timeline/sc-status-timeline-overlay/sc-status-timeline-overlay';
 import { ScChartIcon } from '../../components/charts/chart-icon/sc-chart-icon';
 
-const VIEW_PORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
+const VIEWPORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
 
 export type ChartProps = Components.ScLineChart;
 
@@ -57,7 +57,7 @@ export const newChartSpecPage = (tagName: string): ChartSpecPage => async props 
   const defaultProps: ChartProps = {
     widgetId: 'default-id',
     gestures: true,
-    viewPort: VIEW_PORT,
+    viewport: VIEWPORT,
     legend: {
       position: LEGEND_POSITION.BOTTOM,
       width: 300,

--- a/packages/synchro-charts/src/testing/dynamicWidgetUtils/constants.ts
+++ b/packages/synchro-charts/src/testing/dynamicWidgetUtils/constants.ts
@@ -160,7 +160,7 @@ const oilAlarmStream: DataStream<string> = {
 
 export const DATA = [mphStream, speedingAlarmStream, oilAlarmStream];
 
-export const VIEW_PORT = {
+export const VIEWPORT = {
   start: X_MIN,
   end: X_MAX,
 };

--- a/packages/synchro-charts/src/testing/dynamicWidgetUtils/testCaseParameters.ts
+++ b/packages/synchro-charts/src/testing/dynamicWidgetUtils/testCaseParameters.ts
@@ -11,8 +11,8 @@ export type SearchQueryParams = {
   height?: number | string;
   duration?: number;
   errMsg: string;
-  viewPortStart: Date;
-  viewPortEnd: Date;
+  viewportStart: Date;
+  viewportEnd: Date;
   componentTag: string;
   legend: LegendConfig;
   isEditing: boolean;
@@ -59,8 +59,8 @@ export const SCREEN_SIZE = {
 };
 
 export const constructSearchQuery = ({
-  viewPortStart,
-  viewPortEnd,
+  viewportStart,
+  viewportEnd,
   dataStreams,
   asyncDataStreams,
   alarms,
@@ -83,8 +83,8 @@ export const constructSearchQuery = ({
     dataStreams: dataStreams && JSON.stringify(dataStreams),
     asyncDataStreams: asyncDataStreams && JSON.stringify(asyncDataStreams),
     alarms: alarms && JSON.stringify(alarms),
-    viewPortStart: viewPortStart && viewPortStart.toISOString(),
-    viewPortEnd: viewPortEnd && viewPortEnd.toISOString(),
+    viewportStart: viewportStart && viewportStart.toISOString(),
+    viewportEnd: viewportEnd && viewportEnd.toISOString(),
     tableColumns: tableColumns && JSON.stringify(tableColumns),
     messageOverrides: messageOverrides && JSON.stringify(messageOverrides),
     axis: axis && JSON.stringify(axis),
@@ -127,7 +127,7 @@ export const testCaseParameters = (): SearchQueryParams => {
     dataStreams: query.dataStreams != null ? JSON.parse(query.dataStreams).map(deserializeDataStream) : [],
     asyncDataStreams:
       query.asyncDataStreams != null ? JSON.parse(query.asyncDataStreams).map(deserializeDataStream) : [],
-    viewPortStart: query.viewPortStart != null ? new Date(query.viewPortStart) : new Date(2000, 0, 0),
-    viewPortEnd: query.viewPortEnd != null ? new Date(query.viewPortEnd) : new Date(2000, 0, 1),
+    viewportStart: query.viewportStart != null ? new Date(query.viewportStart) : new Date(2000, 0, 0),
+    viewportEnd: query.viewportEnd != null ? new Date(query.viewportEnd) : new Date(2000, 0, 1),
   };
 };

--- a/packages/synchro-charts/src/testing/test-routes/charts/line-chart-viewport-change.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/line-chart-viewport-change.tsx
@@ -1,40 +1,40 @@
 import { Component, h, State } from '@stencil/core';
 import { MinimalViewPortConfig } from '../../../utils/dataTypes';
 
-const VIEW_PORT_GROUP = 'some-group';
+const VIEWPORT_GROUP = 'some-group';
 
 const NARROW_VIEWPORT: MinimalViewPortConfig = {
   start: new Date(2000, 0, 0),
   end: new Date(2000, 0, 1),
-  group: VIEW_PORT_GROUP,
+  group: VIEWPORT_GROUP,
 };
 
 const WIDE_VIEWPORT: MinimalViewPortConfig = {
   start: new Date(2000, 0, 0),
   end: new Date(2001, 0, 0),
-  group: VIEW_PORT_GROUP,
+  group: VIEWPORT_GROUP,
 };
 
 @Component({
   tag: 'line-chart-viewport-change',
 })
 export class LineChartViewportChange {
-  @State() viewPort: MinimalViewPortConfig = NARROW_VIEWPORT;
+  @State() viewport: MinimalViewPortConfig = NARROW_VIEWPORT;
 
   toggleViewPort = () => {
-    this.viewPort = this.viewPort !== NARROW_VIEWPORT ? NARROW_VIEWPORT : WIDE_VIEWPORT;
+    this.viewport = this.viewport !== NARROW_VIEWPORT ? NARROW_VIEWPORT : WIDE_VIEWPORT;
   };
 
   render() {
     return (
       <div>
         <button id="toggle-view-port" onClick={this.toggleViewPort}>
-          use {this.viewPort === NARROW_VIEWPORT ? 'wide' : 'narrow'} viewport
+          use {this.viewport === NARROW_VIEWPORT ? 'wide' : 'narrow'} viewport
         </button>
         <br />
         <br />
         <div id="chart-container" style={{ marginTop: '20px', width: '500px', height: '500px' }}>
-          <sc-line-chart widgetId="widget-id" dataStreams={[]} viewPort={this.viewPort} />
+          <sc-line-chart widgetId="widget-id" dataStreams={[]} viewport={this.viewport} />
         </div>
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/performance/sc-line-chart-stream-data.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/performance/sc-line-chart-stream-data.tsx
@@ -18,7 +18,7 @@ const TEST_DATA_POINT: DataPoint<number> = {
 const urlParams = new URLSearchParams(window.location.search);
 const dataPerRoundParam = urlParams.get('dataPerRound');
 const roundFrequencyParam = urlParams.get('roundFrequency');
-const viewportSpeedParam = urlParams.get('viewPortSpeed');
+const viewportSpeedParam = urlParams.get('viewportSpeed');
 
 const DATA_SIZE_BATCH = dataPerRoundParam ? Number.parseInt(dataPerRoundParam, 10) : 1;
 const DATA_FREQUENCY_MS = roundFrequencyParam ? Number.parseInt(roundFrequencyParam, 10) : SECOND_IN_MS;
@@ -35,23 +35,23 @@ const createData = (point: DataPoint<number>): DataPoint<number>[] =>
 })
 export class ScLineChartStreamData {
   @State() dataPoints: DataPoint<number>[] = [TEST_DATA_POINT];
-  @State() viewPort: ViewPort = { start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX };
+  @State() viewport: ViewPort = { start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX };
   private dataLoop: number;
-  private viewPortShifter: number | undefined;
+  private viewportShifter: number | undefined;
 
-  viewPortLoop = () =>
+  viewportLoop = () =>
     window.requestAnimationFrame(() => {
-      this.viewPort = {
-        ...this.viewPort,
-        start: new Date(this.viewPort.start.getTime() + VIEWPORT_SPEED),
-        end: new Date(this.viewPort.end.getTime() + VIEWPORT_SPEED),
+      this.viewport = {
+        ...this.viewport,
+        start: new Date(this.viewport.start.getTime() + VIEWPORT_SPEED),
+        end: new Date(this.viewport.end.getTime() + VIEWPORT_SPEED),
       };
-      this.viewPortShifter = this.viewPortLoop();
+      this.viewportShifter = this.viewportLoop();
     });
 
   componentWillLoad() {
     if (VIEWPORT_SPEED > 0) {
-      this.viewPortShifter = this.viewPortLoop();
+      this.viewportShifter = this.viewportLoop();
     }
 
     this.dataLoop = window.setInterval(() => {
@@ -67,8 +67,8 @@ export class ScLineChartStreamData {
 
   disconnectedCallback() {
     clearInterval(this.dataLoop);
-    if (this.viewPortShifter != null) {
-      window.cancelAnimationFrame(this.viewPortShifter);
+    if (this.viewportShifter != null) {
+      window.cancelAnimationFrame(this.viewportShifter);
     }
   }
 
@@ -91,7 +91,7 @@ export class ScLineChartStreamData {
             height: 500,
             width: 500,
           }}
-          viewPort={this.viewPort}
+          viewport={this.viewport}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-chart-y-range.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-chart-y-range.tsx
@@ -66,7 +66,7 @@ export class ScChartYRange {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-bar-margin.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-bar-margin.tsx
@@ -59,7 +59,7 @@ export class ScWebglBarChartDynamicBuffer {
         <sc-bar-chart
           widgetId="widget-id"
           dataStreams={[DATA_STREAM_1, DATA_STREAM_2]}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
           bufferFactor={1}
           minBufferSize={1}
         />

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-dynamic-buffer.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-dynamic-buffer.tsx
@@ -54,7 +54,7 @@ export class ScWebglBarChartDynamicBuffer {
                 dataType: DataType.NUMBER,
               },
             ]}
-            viewPort={{
+            viewport={{
               yMin: Y_MIN,
               yMax: Y_MAX,
               start: X_MIN,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-dynamic-data-streams.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-dynamic-data-streams.tsx
@@ -93,7 +93,7 @@ export class ScWebglBarChartDynamicDataStreams {
               height: 500,
             }}
             widgetId="widget-id"
-            viewPort={{
+            viewport={{
               yMin: Y_MIN,
               yMax: Y_MAX,
               start: X_MIN,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-dynamic-data.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-dynamic-data.tsx
@@ -70,7 +70,7 @@ export class ScWebglBarChartDynamicData {
               height: 500,
             }}
             widgetId="widget-id"
-            viewPort={{
+            viewport={{
               yMin: Y_MIN,
               yMax: Y_MAX,
               start: X_MIN,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-fast-viewport.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-fast-viewport.tsx
@@ -75,7 +75,7 @@ export class ScWebglBarChartFastViewport {
               height: 500,
               width: 500,
             }}
-            viewPort={{
+            viewport={{
               yMin: Y_MIN,
               yMax: Y_MAX,
               start: this.start,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-negative.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-negative.tsx
@@ -48,7 +48,7 @@ export class ScWebglBarChartNegative {
             width: 500,
             height: 500,
           }}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-positive-negative.component.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-positive-negative.component.tsx
@@ -51,7 +51,7 @@ export class ScWebglBarChartPositiveNegative {
             width: 500,
             height: 500,
           }}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-standard.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-standard.tsx
@@ -36,7 +36,7 @@ export class ScWebglBarChartStandard {
             width: 500,
             height: 500,
           }}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-start-from-zero.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-start-from-zero.tsx
@@ -61,7 +61,7 @@ export class ScWebglBarChartStartFromZero {
               width: 500,
               height: 500,
             }}
-            viewPort={{ start: X_MIN, end: X_MAX }}
+            viewport={{ start: X_MIN, end: X_MAX }}
           />
           <sc-webgl-context />
         </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-band.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-band.tsx
@@ -62,7 +62,7 @@ export class ScWebglBarChartThresholdBand {
             width: 500,
             height: 500,
           }}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-coloration.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-coloration.tsx
@@ -51,7 +51,7 @@ export class ScWebglBarChartThresholdColoration {
             width: 500,
             height: 500,
           }}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-exact-point.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-exact-point.tsx
@@ -49,7 +49,7 @@ export class ScWebglBarChartThresholdExactPoint {
             width: 500,
             height: 500,
           }}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-multiple-data-stream.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-multiple-data-stream.tsx
@@ -87,7 +87,7 @@ export class ScWebglBarChartThresholdMultipleDataStream {
             width: 500,
             height: 500,
           }}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-multiple-thresholds.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-multiple-thresholds.tsx
@@ -60,7 +60,7 @@ export class ScWebglBarChartThresholdMultipleThresholds {
             width: 500,
             height: 500,
           }}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-no-coloration.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-no-coloration.tsx
@@ -53,7 +53,7 @@ export class ScWebglBarChartThresholdNoColoration {
             width: 500,
             height: 500,
           }}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-annotations-always-in-viewport.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-annotations-always-in-viewport.tsx
@@ -63,7 +63,7 @@ export class ScWebglChartAnnotationsAlwaysInViewport {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX }}
           widgetId="widget-id"
         />
         <sc-webgl-context />

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-annotations.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-annotations.tsx
@@ -62,7 +62,7 @@ export class ScWebglChartAnnotations {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-axis.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-axis.tsx
@@ -19,7 +19,7 @@ export class ScWebglChartAnnotations {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-dynamic-charts.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-dynamic-charts.tsx
@@ -142,7 +142,7 @@ export class ScWebglChartStandard {
             <sc-line-chart
               dataStreams={data}
               widgetId={key}
-              viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+              viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
             />
           </div>
         ))}

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-large-viewport.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-large-viewport.tsx
@@ -43,7 +43,7 @@ export class ScWebglChartLargeViewport {
             height: 500,
             width: 500,
           }}
-          viewPort={VIEWPORT}
+          viewport={VIEWPORT}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-multi.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-multi.tsx
@@ -2,7 +2,7 @@ import { Component, h } from '@stencil/core';
 import { DataPoint } from '../../../utils/dataTypes';
 import { DataType } from '../../../utils/dataConstants';
 
-const VIEW_PORT_GROUP = 'group';
+const VIEWPORT_GROUP = 'group';
 
 // viewport boundaries
 const Y_MIN = 0;
@@ -41,7 +41,7 @@ export class ScWebglChartMulti {
               dataType: DataType.NUMBER,
             },
           ]}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX, group: VIEW_PORT_GROUP }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX, group: VIEWPORT_GROUP }}
         />
 
         <sc-line-chart
@@ -61,7 +61,7 @@ export class ScWebglChartMulti {
             height: 150,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX, group: VIEW_PORT_GROUP }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX, group: VIEWPORT_GROUP }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-no-annotations.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-no-annotations.tsx
@@ -40,7 +40,7 @@ export class ScWebglChartNoAnnotations {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-standard-with-legend-on-right.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-standard-with-legend-on-right.tsx
@@ -42,7 +42,7 @@ export class ScWebglChartStandardWithLegendOnRight {
             width: 100,
             position: LEGEND_POSITION.RIGHT,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-standard-with-legend.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-standard-with-legend.tsx
@@ -38,7 +38,7 @@ export class ScWebglChartStandardWithLegend {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
           legend={{
             position: LEGEND_POSITION.BOTTOM,
             width: 300,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-standard.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-standard.tsx
@@ -43,7 +43,7 @@ export class ScWebglChartStandard {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration-band.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration-band.tsx
@@ -89,7 +89,7 @@ export class ScWebglThresholdColorationBand {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration-exact-point.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration-exact-point.tsx
@@ -61,7 +61,7 @@ export class ScWebglChartThresholdColorationExactPoint {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration-multiple-data-stream.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration-multiple-data-stream.tsx
@@ -75,7 +75,7 @@ export class ScWebglChartThresholdColorationMultipleDataStream {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration-multiple-thresholds.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration-multiple-thresholds.tsx
@@ -85,7 +85,7 @@ export class ScWebglChartThresholdColorationMultipleThresholds {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration.tsx
@@ -57,7 +57,7 @@ export class ScWebglChartThresholdColoration {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-tooltip-with-multiple-data-streams.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-tooltip-with-multiple-data-streams.tsx
@@ -55,7 +55,7 @@ export class ScWebglChartTooltipWithMultipleDataStreams {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-line-chart-dynamic-buffer.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-line-chart-dynamic-buffer.tsx
@@ -52,7 +52,7 @@ export class ScWebglLineChartDynamicBuffer {
               height: 500,
               width: 500,
             }}
-            viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+            viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
             bufferFactor={1}
             minBufferSize={1}
           />

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-line-chart-dynamic-data-streams.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-line-chart-dynamic-data-streams.tsx
@@ -80,7 +80,7 @@ export class ScWebglLineChartDynamicDataStreams {
               height: 500,
               width: 500,
             }}
-            viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+            viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
           />
         </div>
         <sc-webgl-context />

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-line-chart-dynamic-data.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-line-chart-dynamic-data.tsx
@@ -64,7 +64,7 @@ export class ScWebglLineChartDynamicData {
               height: 500,
               width: 500,
             }}
-            viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+            viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
           />
 
           <sc-webgl-context />

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-dynamic-data.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-dynamic-data.tsx
@@ -67,7 +67,7 @@ export class ScScatterChartDynamicData {
               height: 500,
               width: 500,
             }}
-            viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+            viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
           />
 
           <sc-webgl-context />

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-band.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-band.tsx
@@ -99,7 +99,7 @@ export class ScScatterChartThresholdColorationBand {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-exact-point.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-exact-point.tsx
@@ -61,7 +61,7 @@ export class ScScatterChartThresholdColorationExactPoint {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-multiple-data-stream.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-multiple-data-stream.tsx
@@ -79,7 +79,7 @@ export class ScScatterChartThresholdColorationMultipleDataStream {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-multiple-thresholds.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-multiple-thresholds.tsx
@@ -94,7 +94,7 @@ export class ScWebglChartThresholdColorationMultipleThresholds {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration.tsx
@@ -58,7 +58,7 @@ export class ScScatterChartThresholdColoration {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-no-coloration.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-no-coloration.tsx
@@ -61,7 +61,7 @@ export class ScScatterChartThresholdNoColoration {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-tooltip-with-multiple-data-streams-and-trends.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-tooltip-with-multiple-data-streams-and-trends.tsx
@@ -74,7 +74,7 @@ export class ScScatterChartTooltipWithMultipleDataStreamsAndTrends {
             height: 500,
             width: 500,
           }}
-          viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
           trends={[
             {
               type: TREND_TYPE.LINEAR,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-trend-line-color-configuration.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-trend-line-color-configuration.tsx
@@ -50,7 +50,7 @@ export class ScScatterChartTrendLineColorConfiguration {
             height: 500,
             width: 500,
           }}
-          viewPort={{
+          viewport={{
             start: X_MIN,
             end: X_MAX,
             yMin: Y_MIN,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-trend-line-with-legend.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-trend-line-with-legend.tsx
@@ -50,7 +50,7 @@ export class ScScatterChartTrendLineWithLegend {
             height: 500,
             width: 500,
           }}
-          viewPort={{
+          viewport={{
             start: X_MIN,
             end: X_MAX,
             yMin: Y_MIN,

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-angled-line-segment.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-angled-line-segment.tsx
@@ -34,7 +34,7 @@ export class ScAngledLineSegment {
     const container = this.el.querySelector('#test-container') as HTMLDivElement;
 
     const scene = chartScene({
-      viewPort: {
+      viewport: {
         start: X_MIN,
         end: X_MAX,
         yMin: Y_MIN,

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-bar-chart/sc-multiple-bars.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-bar-chart/sc-multiple-bars.tsx
@@ -39,7 +39,7 @@ export class ScMultipleBars {
   componentDidLoad() {
     const container = this.el.querySelector('#test-container') as HTMLDivElement;
     const scene = chartScene({
-      viewPort: {
+      viewport: {
         start: X_MIN,
         end: X_MAX,
         yMin: Y_MIN,

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-bar-chart/sc-single-bar.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-bar-chart/sc-single-bar.tsx
@@ -35,7 +35,7 @@ export class ScSingleBar {
   componentDidLoad() {
     const container = this.el.querySelector('#test-container') as HTMLDivElement;
     const scene = chartScene({
-      viewPort: {
+      viewport: {
         start: X_MIN,
         end: X_MAX,
         yMin: Y_MIN,

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-bar-chart/sc-single-colored-bar.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-bar-chart/sc-single-colored-bar.tsx
@@ -35,7 +35,7 @@ export class ScSingleColoredBar {
   componentDidLoad() {
     const container = this.el.querySelector('#test-container') as HTMLDivElement;
     const scene = chartScene({
-      viewPort: {
+      viewport: {
         start: X_MIN,
         end: X_MAX,
         yMin: Y_MIN,

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-circle-point-shaders.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-circle-point-shaders.tsx
@@ -30,7 +30,7 @@ export class ScCirclePointShaders {
   componentDidLoad() {
     const container = this.el.querySelector('#test-container') as HTMLDivElement;
     const scene = chartScene({
-      viewPort: {
+      viewport: {
         start: X_MIN,
         end: X_MAX,
         yMin: Y_MIN,

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-line-chart-colored-point.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-line-chart-colored-point.tsx
@@ -26,7 +26,7 @@ export class ScLineChartColoredPoint {
   componentDidLoad() {
     const container = this.el.querySelector('#test-container') as HTMLDivElement;
     const scene = chartScene({
-      viewPort: {
+      viewport: {
         start: X_MIN,
         end: X_MAX,
         yMin: Y_MIN,

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-multiple-lines-overlapping.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-multiple-lines-overlapping.tsx
@@ -42,7 +42,7 @@ export class ScMultipleLinesOverlapping {
   componentDidLoad() {
     const container = this.el.querySelector('#test-container') as HTMLDivElement;
     const scene = chartScene({
-      viewPort: {
+      viewport: {
         start: X_MIN,
         end: X_MAX,
         yMin: Y_MIN,

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-multiple-lines.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-multiple-lines.tsx
@@ -42,7 +42,7 @@ export class ScMultipleLines {
   componentDidLoad() {
     const container = this.el.querySelector('#test-container') as HTMLDivElement;
     const scene = chartScene({
-      viewPort: {
+      viewport: {
         start: X_MIN,
         end: X_MAX,
         yMin: Y_MIN,

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-straight-line-segment-colored.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-straight-line-segment-colored.tsx
@@ -37,7 +37,7 @@ export class ScStraightLineSegment {
     const container = this.el.querySelector('#test-container') as HTMLDivElement;
 
     const scene = chartScene({
-      viewPort: {
+      viewport: {
         start: X_MIN,
         end: X_MAX,
         yMin: Y_MIN,

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-straight-line-segment.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-straight-line-segment.tsx
@@ -32,7 +32,7 @@ export class ScStraightLineSegment {
   componentDidLoad() {
     const container = this.el.querySelector('#test-container') as HTMLDivElement;
     const scene = chartScene({
-      viewPort: {
+      viewport: {
         start: X_MIN,
         end: X_MAX,
         yMin: Y_MIN,

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/status-timeline/multiple-statuses.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/status-timeline/multiple-statuses.tsx
@@ -33,7 +33,7 @@ export class MultipleStatuses {
     const container = this.el.querySelector('#test-container') as HTMLDivElement;
     const scene = chartScene({
       alarms: { expires: HOUR_IN_MS * 5 },
-      viewPort: {
+      viewport: {
         start: X_MIN,
         end: X_MAX,
         yMin: 0,

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/status-timeline/single-colored-status.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/status-timeline/single-colored-status.tsx
@@ -28,7 +28,7 @@ export class SingleColoredStatus {
     const container = this.el.querySelector('#test-container') as HTMLDivElement;
     const scene = chartScene({
       alarms: { expires: DAY_IN_MS },
-      viewPort: {
+      viewport: {
         start: X_MIN,
         end: X_MAX,
         yMin: 0,

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/status-timeline/single-status.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/status-timeline/single-status.tsx
@@ -28,7 +28,7 @@ export class ScSingleStatus {
     const container = this.el.querySelector('#test-container') as HTMLDivElement;
     const scene = chartScene({
       alarms: { expires: DAY_IN_MS },
-      viewPort: {
+      viewport: {
         start: X_MIN,
         end: X_MAX,
         yMin: 0,

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-dynamic-buffer.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-dynamic-buffer.tsx
@@ -47,7 +47,7 @@ export class StatusTimelineDynamicBuffer {
                 dataType: DataType.NUMBER,
               },
             ]}
-            viewPort={{
+            viewport={{
               yMin: Y_MIN,
               yMax: Y_MAX,
               start: X_MIN,

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-dynamic-data-streams.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-dynamic-data-streams.tsx
@@ -89,7 +89,7 @@ export class StatusTimelineDynamicDataStreams {
               height: 500,
             }}
             widgetId="widget-id"
-            viewPort={{
+            viewport={{
               yMin: Y_MIN,
               yMax: Y_MAX,
               start: X_MIN,

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-dynamic-data.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-dynamic-data.tsx
@@ -63,7 +63,7 @@ export class StatusTimelineDynamicData {
               height: 500,
             }}
             widgetId="widget-id"
-            viewPort={{
+            viewport={{
               yMin: Y_MIN,
               yMax: Y_MAX,
               start: X_MIN,

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-fast-viewport.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-fast-viewport.tsx
@@ -70,7 +70,7 @@ export class StatusTimelineFastViewport {
               height: 500,
               width: 500,
             }}
-            viewPort={{
+            viewport={{
               yMin: Y_MIN,
               yMax: Y_MAX,
               start: this.start,

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-multiple-data-streams.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-multiple-data-streams.tsx
@@ -47,7 +47,7 @@ export class StatusTimelineMultipleDataStreams {
             width: 500,
             height: 500,
           }}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-raw-data.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-raw-data.tsx
@@ -69,7 +69,7 @@ export class StatusTimelineRawData {
             height: 500,
           }}
           annotations={annotations}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-standard.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-standard.tsx
@@ -28,7 +28,7 @@ export class StatusTimelineStandard {
             width: 500,
             height: 500,
           }}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-status-margin.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-status-margin.tsx
@@ -50,7 +50,7 @@ export class StatusTimelineStatusMargin {
           alarms={{ expires: MONTH_IN_MS }}
           widgetId="widget-id"
           dataStreams={[DATA_STREAM_1, DATA_STREAM_2]}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-band.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-band.tsx
@@ -65,7 +65,7 @@ export class StatusTimelineThresholdBand {
             width: 500,
             height: 500,
           }}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-coloration.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-coloration.tsx
@@ -46,7 +46,7 @@ export class StatusTimelineThresholdColoration {
             width: 500,
             height: 500,
           }}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-exact-point.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-exact-point.tsx
@@ -46,7 +46,7 @@ export class StatusTimelineThresholdExactPoint {
             width: 500,
             height: 500,
           }}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-multiple-data-stream.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-multiple-data-stream.tsx
@@ -80,7 +80,7 @@ export class StatusTimelineThresholdMultipleDataStream {
             width: 500,
             height: 500,
           }}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-multiple-thresholds.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-multiple-thresholds.tsx
@@ -53,7 +53,7 @@ export class StatusTimelineThresholdMultipleThresholds {
             width: 500,
             height: 500,
           }}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-no-coloration.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-no-coloration.tsx
@@ -46,7 +46,7 @@ export class StatusTimelineThresholdNoColoration {
             width: 500,
             height: 500,
           }}
-          viewPort={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/testing/test-routes/kpi/sc-kpi-standard.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/kpi/sc-kpi-standard.tsx
@@ -62,7 +62,7 @@ export class ScKpiStandard {
       <sc-kpi
         widgetId="test-widget"
         dataStreams={dataStreams}
-        viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX, duration: isEnabled ? YEAR_IN_MS : undefined }}
+        viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX, duration: isEnabled ? YEAR_IN_MS : undefined }}
       />
     );
   }

--- a/packages/synchro-charts/src/testing/test-routes/status-grid/sc-status-grid-standard.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/status-grid/sc-status-grid-standard.tsx
@@ -43,7 +43,7 @@ export class ScStatusGridStandard {
         labelsConfig={labelsConfig}
         annotations={annotations}
         dataStreams={data}
-        viewPort={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX, duration: isEnabled ? YEAR_IN_MS : undefined }}
+        viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX, duration: isEnabled ? YEAR_IN_MS : undefined }}
         isEditing={isEditing}
       />
     );

--- a/packages/synchro-charts/src/testing/test-routes/widget-test-route.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/widget-test-route.tsx
@@ -1,5 +1,5 @@
 import { Component, h, Listen, Prop } from '@stencil/core';
-import { SIZE, VIEW_PORT as DEFAULT_VIEW_PORT } from '../dynamicWidgetUtils/constants';
+import { SIZE, VIEWPORT as DEFAULT_VIEWPORT } from '../dynamicWidgetUtils/constants';
 import { testCaseParameters } from '../dynamicWidgetUtils/testCaseParameters';
 import { DataStreamInfo } from '../../utils/dataTypes';
 
@@ -15,8 +15,8 @@ const {
   axis,
   componentTag,
   annotations,
-  viewPortStart,
-  viewPortEnd,
+  viewportStart,
+  viewportEnd,
   duration,
   isEditing,
   dataStreams,
@@ -25,10 +25,10 @@ const {
   tableColumns,
 } = testCaseParameters();
 
-const viewPort = {
-  ...DEFAULT_VIEW_PORT,
-  start: viewPortStart,
-  end: viewPortEnd,
+const viewport = {
+  ...DEFAULT_VIEWPORT,
+  start: viewportStart,
+  end: viewportEnd,
   duration,
   group: 'some-viewport-group',
 };
@@ -73,7 +73,7 @@ export class WidgetTestRoute {
           dataStreams={dataStreams}
           isEditing={isEditing}
           alarms={alarms}
-          viewPort={viewPort}
+          viewport={viewport}
           legend={legend}
           size={getSize(width)}
           axis={axis}

--- a/packages/synchro-charts/src/testing/testing-ground/testConfigs.ts
+++ b/packages/synchro-charts/src/testing/testing-ground/testConfigs.ts
@@ -26,7 +26,7 @@ const infos: DataStreamInfo[] = [
 export const TESTING_GROUND_CHART_CONFIG: ChartConfig & { dataStreamInfo: DataStreamInfo[] } = {
   widgetId: 'fake-id',
   legend: DEFAULT_CHART_CONFIG.legend,
-  viewPort: {
+  viewport: {
     start: new Date(1998, 0, 0),
     end: new Date(2000, 0, 1),
   },

--- a/packages/synchro-charts/src/testing/types.ts
+++ b/packages/synchro-charts/src/testing/types.ts
@@ -2,8 +2,8 @@ import { Annotations, LegendConfig } from '../components/charts/common/types';
 import { DataStream, DataStreamInfo, Resolution } from '../utils/dataTypes';
 
 export type WidgetSearchQueryParams = {
-  viewPortStart: Date;
-  viewPortEnd: Date;
+  viewportStart: Date;
+  viewportEnd: Date;
   componentTag: string;
   legend: LegendConfig;
   resolution: Resolution;

--- a/packages/synchro-charts/src/utils/dataTypes.ts
+++ b/packages/synchro-charts/src/utils/dataTypes.ts
@@ -150,7 +150,7 @@ export interface BaseConfig {
   // A unique identifier to the widget
   widgetId: string;
   // The viewport in which the widget analyzes/visualizes data.
-  viewPort: MinimalViewPortConfig | ViewPortConfig;
+  viewport: MinimalViewPortConfig | ViewPortConfig;
   // Exact pixel dimensions of the widget
   size?: MinimalSizeConfig;
 }

--- a/packages/synchro-charts/src/utils/time.ts
+++ b/packages/synchro-charts/src/utils/time.ts
@@ -63,16 +63,16 @@ export const convertMS = (
 };
 
 export const displayDate = (date: Date, resolution: number, { start, end }: { start: Date; end: Date }): string => {
-  const viewPortDurationMS = end.getTime() - start.getTime();
+  const viewportDurationMS = end.getTime() - start.getTime();
   if (resolution < HOUR_IN_MS) {
-    if (viewPortDurationMS < MINUTE_IN_MS) {
+    if (viewportDurationMS < MINUTE_IN_MS) {
       return date.toLocaleString('en-US', {
         minute: 'numeric',
         second: 'numeric',
       });
     }
 
-    if (viewPortDurationMS <= 10 * MINUTE_IN_MS) {
+    if (viewportDurationMS <= 10 * MINUTE_IN_MS) {
       return date.toLocaleString('en-US', {
         hour: 'numeric',
         minute: 'numeric',
@@ -81,7 +81,7 @@ export const displayDate = (date: Date, resolution: number, { start, end }: { st
       });
     }
 
-    if (viewPortDurationMS <= HOUR_IN_MS) {
+    if (viewportDurationMS <= HOUR_IN_MS) {
       return date.toLocaleString('en-US', {
         hour: 'numeric',
         minute: 'numeric',
@@ -89,7 +89,7 @@ export const displayDate = (date: Date, resolution: number, { start, end }: { st
       });
     }
 
-    if (viewPortDurationMS <= DAY_IN_MS) {
+    if (viewportDurationMS <= DAY_IN_MS) {
       return date.toLocaleString('en-US', {
         hour12: true,
         hour: 'numeric',
@@ -99,7 +99,7 @@ export const displayDate = (date: Date, resolution: number, { start, end }: { st
       });
     }
 
-    if (viewPortDurationMS <= MONTH_IN_MS) {
+    if (viewportDurationMS <= MONTH_IN_MS) {
       return date.toLocaleString('en-US', {
         hour12: true,
         hour: 'numeric',

--- a/packages/synchro-charts/src/utils/viewPort.spec.ts
+++ b/packages/synchro-charts/src/utils/viewPort.spec.ts
@@ -1,43 +1,43 @@
 import { DAY_IN_MS } from './time';
-import { viewPortEndDate, viewPortStartDate } from './viewPort';
+import { viewportEndDate, viewportStartDate } from './viewPort';
 
 const mockCurrentTime = (mockedDate: Date) => {
   // @ts-ignore
   Date.now = jest.spyOn(Date, 'now').mockImplementation(() => mockedDate.getTime());
 };
 
-describe('viewPortStart', () => {
+describe('viewportStart', () => {
   it('returns start date if one is present', () => {
     const START = new Date(2000, 0, 0);
-    expect(viewPortStartDate({ start: START })).toBe(START);
+    expect(viewportStartDate({ start: START })).toBe(START);
   });
 
   it('returns start date calculated from the end minus the duration', () => {
-    expect(viewPortStartDate({ end: new Date(2000, 0, 1), duration: DAY_IN_MS })).toEqual(new Date(2000, 0, 0));
+    expect(viewportStartDate({ end: new Date(2000, 0, 1), duration: DAY_IN_MS })).toEqual(new Date(2000, 0, 0));
   });
 
   it('returns current date if empty viewport is provided', () => {
     const CURR_DATE = new Date();
     mockCurrentTime(CURR_DATE);
 
-    expect(viewPortStartDate({})).toEqual(CURR_DATE);
+    expect(viewportStartDate({})).toEqual(CURR_DATE);
   });
 });
 
-describe('viewPortEnd', () => {
+describe('viewportEnd', () => {
   it('returns end date if one is present', () => {
     const END = new Date(2000, 0, 0);
-    expect(viewPortEndDate({ end: END })).toBe(END);
+    expect(viewportEndDate({ end: END })).toBe(END);
   });
 
   it('returns end date calculated from the start plus the duration', () => {
-    expect(viewPortEndDate({ start: new Date(2000, 0, 0), duration: DAY_IN_MS })).toEqual(new Date(2000, 0, 1));
+    expect(viewportEndDate({ start: new Date(2000, 0, 0), duration: DAY_IN_MS })).toEqual(new Date(2000, 0, 1));
   });
 
   it('returns current date if empty viewport is provided', () => {
     const CURR_DATE = new Date();
     mockCurrentTime(CURR_DATE);
 
-    expect(viewPortEndDate({})).toEqual(CURR_DATE);
+    expect(viewportEndDate({})).toEqual(CURR_DATE);
   });
 });

--- a/packages/synchro-charts/src/utils/viewPort.ts
+++ b/packages/synchro-charts/src/utils/viewPort.ts
@@ -1,6 +1,6 @@
 import { MinimalViewPortConfig } from './dataTypes';
 
-export const viewPortStartDate = ({ start, end, duration }: MinimalViewPortConfig): Date => {
+export const viewportStartDate = ({ start, end, duration }: MinimalViewPortConfig): Date => {
   if (start) {
     return start;
   }
@@ -14,7 +14,7 @@ export const viewPortStartDate = ({ start, end, duration }: MinimalViewPortConfi
   return new Date(Date.now());
 };
 
-export const viewPortEndDate = ({ start, end, duration }: MinimalViewPortConfig): Date => {
+export const viewportEndDate = ({ start, end, duration }: MinimalViewPortConfig): Date => {
   if (end) {
     return end;
   }


### PR DESCRIPTION
### Overview
refactor `viewPort` to `viewport`, and `VIEW_PORT` to `VIEWPORT`.

A viewport is a single word.

### Changes
- synchro-charts changes to viewPort/VIEW_PORT to be veiwport and VIEWPORT
- doc-site updated to `viewport`

### Tests

```
@synchro-charts/core: =============================== Coverage summary ===============================
@synchro-charts/core: Statements   : 89.6% ( 2456/2741 )
@synchro-charts/core: Branches     : 84.86% ( 1160/1367 )
@synchro-charts/core: Functions    : 86.77% ( 505/582 )
@synchro-charts/core: Lines        : 89.27% ( 2345/2627 )
@synchro-charts/core: ================================================================================
@synchro-charts/core: Test Suites: 76 passed, 76 total
@synchro-charts/core: Tests:       6 skipped, 1253 passed, 1259 total
@synchro-charts/core: Snapshots:   9 passed, 9 total
@synchro-charts/core: Time:        60.651s, estimated 64s
@synchro-charts/core: Ran all test suites.
@synchro-charts/core: (node:65519) [DEP0128] DeprecationWarning: Invalid 'main' field in '/Users/diehbria/aws-synchro-charts/node_modules/eslint-config-airbnb-typescript/package.json' of 'dist/eslint-config-airbnb-typescript.js'. Please either fix that or report it to the module author
@synchro-charts/core: (Use `node --trace-deprecation ...` to show where the warning was created)
@synchro-charts/doc-site: $ echo "INFO: no test specified"
@synchro-charts/doc-site: INFO: no test specified
lerna success run Ran npm script 'test' in 2 packages in 90.0s:
lerna success - @synchro-charts/doc-site
lerna success - @synchro-charts/core
✨  Done in 91.32s.
```

```

       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  charts/alarms.spec.ts                    00:33       18       18        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/annotation-rescaling.spec.ts      00:11        4        4        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/empty-status.spec.      00:04        2        2        -        -        - │
  │    ts                                                                                          │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/errors.spec.ts          00:03        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/gestures.spec.ts        00:06        3        3        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/loading.spec.ts         00:02        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/sc-webgl-bar-chart      00:31       15       15        -        -        - │
  │    .spec.ts                                                                                    │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/threshold-colorati      00:10        6        6        -        -        - │
  │    on.spec.ts                                                                                  │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/tooltip.spec.ts         00:08        3        3        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/cross-resolution.spec.ts          00:04        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/empty-status.spec      00:05        2        2        -        -        - │
  │    .ts                                                                                         │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/errors.spec.ts         00:05        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/gestures.spec.ts       00:13        4        4        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/loading.spec.ts        00:04        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/sc-webgl-chart.sp      00:39       20       18        -        2        - │
  │    ec.ts                                                                                       │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/threshold-colorat      00:11        5        5        -        -        - │
  │    ion.spec.ts                                                                                 │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/tooltip.spec.ts        00:04        2        2        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/performance.spec.ts                32ms        6        -        -        6        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/rendering-meshes.spec.ts          00:28       10       10        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/empty-status.s      00:04        2        2        -        -        - │
  │    pec.ts                                                                                      │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/errors.spec.ts      00:02        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/gestures.spec.      00:03        2        2        -        -        - │
  │    ts                                                                                          │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/loading.spec.t      00:02        1        1        -        -        - │
  │    s                                                                                           │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/sc-webgl-scatt      00:08        4        4        -        -        - │
  │    er-chart.spec.ts                                                                            │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/threshold-colo      00:10        6        6        -        -        - │
  │    ration.spec.ts                                                                              │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/tooltip.spec.t      00:04        2        2        -        -        - │
  │    s                                                                                           │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/empty-status      00:03        2        2        -        -        - │
  │    .spec.ts                                                                                    │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/errors.spec.      00:03        2        2        -        -        - │
  │    ts                                                                                          │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/gestures.spe      00:03        2        2        -        -        - │
  │    c.ts                                                                                        │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/loading.spec      00:02        1        1        -        -        - │
  │    .ts                                                                                         │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/status-timel      00:36       17       17        -        -        - │
  │    ine.spec.ts                                                                                 │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/threshold-co      00:12        7        7        -        -        - │
  │    loration.spec.ts                                                                            │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/threshold-le      00:05        3        3        -        -        - │
  │    gend.spec.ts                                                                                │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/tooltip.spec      00:03        1        1        -        -        - │
  │    .ts                                                                                         │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  expandable-input.spec.ts                 00:01        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  kpi/kpi.spec.ts                          00:07        5        5        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  size-provider.spec.ts                    00:06        6        6        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  status-grid/status-grid.spec.ts          00:17       14       13        -        1        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  table/table.spec.ts                      00:10        9        9        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  webglContext.spec.ts                     00:15        6        6        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        06:37      199      190        -        9        -  

```
