### PR TITLE
Synchro Charts: Increase threshold limit to 12

### DIFF
--- a/packages/synchro-charts/src/components/charts/common/annotations/thresholdBands.spec.ts
+++ b/packages/synchro-charts/src/components/charts/common/annotations/thresholdBands.spec.ts
@@ -2,400 +2,407 @@ import { Threshold } from '../types';
 import { thresholdBands } from './thresholdBands';
 import { COMPARISON_OPERATOR } from '../constants';
 
-describe('threshold bands', () => {
-  it('returns the correct bands for 1 threshold with greater than comparison operator', () => {
-    const expectedLowerValue = 28;
-    const thresholds: Threshold[] = [
-      {
-        color: 'orange',
-        value: expectedLowerValue,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
-      },
-    ];
+it('returns 13 bands always', () => {
+  const expectedLowerValue = 28;
+  const thresholds: Threshold[] = [
+    {
+      color: 'orange',
+      value: expectedLowerValue,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
+    },
+  ];
 
-    const bands = thresholdBands(thresholds);
-    expect(bands).toHaveLength(12);
+  const bands = thresholdBands(thresholds);
+  expect(bands).toHaveLength(13);
+});
 
-    expect(bands).toContainEqual(
-      expect.objectContaining({
-        color: [255, 165, 0],
-        lower: expectedLowerValue,
-        upper: Number.MAX_SAFE_INTEGER,
-      })
-    );
-  });
+it('returns the correct bands for 1 threshold with greater than comparison operator', () => {
+  const expectedLowerValue = 28;
+  const thresholds: Threshold[] = [
+    {
+      color: 'orange',
+      value: expectedLowerValue,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
+    },
+  ];
 
-  it('returns the correct bands for 1 threshold with less than comparison operator', () => {
-    const expectedUpperValue = 28;
-    const thresholds: Threshold[] = [
-      {
-        color: 'orange',
-        value: expectedUpperValue,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.LESS_THAN_EQUAL,
-      },
-    ];
+  const bands = thresholdBands(thresholds);
 
-    const bands = thresholdBands(thresholds);
-    expect(bands).toHaveLength(12);
+  expect(bands).toContainEqual(
+    expect.objectContaining({
+      color: [255, 165, 0],
+      lower: expectedLowerValue,
+      upper: Number.MAX_SAFE_INTEGER,
+    })
+  );
+});
 
-    expect(bands).toContainEqual(
-      expect.objectContaining({
-        color: [255, 165, 0],
-        lower: Number.MIN_SAFE_INTEGER,
-        upper: expectedUpperValue,
-      })
-    );
-  });
+it('returns the correct bands for 1 threshold with less than comparison operator', () => {
+  const expectedUpperValue = 28;
+  const thresholds: Threshold[] = [
+    {
+      color: 'orange',
+      value: expectedUpperValue,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.LESS_THAN_EQUAL,
+    },
+  ];
 
-  it('returns the correct bands for 2 thresholds with both greater than comparison operator', () => {
-    const expectedFirstValue = 28;
-    const expectedSecondValue = 20;
-    const thresholds: Threshold[] = [
-      {
-        color: 'orange',
-        value: expectedFirstValue,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
-      },
-      {
-        color: 'blue',
-        value: expectedSecondValue,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
-      },
-    ];
+  const bands = thresholdBands(thresholds);
 
-    const bands = thresholdBands(thresholds);
-    expect(bands).toHaveLength(12);
+  expect(bands).toContainEqual(
+    expect.objectContaining({
+      color: [255, 165, 0],
+      lower: Number.MIN_SAFE_INTEGER,
+      upper: expectedUpperValue,
+    })
+  );
+});
 
-    expect(bands).toContainEqual(
-      expect.objectContaining({
-        color: [255, 165, 0],
-        lower: expectedFirstValue,
-        upper: Number.MAX_SAFE_INTEGER,
-      })
-    );
+it('returns the correct bands for 2 thresholds with both greater than comparison operator', () => {
+  const expectedFirstValue = 28;
+  const expectedSecondValue = 20;
+  const thresholds: Threshold[] = [
+    {
+      color: 'orange',
+      value: expectedFirstValue,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
+    },
+    {
+      color: 'blue',
+      value: expectedSecondValue,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
+    },
+  ];
 
-    expect(bands).toContainEqual(
-      expect.objectContaining({
-        color: [0, 0, 255],
-        lower: expectedSecondValue,
-        upper: expectedFirstValue,
-      })
-    );
-  });
+  const bands = thresholdBands(thresholds);
 
-  it('returns the correct bands for 2 thresholds with both less than comparison operator', () => {
-    const expectedFirstValue = 28;
-    const expectedSecondValue = 20;
-    const thresholds: Threshold[] = [
-      {
-        color: 'orange',
-        value: expectedFirstValue,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
-      },
-      {
-        color: 'blue',
-        value: expectedSecondValue,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
-      },
-    ];
+  expect(bands).toContainEqual(
+    expect.objectContaining({
+      color: [255, 165, 0],
+      lower: expectedFirstValue,
+      upper: Number.MAX_SAFE_INTEGER,
+    })
+  );
 
-    const bands = thresholdBands(thresholds);
-    expect(bands).toHaveLength(12);
+  expect(bands).toContainEqual(
+    expect.objectContaining({
+      color: [0, 0, 255],
+      lower: expectedSecondValue,
+      upper: expectedFirstValue,
+    })
+  );
+});
 
-    // The band between the max safe integer and first threshold should not exist as it is less than operator
-    expect(bands).not.toContainEqual(
-      expect.objectContaining({
-        color: [255, 165, 0],
-        lower: expectedFirstValue,
-        upper: Number.MAX_SAFE_INTEGER,
-      })
-    );
+it('returns the correct bands for 2 thresholds with both less than comparison operator', () => {
+  const expectedFirstValue = 28;
+  const expectedSecondValue = 20;
+  const thresholds: Threshold[] = [
+    {
+      color: 'orange',
+      value: expectedFirstValue,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
+    },
+    {
+      color: 'blue',
+      value: expectedSecondValue,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
+    },
+  ];
 
-    // The first band should be between the two expected number
-    expect(bands).toContainEqual(
-      expect.objectContaining({
-        color: [255, 165, 0],
-        lower: expectedSecondValue,
-        upper: expectedFirstValue,
-      })
-    );
+  const bands = thresholdBands(thresholds);
 
-    // The second band should be between the lowest threshold and the min safe integer.
-    expect(bands).toContainEqual(
-      expect.objectContaining({
-        color: [0, 0, 255],
-        lower: Number.MIN_SAFE_INTEGER,
-        upper: expectedSecondValue,
-      })
-    );
-  });
+  // The band between the max safe integer and first threshold should not exist as it is less than operator
+  expect(bands).not.toContainEqual(
+    expect.objectContaining({
+      color: [255, 165, 0],
+      lower: expectedFirstValue,
+      upper: Number.MAX_SAFE_INTEGER,
+    })
+  );
 
-  it('returns the correct bands for 2 thresholds with first one with less than and second one with greater than comparison operator', () => {
-    const expectedFirstValue = 28;
-    const expectedSecondValue = 20;
-    const thresholds: Threshold[] = [
-      {
-        color: 'orange',
-        value: expectedFirstValue,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
-      },
-      {
-        color: 'blue',
-        value: expectedSecondValue,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
-      },
-    ];
+  // The first band should be between the two expected number
+  expect(bands).toContainEqual(
+    expect.objectContaining({
+      color: [255, 165, 0],
+      lower: expectedSecondValue,
+      upper: expectedFirstValue,
+    })
+  );
 
-    const bands = thresholdBands(thresholds);
-    expect(bands).toHaveLength(12);
+  // The second band should be between the lowest threshold and the min safe integer.
+  expect(bands).toContainEqual(
+    expect.objectContaining({
+      color: [0, 0, 255],
+      lower: Number.MIN_SAFE_INTEGER,
+      upper: expectedSecondValue,
+    })
+  );
+});
 
-    // Should not have a band that goes from the first threshold to max integer
-    expect(bands).not.toContainEqual(
-      expect.objectContaining({
-        color: [255, 165, 0],
-        lower: expectedFirstValue,
-        upper: Number.MAX_SAFE_INTEGER,
-      })
-    );
+it('returns the correct bands for 2 thresholds with first one with less than and second one with greater than comparison operator', () => {
+  const expectedFirstValue = 28;
+  const expectedSecondValue = 20;
+  const thresholds: Threshold[] = [
+    {
+      color: 'orange',
+      value: expectedFirstValue,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
+    },
+    {
+      color: 'blue',
+      value: expectedSecondValue,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
+    },
+  ];
 
-    // The first band should be between the two expected number with the first threshold color.
-    expect(bands).toContainEqual(
-      expect.objectContaining({
-        color: [255, 165, 0],
-        lower: expectedSecondValue,
-        upper: expectedFirstValue,
-      })
-    );
+  const bands = thresholdBands(thresholds);
 
-    // There should be no band between the lowest threshold and the min safe integer.
-    expect(bands).not.toContainEqual(
-      expect.objectContaining({
-        color: [0, 0, 255],
-        lower: Number.MIN_SAFE_INTEGER,
-        upper: expectedSecondValue,
-      })
-    );
-  });
+  // Should not have a band that goes from the first threshold to max integer
+  expect(bands).not.toContainEqual(
+    expect.objectContaining({
+      color: [255, 165, 0],
+      lower: expectedFirstValue,
+      upper: Number.MAX_SAFE_INTEGER,
+    })
+  );
 
-  it('returns the correct bands for 2 thresholds with first one with less than and second one with greater than comparison operator with both negative thresholds', () => {
-    const expectedFirstValue = -18;
-    const expectedSecondValue = -20;
-    const thresholds: Threshold[] = [
-      {
-        color: 'orange',
-        value: expectedFirstValue,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
-      },
-      {
-        color: 'blue',
-        value: expectedSecondValue,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
-      },
-    ];
+  // The first band should be between the two expected number with the first threshold color.
+  expect(bands).toContainEqual(
+    expect.objectContaining({
+      color: [255, 165, 0],
+      lower: expectedSecondValue,
+      upper: expectedFirstValue,
+    })
+  );
 
-    const bands = thresholdBands(thresholds);
-    expect(bands).toHaveLength(12);
+  // There should be no band between the lowest threshold and the min safe integer.
+  expect(bands).not.toContainEqual(
+    expect.objectContaining({
+      color: [0, 0, 255],
+      lower: Number.MIN_SAFE_INTEGER,
+      upper: expectedSecondValue,
+    })
+  );
+});
 
-    // Should not have a band that goes from the first threshold to max integer
-    expect(bands).not.toContainEqual(
-      expect.objectContaining({
-        color: [255, 165, 0],
-        lower: expectedFirstValue,
-        upper: Number.MAX_SAFE_INTEGER,
-      })
-    );
+it('returns the correct bands for 2 thresholds with first one with less than and second one with greater than comparison operator with both negative thresholds', () => {
+  const expectedFirstValue = -18;
+  const expectedSecondValue = -20;
+  const thresholds: Threshold[] = [
+    {
+      color: 'orange',
+      value: expectedFirstValue,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
+    },
+    {
+      color: 'blue',
+      value: expectedSecondValue,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
+    },
+  ];
 
-    // The first band should be between the two expected number with the second threshold color.
-    expect(bands).toContainEqual(
-      expect.objectContaining({
-        color: [0, 0, 255],
-        lower: expectedSecondValue,
-        upper: expectedFirstValue,
-      })
-    );
+  const bands = thresholdBands(thresholds);
 
-    // There should be no band between the lowest threshold and the min safe integer.
-    expect(bands).not.toContainEqual(
-      expect.objectContaining({
-        color: [0, 0, 255],
-        lower: Number.MIN_SAFE_INTEGER,
-        upper: expectedSecondValue,
-      })
-    );
-  });
+  // Should not have a band that goes from the first threshold to max integer
+  expect(bands).not.toContainEqual(
+    expect.objectContaining({
+      color: [255, 165, 0],
+      lower: expectedFirstValue,
+      upper: Number.MAX_SAFE_INTEGER,
+    })
+  );
 
-  it('returns the correct bands for 2 thresholds with first one with greater than and second one with less than comparison operator', () => {
-    const expectedFirstValue = 28;
-    const expectedSecondValue = 20;
-    const thresholds: Threshold[] = [
-      {
-        color: 'orange',
-        value: expectedFirstValue,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
-      },
-      {
-        color: 'blue',
-        value: expectedSecondValue,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
-      },
-    ];
+  // The first band should be between the two expected number with the second threshold color.
+  expect(bands).toContainEqual(
+    expect.objectContaining({
+      color: [0, 0, 255],
+      lower: expectedSecondValue,
+      upper: expectedFirstValue,
+    })
+  );
 
-    const bands = thresholdBands(thresholds);
-    expect(bands).toHaveLength(12);
+  // There should be no band between the lowest threshold and the min safe integer.
+  expect(bands).not.toContainEqual(
+    expect.objectContaining({
+      color: [0, 0, 255],
+      lower: Number.MIN_SAFE_INTEGER,
+      upper: expectedSecondValue,
+    })
+  );
+});
 
-    // Should have a band that goes from the first threshold to max integer
-    expect(bands).toContainEqual(
-      expect.objectContaining({
-        color: [255, 165, 0],
-        lower: expectedFirstValue,
-        upper: Number.MAX_SAFE_INTEGER,
-      })
-    );
+it('returns the correct bands for 2 thresholds with first one with greater than and second one with less than comparison operator', () => {
+  const expectedFirstValue = 28;
+  const expectedSecondValue = 20;
+  const thresholds: Threshold[] = [
+    {
+      color: 'orange',
+      value: expectedFirstValue,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
+    },
+    {
+      color: 'blue',
+      value: expectedSecondValue,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
+    },
+  ];
 
-    // Should not have a band between two thresholds
-    expect(bands).not.toContainEqual(
-      expect.objectContaining({
-        color: [255, 165, 0],
-        lower: expectedSecondValue,
-        upper: expectedFirstValue,
-      })
-    );
+  const bands = thresholdBands(thresholds);
 
-    // There should be a band between the lowest threshold and the min safe integer.
-    expect(bands).toContainEqual(
-      expect.objectContaining({
-        color: [0, 0, 255],
-        lower: Number.MIN_SAFE_INTEGER,
-        upper: expectedSecondValue,
-      })
-    );
-  });
+  // Should have a band that goes from the first threshold to max integer
+  expect(bands).toContainEqual(
+    expect.objectContaining({
+      color: [255, 165, 0],
+      lower: expectedFirstValue,
+      upper: Number.MAX_SAFE_INTEGER,
+    })
+  );
 
-  it('returns the correct bands for 10 thresholds of unsorted assorted comparison operator', () => {
-    const thresholds: Threshold[] = [
-      {
-        color: '#4363d8',
-        value: 3,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
-      },
-      {
-        color: '#00008B',
-        value: -1,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
-      },
-      {
-        color: '#42d4f4',
-        value: -3,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN_EQUAL,
-      },
-      {
-        color: '#800000',
-        value: 10,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
-      },
-      {
-        color: '#f58231',
-        value: 8,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
-      },
-      {
-        color: '#ffe119',
-        value: 6,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
-      },
-      {
-        color: '#000075',
-        value: 5,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
-      },
-      {
-        color: '#dcbeff',
-        value: 5,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
-      },
-      {
-        color: '#9370DB',
-        value: -3,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
-      },
-      {
-        color: '#800080',
-        value: 0,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
-      },
-    ];
+  // Should not have a band between two thresholds
+  expect(bands).not.toContainEqual(
+    expect.objectContaining({
+      color: [255, 165, 0],
+      lower: expectedSecondValue,
+      upper: expectedFirstValue,
+    })
+  );
 
-    const bands = thresholdBands(thresholds);
-    expect(bands).toHaveLength(12);
+  // There should be a band between the lowest threshold and the min safe integer.
+  expect(bands).toContainEqual(
+    expect.objectContaining({
+      color: [0, 0, 255],
+      lower: Number.MIN_SAFE_INTEGER,
+      upper: expectedSecondValue,
+    })
+  );
+});
 
-    expect(bands).toStrictEqual([
-      { color: [128, 0, 0], lower: 10, upper: Number.MAX_SAFE_INTEGER },
-      { color: [245, 130, 49], lower: 8, upper: 10 },
-      { color: [255, 225, 25], lower: 5, upper: 6 },
-      { color: [220, 190, 255], lower: 3, upper: 5 },
-      { color: [67, 99, 216], lower: 0, upper: 3 },
-      { color: [0, 0, 139], lower: -1, upper: 0 },
-      { color: [66, 212, 244], lower: -3, upper: -1 },
-      { color: [66, 212, 244], lower: -3, upper: -3 },
-      { color: [147, 112, 219], lower: Number.MIN_SAFE_INTEGER, upper: -3 },
-      { color: [147, 112, 219], lower: Number.MIN_SAFE_INTEGER, upper: -3 },
-      { color: [147, 112, 219], lower: Number.MIN_SAFE_INTEGER, upper: -3 },
-      { color: [147, 112, 219], lower: Number.MIN_SAFE_INTEGER, upper: -3 },
-    ]);
-  });
+it('returns the correct bands for 10 thresholds of unsorted assorted comparison operator', () => {
+  const thresholds: Threshold[] = [
+    {
+      color: '#4363d8',
+      value: 3,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
+    },
+    {
+      color: '#00008B',
+      value: -1,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
+    },
+    {
+      color: '#42d4f4',
+      value: -3,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN_EQUAL,
+    },
+    {
+      color: '#800000',
+      value: 10,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
+    },
+    {
+      color: '#f58231',
+      value: 8,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
+    },
+    {
+      color: '#ffe119',
+      value: 6,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
+    },
+    {
+      color: '#000075',
+      value: 5,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN,
+    },
+    {
+      color: '#dcbeff',
+      value: 5,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
+    },
+    {
+      color: '#9370DB',
+      value: -3,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
+    },
+    {
+      color: '#800080',
+      value: 0,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
+    },
+  ];
 
-  it('returns correct bands for EQ comparison', () => {
-    const thresholds: Threshold[] = [
-      {
-        color: '#800000',
-        value: 3.5675768878,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.EQUAL,
-      },
-      {
-        color: '#800080',
-        value: 100005,
-        showValue: false,
-        comparisonOperator: COMPARISON_OPERATOR.EQUAL,
-      },
-    ];
+  const bands = thresholdBands(thresholds);
 
-    const bands = thresholdBands(thresholds);
-    expect(bands).toStrictEqual([
-      { color: [128, 0, 128], lower: 100005, upper: 100005 },
-      { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
-      { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
-      { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
-      { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
-      { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
-      { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
-      { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
-      { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
-      { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
-      { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
-      { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
-    ]);
-  });
+  expect(bands).toStrictEqual([
+    { color: [128, 0, 0], lower: 10, upper: Number.MAX_SAFE_INTEGER },
+    { color: [245, 130, 49], lower: 8, upper: 10 },
+    { color: [255, 225, 25], lower: 5, upper: 6 },
+    { color: [220, 190, 255], lower: 3, upper: 5 },
+    { color: [67, 99, 216], lower: 0, upper: 3 },
+    { color: [0, 0, 139], lower: -1, upper: 0 },
+    { color: [66, 212, 244], lower: -3, upper: -1 },
+    { color: [66, 212, 244], lower: -3, upper: -3 },
+    { color: [147, 112, 219], lower: Number.MIN_SAFE_INTEGER, upper: -3 },
+    { color: [147, 112, 219], lower: Number.MIN_SAFE_INTEGER, upper: -3 },
+    { color: [147, 112, 219], lower: Number.MIN_SAFE_INTEGER, upper: -3 },
+    { color: [147, 112, 219], lower: Number.MIN_SAFE_INTEGER, upper: -3 },
+    { color: [147, 112, 219], lower: Number.MIN_SAFE_INTEGER, upper: -3 },
+  ]);
+});
+
+it('returns correct bands for EQ comparison', () => {
+  const thresholds: Threshold[] = [
+    {
+      color: '#800000',
+      value: 3.5675768878,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.EQUAL,
+    },
+    {
+      color: '#800080',
+      value: 100005,
+      showValue: false,
+      comparisonOperator: COMPARISON_OPERATOR.EQUAL,
+    },
+  ];
+
+  const bands = thresholdBands(thresholds);
+  expect(bands).toStrictEqual([
+    { color: [128, 0, 128], lower: 100005, upper: 100005 },
+    { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
+    { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
+    { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
+    { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
+    { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
+    { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
+    { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
+    { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
+    { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
+    { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
+    { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
+    { color: [128, 0, 0], lower: 3.5675768878, upper: 3.5675768878 },
+  ]);
 });

--- a/packages/synchro-charts/src/components/charts/common/annotations/thresholdBands.ts
+++ b/packages/synchro-charts/src/components/charts/common/annotations/thresholdBands.ts
@@ -4,10 +4,10 @@ import { getBreachedThreshold, sortThreshold, getNumberThresholds } from './util
 import { COMPARISON_OPERATOR } from '../constants';
 
 /**
- * Max of 12 threshold bands because we allow only up to 10 thresholds. Imaging a piece of paper being split into
- * 10 times. You will end up with 11 different pieces. Set it as 12 to over allocate.
+ * Max of 13 threshold bands because we allow only up to 12 thresholds. Imaging a piece of paper being split into
+ * 12 times. You will end up with 13 different pieces.
  */
-export const MAX_THRESHOLD_BANDS = 12;
+export const MAX_THRESHOLD_BANDS = 13;
 
 /**
  * First we sort the thresholds then reverse it. Reversing the sorted threshold allows us to create the band from


### PR DESCRIPTION
### Overview

Increase the max threshold count on a line/scatter/bar chart to 12.

### Tests
```
@synchro-charts/core: =============================== Coverage summary ===============================
@synchro-charts/core: Statements   : 89.74% ( 2494/2779 )
@synchro-charts/core: Branches     : 84.92% ( 1166/1373 )
@synchro-charts/core: Functions    : 86.88% ( 510/587 )
@synchro-charts/core: Lines        : 89.41% ( 2381/2663 )
@synchro-charts/core: ================================================================================
@synchro-charts/core: Test Suites: 77 passed, 77 total
@synchro-charts/core: Tests:       6 skipped, 1259 passed, 1265 total
@synchro-charts/core: Snapshots:   9 passed, 9 total
@synchro-charts/core: Time:        46.395s
@synchro-charts/core: Ran all test suites.
@synchro-charts/doc-site: $ echo "INFO: no test specified"
@synchro-charts/doc-site: INFO: no test specified
lerna success run Ran npm script 'test' in 2 packages in 50.9s:
lerna success - @synchro-charts/doc-site
lerna success - @synchro-charts/core
✨  Done in 51.69s.
```


```
       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  charts/alarms.spec.ts                    00:26       18       18        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/annotation-rescaling.spec.ts      00:10        4        4        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/empty-status.spec.      00:04        2        2        -        -        - │
  │    ts                                                                                          │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/errors.spec.ts          00:02        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/gestures.spec.ts        00:05        3        3        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/loading.spec.ts         00:02        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/sc-webgl-bar-chart      00:26       15       15        -        -        - │
  │    .spec.ts                                                                                    │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/threshold-colorati      00:13        6        6        -        -        - │
  │    on.spec.ts                                                                                  │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/bar-chart/tooltip.spec.ts         00:06        3        3        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/cross-resolution.spec.ts          00:03        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/empty-status.spec      00:05        2        2        -        -        - │
  │    .ts                                                                                         │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/errors.spec.ts         00:03        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/gestures.spec.ts       00:09        4        4        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/loading.spec.ts        00:02        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/sc-webgl-chart.sp      00:37       20       18        -        2        - │
  │    ec.ts                                                                                       │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/threshold-colorat      00:13        5        5        -        -        - │
  │    ion.spec.ts                                                                                 │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/line-chart/tooltip.spec.ts        00:11        2        2        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/performance.spec.ts                65ms        6        -        -        6        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/rendering-meshes.spec.ts          00:30       10       10        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/empty-status.s      00:07        2        2        -        -        - │
  │    pec.ts                                                                                      │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/errors.spec.ts      00:04        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/gestures.spec.      00:07        2        2        -        -        - │
  │    ts                                                                                          │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/loading.spec.t      00:04        1        1        -        -        - │
  │    s                                                                                           │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/sc-webgl-scatt      00:19        4        4        -        -        - │
  │    er-chart.spec.ts                                                                            │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/threshold-colo      00:14        6        6        -        -        - │
  │    ration.spec.ts                                                                              │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/scatter-chart/tooltip.spec.t      00:05        2        2        -        -        - │
  │    s                                                                                           │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/empty-status      00:05        2        2        -        -        - │
  │    .spec.ts                                                                                    │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/errors.spec.      00:03        2        2        -        -        - │
  │    ts                                                                                          │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/gestures.spe      00:03        2        2        -        -        - │
  │    c.ts                                                                                        │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/loading.spec      00:05        1        1        -        -        - │
  │    .ts                                                                                         │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/status-timel      00:38       17       17        -        -        - │
  │    ine.spec.ts                                                                                 │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/threshold-co      00:22        7        7        -        -        - │
  │    loration.spec.ts                                                                            │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/threshold-le      00:06        3        3        -        -        - │
  │    gend.spec.ts                                                                                │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  charts/status-timeline/tooltip.spec      00:03        1        1        -        -        - │
  │    .ts                                                                                         │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  expandable-input.spec.ts                 00:01        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  kpi/kpi.spec.ts                          00:08        5        5        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  size-provider.spec.ts                    00:06        6        6        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  status-grid/status-grid.spec.ts          00:20       14       13        -        1        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  table/table.spec.ts                      00:15        9        9        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  webglContext.spec.ts                     00:15        6        6        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        07:15      199      190        -        9        -  

✨  Done in 526.00s.
```