### PR TITLE
doc-site: threshold severity documentation

### DIFF
--- a/packages/doc-site/docs/properties.md
+++ b/packages/doc-site/docs/properties.md
@@ -307,6 +307,11 @@
         (Optional) A setting to control whether the annotation is configurable from within the widget. Defaults to false.
         For example when `isEditable` is true on a line chart, you are able to drag the annotation handle to change the annotation value and emit [`widgetUpdated`](#/API/Events) events reflecting the new annotation.
         
+      - `severity`: number
+  
+        (Optional) Specifies the severity of the threshold being breached. The lower the numerical number, the more importance is attributed to the threshold.
+        The `severity` is used to determine which threshold to indicate as breached when a `DataStream` has multiple thresholds that are breached, simultaneously.
+        
       - `label`: Object
       
         (Optional) a label which can be optionally displayed.

--- a/packages/doc-site/docs/threshold.md
+++ b/packages/doc-site/docs/threshold.md
@@ -487,3 +487,31 @@ const dataStreams = [{
   />
 </div>
 ```
+
+### Threshold severity
+Often with thresholds, we will have multiple thresholds applied to a single data stream. In certain cases, there will be particular thresholds
+which when breached is more important than a different, but also breached threshold.
+
+For example, if you have a warning threshold, and a critical error threshold, we would to ensure that the 'critical error' threshold was displayed as being breached, rather than the 'warning' threshold.
+
+To make the 'critical error' threshold a higher priority, we will utilize the `threshold.severity` property as such:
+
+```js static
+const annotations = {
+  y: [{
+    severity: 1,
+    label: 'critical error',
+    color: 'red',
+    value: 100,
+    comparisonOperator: 'GT',
+  }, {
+    label: 'warning',
+    severity: 2,
+    color: 'orange',
+    value: 50,
+    comparisonOperator: 'GT',
+  }],
+};
+```
+
+Note that if severity is left undefined, any threshold with a defined severity will be considered higher priority.


### PR DESCRIPTION
Add documentation for an already existing feature, `threshold.severity`.

