### PR TITLE
Annotation Focus Mode

### DIFF
--- a/packages/synchro-charts/cypress/integration/charts/utils-draggable.ts
+++ b/packages/synchro-charts/cypress/integration/charts/utils-draggable.ts
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 
 import { SECOND_IN_MS } from '../../../src/utils/time';
+import { FOCUS_TRANSITION_TIME } from '../../../src/components/charts/common/annotations/draggableAnnotations';
 
 export function moveHandle(selector: string, x: number, y: number) {
   cy.window().then(win => {
@@ -8,6 +9,7 @@ export function moveHandle(selector: string, x: number, y: number) {
     cy.get(selector)
       .trigger('mousemove', { clientX: x, clientY: y, force: true, view: win })
       .trigger('mouseup', { force: true, view: win });
+    cy.wait(2 * FOCUS_TRANSITION_TIME);
   });
 }
 
@@ -20,6 +22,7 @@ export function moveHandleFilter(selector: string, filter: string, x: number, y:
       .filter(filter)
       .trigger('mousemove', { clientX: x, clientY: y, force: true, view: win })
       .trigger('mouseup', { force: true, view: win });
+    cy.wait(2 * FOCUS_TRANSITION_TIME);
   });
 }
 

--- a/packages/synchro-charts/src/components/charts/common/annotations/draggableAnnotations.ts
+++ b/packages/synchro-charts/src/components/charts/common/annotations/draggableAnnotations.ts
@@ -56,7 +56,7 @@ const needAxisRescale = ({ annotationValue, viewport }: { annotationValue: numbe
   return annotationValue < lowerThreshold || annotationValue > upperThreshold;
 };
 
-const FOCUS_TRANSITION_TIME = 100; // milliseconds of the focus mode transition
+export const FOCUS_TRANSITION_TIME = 100; // milliseconds of the focus mode transition
 const FOCUS_OPACITY = 0.4;
 
 /**


### PR DESCRIPTION
Add new feature for draggable annotations: when an annotation drag handle is clicked, the other annotations fade out (reduced opacity) until the annotation drag handle is released. UX and feature approved by UX Designer. 

Tests: https://github.com/awslabs/synchro-charts/actions/runs/1113598085

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
