### PR TITLE
Aggregate type support

### DIFF
--- a/packages/synchro-charts/src/components/charts/common/trends/trendAnalysis.ts
+++ b/packages/synchro-charts/src/components/charts/common/trends/trendAnalysis.ts
@@ -1,7 +1,7 @@
 import { LinearRegressionResult, Trend, TrendResult } from './types';
 import { getVisibleData } from '../dataFilters';
 import { getDataPoints } from '../../../../utils/getDataPoints';
-import { DataStream, Timestamp, ViewPortConfig } from '../../../../utils/dataTypes';
+import { AggregateType, DataStream, Timestamp, ViewPortConfig } from '../../../../utils/dataTypes';
 import { TREND_TYPE } from '../../../../utils/dataConstants';
 
 /**
@@ -71,7 +71,8 @@ export const getAllTrendResults = (
   const trendResults: TrendResult[] = [];
   dataStreams.forEach(stream => {
     const { id } = stream;
-    const dataPoints = getDataPoints(stream, stream.resolution);
+    const firstAggregateType = stream.aggregateTypes !== undefined ? stream.aggregateTypes[0] : AggregateType.AVERAGE;
+    const dataPoints = getDataPoints(stream, stream.resolution, firstAggregateType);
 
     // only compute a trend line if there are at least two visible and/or boundary data points, the reason being that
     // a trend line based on a single point of data has no informational value and may actually be misleading

--- a/packages/synchro-charts/src/components/charts/sc-status-timeline/sc-status-timeline-overlay/sc-status-timeline-overlay.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-status-timeline/sc-status-timeline-overlay/sc-status-timeline-overlay.tsx
@@ -1,5 +1,5 @@
 import { Component, Event, EventEmitter, h, Prop, State } from '@stencil/core';
-import { DataStream, SizeConfig } from '../../../../utils/dataTypes';
+import { AggregateType, DataStream, SizeConfig } from '../../../../utils/dataTypes';
 import { WidgetConfigurationUpdate, Threshold } from '../../common/types';
 import { breachedThreshold } from '../../common/annotations/breachedThreshold';
 import { closestPoint } from '../../sc-webgl-base-chart/activePoints';
@@ -85,7 +85,8 @@ export class ScStatusTimelineOverlay {
         }}
       >
         {this.dataStreams.map(dataStream => {
-          const point = closestPoint(getDataPoints(dataStream, dataStream.resolution), this.date, DATA_ALIGNMENT.LEFT);
+          const firstAggregateType = dataStream.aggregateTypes !== undefined ? dataStream.aggregateTypes[0] : AggregateType.AVERAGE;
+          const point = closestPoint(getDataPoints(dataStream, dataStream.resolution, firstAggregateType), this.date, DATA_ALIGNMENT.LEFT);
           const value = point ? point.y : undefined;
 
           const threshold = breachedThreshold({

--- a/packages/synchro-charts/src/components/charts/sc-tooltip/sc-tooltip-row.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-tooltip/sc-tooltip-row.tsx
@@ -7,6 +7,7 @@ import {
   STREAM_ICON_STROKE_LINECAP,
   STREAM_ICON_STROKE_WIDTH,
   TREND_ICON_DASH_ARRAY,
+  AggregateType,
 } from '../../../utils/dataTypes';
 import { Value } from '../../value/Value';
 import { getAggregationFrequency } from '../../sc-data-stream-name/helper';
@@ -23,12 +24,16 @@ const AGGREGATED_LEVEL = 'average';
 export class ScTooltipRow {
   @Prop() label!: string;
   @Prop() resolution!: number | undefined;
+  @Prop() aggregateTypes?: AggregateType[] | undefined;
+  @Prop() hasIndexForFirstAggregate?: boolean | undefined;
   @Prop() color!: string;
   @Prop() point!: DataPoint | undefined;
   @Prop() showDataStreamColor!: boolean;
   @Prop() pointType!: POINT_TYPE;
   @Prop() valueColor?: string = baseColor;
   @Prop() icon?: StatusIcon;
+
+  private firstAggregateType = this.aggregateTypes && this.hasIndexForFirstAggregate ? this.aggregateTypes[0] : AggregateType.AVERAGE;
 
   render() {
     const isTrendPoint = this.pointType === POINT_TYPE.TREND;
@@ -57,7 +62,7 @@ export class ScTooltipRow {
         </span>
         {this.resolution != null && (
           <div class="awsui-util-pb-s">
-            <small>{getAggregationFrequency(this.resolution, AGGREGATED_LEVEL)}</small>
+            <small>{getAggregationFrequency(this.resolution, this.firstAggregateType)}</small>
           </div>
         )}
       </div>

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/activePoints.ts
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/activePoints.ts
@@ -1,5 +1,5 @@
 import { pointBisector, getDataBeforeDate } from '../common/dataFilters';
-import { DataPoint, DataStream, Primitive } from '../../../utils/dataTypes';
+import { AggregateType, DataPoint, DataStream, Primitive } from '../../../utils/dataTypes';
 import { sortTooltipPoints } from '../sc-tooltip/sort';
 import { getDataPoints } from '../../../utils/getDataPoints';
 import { DATA_ALIGNMENT } from '../common/constants';
@@ -111,10 +111,13 @@ export const activePoints = <T extends Primitive>({
   dataAlignment: DATA_ALIGNMENT;
   maxDurationFromDate?: number; // if no max distance present, then no max distance filter is applied on selected points
 }): ActivePoint<T>[] => {
-  const dataStreamUtilizedData = dataStreams.map(stream => ({
-    streamId: stream.id,
-    dataPoints: getDataBeforeDate(getDataPoints(stream, stream.resolution), viewport.end),
-  }));
+  const dataStreamUtilizedData = dataStreams.map(stream => {
+    const firstAggregateType = stream.aggregateTypes !== undefined ? stream.aggregateTypes[0] : AggregateType.AVERAGE;
+    return {
+      streamId: stream.id,
+      dataPoints: getDataBeforeDate(getDataPoints(stream, stream.resolution, firstAggregateType), viewport.end),
+    }
+  });
   const selectedTimestamp = selectedDate.getTime();
 
   // Find the closest point to the selected date for each stream

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
@@ -14,6 +14,7 @@ import {
   ViewPortConfig,
   RequestDataFn,
   MessageOverrides,
+  AggregateType,
 } from '../../../utils/dataTypes';
 import {
   Annotations,
@@ -410,8 +411,10 @@ export class ScWebglBaseChart {
     // Filter down the data streams to only contain data within the viewport
     const inViewPoints: DataPoint<number>[] = this.dataStreams
       .filter(isNumberDataStream)
-      .map(stream =>
-        getVisibleData(getDataPoints(stream, stream.resolution), { start: this.start, end: this.end }, false)
+      .map(stream => {
+        const firstAggregateType = stream.aggregateTypes !== undefined ? stream.aggregateTypes[0] : AggregateType.AVERAGE;
+        return getVisibleData(getDataPoints(stream, stream.resolution, firstAggregateType), { start: this.start, end: this.end }, false)
+      }
       )
       .flat();
 
@@ -819,7 +822,8 @@ export class ScWebglBaseChart {
     const hasNoDataStreamsPresent = this.visualizedDataStreams().length === 0;
 
     const hasNoDataPresent = this.visualizedDataStreams().every(stream => {
-      const points = getDataPoints(stream, stream.resolution);
+      const firstAggregateType = stream.aggregateTypes !== undefined ? stream.aggregateTypes[0] : AggregateType.AVERAGE;
+      const points = getDataPoints(stream, stream.resolution, firstAggregateType);
       if (points.length === 0) {
         return true;
       }

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/utils.ts
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/utils.ts
@@ -2,7 +2,7 @@ import { Mesh, OrthographicCamera, Scene } from 'three';
 import uuid from 'uuid/v4';
 import { ChartScene } from '../../sc-webgl-context/types';
 import { getDataPoints } from '../../../utils/getDataPoints';
-import { DataStream, Primitive, Resolution, ViewPort } from '../../../utils/dataTypes';
+import { AggregateType, DataStream, Primitive, Resolution, ViewPort } from '../../../utils/dataTypes';
 import { getCSSColorByString } from '../common/getCSSColorByString';
 
 /**
@@ -17,7 +17,8 @@ export const vertices = <T extends Primitive>(
   resolution: Resolution
 ): [number, T, number, number, number][] => {
   const [r, g, b] = getCSSColorByString(stream.color || 'black');
-  return getDataPoints(stream, resolution).map(p => [p.x, p.y, r, g, b]);
+  const firstAggregateType = stream.aggregateTypes !== undefined ? stream.aggregateTypes[0] : AggregateType.AVERAGE;
+  return getDataPoints(stream, resolution, firstAggregateType).map(p => [p.x, p.y, r, g, b]);
 };
 
 // The max and minimum z value an entity may have and still be present.
@@ -130,5 +131,10 @@ export const constructChartScene = ({
  *
  * Total data points across all data streams
  */
-export const numDataPoints = <T extends Primitive>(dataStreams: DataStream<T>[]): number =>
-  dataStreams.map(stream => getDataPoints(stream, stream.resolution).length).reduce((total, num) => total + num, 0);
+
+export const numDataPoints = <T extends Primitive>(dataStreams: DataStream<T>[]): number => {
+  return dataStreams.map(stream => {
+    const firstAggregateType = stream.aggregateTypes !== undefined ? stream.aggregateTypes[0] : AggregateType.AVERAGE;
+    return getDataPoints(stream, stream.resolution, firstAggregateType).length;
+  }).reduce((total, num) => total + num, 0);
+}

--- a/packages/synchro-charts/src/index.ts
+++ b/packages/synchro-charts/src/index.ts
@@ -5,3 +5,4 @@ export type { Components, JSX } from './components';
 
 export { getThresholds } from './components/charts/common/annotations/utils';
 export { breachedThreshold } from './components/charts/common/annotations/breachedThreshold';
+export { getDataPoints } from './utils/getDataPoints';

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-line-chart-dynamic-data-streams.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-line-chart-dynamic-data-streams.tsx
@@ -1,7 +1,7 @@
 import { Component, h, State } from '@stencil/core';
 import { Y_VALUE } from './constants';
-import { MINUTE_IN_MS } from '../../../utils/time';
-import { DataStream } from '../../../utils/dataTypes';
+import { MINUTE_IN_MS, HOUR_IN_MS } from '../../../utils/time';
+import { DataStream, AggregateType } from '../../../utils/dataTypes';
 import { DataType } from '../../../utils/dataConstants';
 
 // viewport boundaries
@@ -54,18 +54,48 @@ export class ScWebglLineChartDynamicDataStreams {
       ...this.dataStreams,
     ];
   };
-
+  addStream2 = () => {
+    const leftPoint = {
+      x: LEFT_X,
+      y: 5000 * Math.random(),
+    };
+    const middlePoint = {
+      x: MIDDLE_X,
+      y: 5000 * Math.random(),
+    };
+    const rightPoint = {
+      x: RIGHT_X,
+      y: 5000 * Math.random(),
+    };
+    const streamId = `stream-${this.dataStreams.length + 1}`;
+    this.dataStreams = [
+      {
+        id: streamId,
+        color: 'red',
+        name: `${streamId}-name`,
+        aggregates: { [HOUR_IN_MS]: {["maximum"]: [leftPoint, middlePoint, rightPoint] }},
+        data: [],
+        resolution: HOUR_IN_MS,
+        dataType: DataType.NUMBER,
+        aggregateTypes: [AggregateType.MAXIMUM, AggregateType.MINIMUM],
+      },
+      ...this.dataStreams,
+    ];
+  };
   removeStream = () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [_firstStream, ...restStreams] = this.dataStreams;
     this.dataStreams = restStreams;
   };
-
+  
   render() {
     return (
       <div>
         <button id="add-stream" onClick={this.addStream}>
           Add Stream
+        </button>
+        <button id="add-stream2" onClick={this.addStream2}>
+          Add Random Stream
         </button>
         <button id="remove-stream" onClick={this.removeStream}>
           Remove Stream

--- a/packages/synchro-charts/src/utils/dataTypes.ts
+++ b/packages/synchro-charts/src/utils/dataTypes.ts
@@ -35,6 +35,18 @@ export type TableColumn = {
 };
 
 /**
+ * Used to keep track of the aggregate type of a data stream.
+ */
+ export enum AggregateType {
+  AVERAGE = 'average',
+  COUNT = 'count',
+  MAXIMUM = 'maxiumum',
+  MINIMUM = 'minimum',
+  SUM = 'sum',
+  STANDARD_DEVIATION = 'standard deviation',
+}
+
+/**
  * Data Stream Info
  *
  * A view model representation of a data stream.

--- a/packages/synchro-charts/src/utils/dataTypes.ts
+++ b/packages/synchro-charts/src/utils/dataTypes.ts
@@ -40,7 +40,7 @@ export type TableColumn = {
  export enum AggregateType {
   AVERAGE = 'average',
   COUNT = 'count',
-  MAXIMUM = 'maxiumum',
+  MAXIMUM = 'maximum',
   MINIMUM = 'minimum',
   SUM = 'sum',
   STANDARD_DEVIATION = 'standard deviation',
@@ -62,6 +62,7 @@ export interface DataStreamInfo {
   detailedName?: string;
   streamType?: StreamType;
   associatedStreams?: StreamAssociation[];
+  aggregateTypes?: AggregateType[];
 }
 
 /**
@@ -236,12 +237,13 @@ export interface DataStream<T extends Primitive = Primitive> extends DataStreamI
 
   // Collection of various aggregates available for the data stream
   aggregates?: {
-    [resolution: number]: DataPoint<T>[] | undefined;
+    [resolution: number]: (DataPoint<T>[] | { [aggregationType: string] : DataPoint<T>[] | undefined } | undefined);
   };
 
   dataType: DataType;
   streamType?: StreamType;
   associatedStreams?: StreamAssociation[];
+  aggregateTypes?: AggregateType[];
   isLoading?: boolean;
   isRefreshing?: boolean;
   error?: string;

--- a/packages/synchro-charts/src/utils/dataTypes.ts
+++ b/packages/synchro-charts/src/utils/dataTypes.ts
@@ -37,14 +37,7 @@ export type TableColumn = {
 /**
  * Used to keep track of the aggregate type of a data stream.
  */
- export enum AggregateType {
-  AVERAGE = 'average',
-  COUNT = 'count',
-  MAXIMUM = 'maximum',
-  MINIMUM = 'minimum',
-  SUM = 'sum',
-  STANDARD_DEVIATION = 'standard deviation',
-}
+ export type AggregateType = "average"|"count"|"maximum"|"minimum"|"sum"|"standard_deviation"|string;
 
 /**
  * Data Stream Info
@@ -190,6 +183,7 @@ export type MessageOverrides = {
   /** no data present - msg displayed when no streams have any data */
   noDataPresentHeader?: string;
   noDataPresentSubHeader?: string;
+  aggregateLabels?: {average: string, sum: string, count: string, maximum: string, minimum: string, standard_deviation: string};
 };
 export const DEFAULT_MESSAGE_OVERRIDES: Required<MessageOverrides> = {
   liveTimeFrameValueLabel: 'Value',
@@ -197,7 +191,8 @@ export const DEFAULT_MESSAGE_OVERRIDES: Required<MessageOverrides> = {
   noDataStreamsPresentHeader: 'No properties or alarms',
   noDataStreamsPresentSubHeader: "This widget doesn't have any properties or alarms.",
   noDataPresentHeader: 'No data',
-  noDataPresentSubHeader: "There's no data to display for this time range.",
+  noDataPresentSubHeader: "There's no data to display for this time range." ,
+  aggregateLabels: {average: 'average', sum: 'sum', count: 'count', maximum: 'maximum', minimum: 'minimum', standard_deviation: 'standard deviation'},
 };
 
 /** SVG Constants */

--- a/packages/synchro-charts/src/utils/getDataPoints.ts
+++ b/packages/synchro-charts/src/utils/getDataPoints.ts
@@ -3,7 +3,7 @@ import { AggregateType, DataPoint, DataStream, Primitive, Resolution } from './d
 /**
  * Get the points for a given resolution (and an optional aggregate type) from a data stream
  */
-export const getDataPoints = <T extends Primitive>(stream: DataStream<T>, resolution: Resolution, aggregateType?: AggregateType | undefined): DataPoint<T>[] => {
+ export const getDataPoints = <T extends Primitive>(stream: DataStream<T>, resolution: Resolution, aggregateType?: AggregateType): DataPoint<T>[] => {
   if (resolution === 0) {
     return stream.data;
   }
@@ -17,21 +17,17 @@ export const getDataPoints = <T extends Primitive>(stream: DataStream<T>, resolu
   }
 
   // if no aggregate type was specified
-  if (!aggregateType && stream.aggregates[resolution] != undefined) {
-    const datapoints = stream.aggregates[resolution] as DataPoint<T>[] | { [aggregationType: string] : DataPoint<T>[] | undefined };
-    if (datapoints[AggregateType.AVERAGE] != undefined) {
-      return datapoints[AggregateType.AVERAGE];
+  if (!aggregateType && stream.aggregates[resolution] != null) {
+    const datapoints = stream.aggregates[resolution];
+
+    if (datapoints != null && !Array.isArray(datapoints) && datapoints.average != null) {
+      return datapoints.average;
     }
-    else if (datapoints != undefined &&
-      !datapoints[AggregateType.AVERAGE] &&
-      !datapoints[AggregateType.MINIMUM] &&
-      !datapoints[AggregateType.MAXIMUM] &&
-      !datapoints[AggregateType.SUM] &&
-      !datapoints[AggregateType.COUNT] &&
-      !datapoints[AggregateType.STANDARD_DEVIATION]
-      ) {
+
+    if (datapoints != null && Array.isArray(datapoints)) {
         return datapoints as DataPoint<T>[] || [];
     }
+
     return [];
   }
 
@@ -41,17 +37,12 @@ export const getDataPoints = <T extends Primitive>(stream: DataStream<T>, resolu
     if (datapoints[aggregateType] != undefined) {
       return datapoints[aggregateType];
     }
-    else if (datapoints != undefined &&
-      !datapoints[AggregateType.AVERAGE] &&
-      !datapoints[AggregateType.MINIMUM] &&
-      !datapoints[AggregateType.MAXIMUM] &&
-      !datapoints[AggregateType.SUM] &&
-      !datapoints[AggregateType.COUNT] &&
-      !datapoints[AggregateType.STANDARD_DEVIATION]
-      ) {
+
+    if (datapoints != null && Array.isArray(datapoints)) {
         return datapoints as DataPoint<T>[] || [];
     }
     return [];
   }
+
   return stream.aggregates[resolution] as DataPoint<T>[] || [];
 };

--- a/packages/synchro-charts/src/utils/getDataPoints.ts
+++ b/packages/synchro-charts/src/utils/getDataPoints.ts
@@ -1,9 +1,9 @@
-import { DataPoint, DataStream, Primitive, Resolution } from './dataTypes';
+import { AggregateType, DataPoint, DataStream, Primitive, Resolution } from './dataTypes';
 
 /**
- * Get the points for a given resolution from a data stream
+ * Get the points for a given resolution (and an optional aggregate type) from a data stream
  */
-export const getDataPoints = <T extends Primitive>(stream: DataStream<T>, resolution: Resolution): DataPoint<T>[] => {
+export const getDataPoints = <T extends Primitive>(stream: DataStream<T>, resolution: Resolution, aggregateType?: AggregateType | undefined): DataPoint<T>[] => {
   if (resolution === 0) {
     return stream.data;
   }
@@ -12,5 +12,46 @@ export const getDataPoints = <T extends Primitive>(stream: DataStream<T>, resolu
     return [];
   }
 
-  return stream.aggregates[resolution] || [];
+  if (!stream.aggregates[resolution]) {
+    return [];
+  }
+
+  // if no aggregate type was specified
+  if (!aggregateType && stream.aggregates[resolution] != undefined) {
+    const datapoints = stream.aggregates[resolution] as DataPoint<T>[] | { [aggregationType: string] : DataPoint<T>[] | undefined };
+    if (datapoints[AggregateType.AVERAGE] != undefined) {
+      return datapoints[AggregateType.AVERAGE];
+    }
+    else if (datapoints != undefined &&
+      !datapoints[AggregateType.AVERAGE] &&
+      !datapoints[AggregateType.MINIMUM] &&
+      !datapoints[AggregateType.MAXIMUM] &&
+      !datapoints[AggregateType.SUM] &&
+      !datapoints[AggregateType.COUNT] &&
+      !datapoints[AggregateType.STANDARD_DEVIATION]
+      ) {
+        return datapoints as DataPoint<T>[] || [];
+    }
+    return [];
+  }
+
+  // if an aggregate type was specified
+  if (aggregateType && stream.aggregates[resolution] != undefined) {
+    const datapoints = stream.aggregates[resolution] as DataPoint<T>[] | { [aggregationType: string] : DataPoint<T>[] | undefined };
+    if (datapoints[aggregateType] != undefined) {
+      return datapoints[aggregateType];
+    }
+    else if (datapoints != undefined &&
+      !datapoints[AggregateType.AVERAGE] &&
+      !datapoints[AggregateType.MINIMUM] &&
+      !datapoints[AggregateType.MAXIMUM] &&
+      !datapoints[AggregateType.SUM] &&
+      !datapoints[AggregateType.COUNT] &&
+      !datapoints[AggregateType.STANDARD_DEVIATION]
+      ) {
+        return datapoints as DataPoint<T>[] || [];
+    }
+    return [];
+  }
+  return stream.aggregates[resolution] as DataPoint<T>[] || [];
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Modified DatastreamInfo and Datastream APIs to support aggregate types. Added tooltip support for displaying aggregate types (it used to display 'average' for every aggregate type).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
