### PR TITLE
Fix copy-styles command

### DIFF
--- a/packages/synchro-charts-react/package.json
+++ b/packages/synchro-charts-react/package.json
@@ -10,7 +10,7 @@
     "build": "tsc --outDir dist",
     "clean": "rm -rf dist *.tsbuildinfo",
     "release": "yarn build",
-    "copy-styles": "cp node_modules/@synchro-charts/core/dist/synchro-charts/synchro-charts.css src/styles.css",
+    "copy-styles": "cp ../../node_modules/@synchro-charts/core/dist/synchro-charts/synchro-charts.css src/styles.css",
     "prepublish": "yarn run build && yarn run copy-styles",
     "pack": "yarn pack"
   },


### PR DESCRIPTION
## Overview
Fix copy-styles command. Had wrong path to styles.

## Tests
https://github.com/awslabs/synchro-charts/actions/runs/1330293462

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
