### PR TITLE
[Draft] onContextInitialization

### DIFF
--- a/packages/doc-site/docs/webglContext.md
+++ b/packages/doc-site/docs/webglContext.md
@@ -42,6 +42,20 @@ Ensure that the position of the `<sc-webgl-context />` is correct
 
  More information about rendering HTML elements in the correct order within [Mozilla's documentation on stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context)
 
+### Accessing the WebGL Context
+
+It can be useful to have direct access to the underlying WebGL context for purposes such as debugging.
+
+The `<sc-webgl-context />` web component has a functional prop `onContextInitialization` that is called with a `WebGLRenderingContext` after initialization.
+
+```jsx static
+<sc-webgl-context onContextInitialization={(context) => {
+   // your code
+}} />
+```
+
+This callback can be used to, for example, instrument your development environment with tools such as [WebGL Lint](https://github.com/greggman/webgl-lint).
+
 ### Current pitfalls and issues
 
 1. Visualization clips on bottom 16px of screen

--- a/packages/synchro-charts/src/components.d.ts
+++ b/packages/synchro-charts/src/components.d.ts
@@ -532,6 +532,7 @@ export namespace Components {
     interface ScWebglChartTooltipWithMultipleDataStreams {
     }
     interface ScWebglContext {
+        "onContextInitialization": (context: WebGLRenderingContext) => void;
     }
     interface ScWebglLineChartDynamicBuffer {
     }
@@ -1937,6 +1938,7 @@ declare namespace LocalJSX {
     interface ScWebglChartTooltipWithMultipleDataStreams {
     }
     interface ScWebglContext {
+        "onContextInitialization"?: (context: WebGLRenderingContext) => void;
     }
     interface ScWebglLineChartDynamicBuffer {
     }

--- a/packages/synchro-charts/src/components/sc-webgl-context/sc-webgl-context.tsx
+++ b/packages/synchro-charts/src/components/sc-webgl-context/sc-webgl-context.tsx
@@ -1,4 +1,4 @@
-import { h, Element, Component } from '@stencil/core';
+import { h, Element, Component, Prop } from '@stencil/core';
 import { webGLRenderer } from './webglContext';
 
 @Component({
@@ -8,10 +8,11 @@ import { webGLRenderer } from './webglContext';
 })
 export class ScWebglContext {
   @Element() el!: HTMLElement;
+  @Prop() onContextInitialization: (context: WebGLRenderingContext) => void;
 
   componentDidLoad() {
     const canvas = this.el.querySelector('canvas') as HTMLCanvasElement;
-    webGLRenderer.initRendering(canvas);
+    webGLRenderer.initRendering(canvas, this.onContextInitialization);
   }
 
   render() {

--- a/packages/synchro-charts/src/components/sc-webgl-context/webglContext.spec.ts
+++ b/packages/synchro-charts/src/components/sc-webgl-context/webglContext.spec.ts
@@ -18,7 +18,7 @@ const testDomRect: DOMRect = {
   toJSON: () => '{}',
 };
 
-export const createTestWebglRenderer = (domRect: DOMRect, skipInit = false) => {
+export const createTestWebglRenderer = (domRect: DOMRect, skipInit = false, onContextInitialization?: () => void) => {
   const webGLRenderer = createWebGLRenderer(new ViewportHandler());
   // @ts-ignore
   const canvas = new HTMLCanvasElement(domRect.width, domRect.height);
@@ -27,7 +27,7 @@ export const createTestWebglRenderer = (domRect: DOMRect, skipInit = false) => {
   canvas.getBoundingClientRect = () => domRect;
 
   if (!skipInit) {
-    webGLRenderer.initRendering(canvas);
+    webGLRenderer.initRendering(canvas, onContextInitialization);
   }
 
   return webGLRenderer;
@@ -175,5 +175,19 @@ describe('when not initialized', () => {
     expect(() => {
       webGLRenderer.addChartScene({ manager: chartScene });
     }).not.toThrowError();
+  });
+});
+
+describe('on initialization', () => {
+  it('calls custom onContextInitialization if provided', () => {
+    const mockOnContextInitialization = jest.fn();
+    createTestWebglRenderer(testDomRect, false, mockOnContextInitialization);
+    expect(mockOnContextInitialization).toBeCalledTimes(1);
+    expect(mockOnContextInitialization).toBeCalledWith(
+      expect.objectContaining({
+        drawingBufferHeight: 500,
+        drawingBufferWidth: 500,
+      })
+    );
   });
 });

--- a/packages/synchro-charts/src/components/sc-webgl-context/webglContext.ts
+++ b/packages/synchro-charts/src/components/sc-webgl-context/webglContext.ts
@@ -139,10 +139,15 @@ export const createWebGLRenderer = (viewportHandler: ViewportHandler<ViewPortMan
     }
   };
 
-  const initRendering = (renderCanvas: HTMLCanvasElement) => {
+  const initRendering = (
+    renderCanvas: HTMLCanvasElement,
+    onContextInitialization: (context: WebGLRenderingContext) => void = () => {}
+  ) => {
     rectMap = new ClipSpaceRectMap(renderCanvas);
     canvas = renderCanvas;
     renderer = new WebGLRenderer({ canvas, alpha: true, antialias: true, preserveDrawingBuffer: true });
+
+    onContextInitialization(renderer.getContext());
 
     // Enable scissor test, which allows us to render our visualizations to a subset of the canvas
     // https://threejs.org/docs/#api/en/renderers/WebGLRenderer.setScissor


### PR DESCRIPTION
## Overview
Currently, synchro-charts library users don't have access to the underlying WebGLRenderingContext. Being able to configure this context object is important for debugging - see utilities such as [WebGL Lint](https://greggman.github.io/webgl-lint/) and [WebGLDeveloperTools](https://github.com/KhronosGroup/WebGLDeveloperTools).

This proposed change adds an `onContextInitialization` hook that allows users to pass in their own callbacks that is able to access context post-initialization.

## Tests
https://github.com/boweihan/synchro-charts/actions/runs/1400137561

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
