### PR TITLE
[CI/CD] Continuously deploy documentation site on push

### DIFF
--- a/.github/workflows/deploy-doc-site.yml
+++ b/.github/workflows/deploy-doc-site.yml
@@ -1,0 +1,19 @@
+name: Deploy Documentation Site
+on: [push]
+jobs:
+  deploy-documentation-site:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install and Build
+        run: |
+          yarn install
+          yarn build
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@4.1.5
+        with:
+          branch: docs-cd
+          folder: docs

--- a/packages/doc-site/README.md
+++ b/packages/doc-site/README.md
@@ -28,18 +28,3 @@ In the project directory, you can run:
 - `yarn clean`
 
   Cleans up artifacts as well as the generated `docs` in the root directory.
-
-## Deployment
-To construct the correct artifacts, you will need to perform the following steps:
-
-1. Alter the `.gitignore` file at the root level of the repository, and remove the following lines:
-    - `build`
-    - `/docs/*`
-  
-   This will allow the build artifacts to be included in the commit you will construct. 
-
-2. Run `yarn build` at the root of the repository.
-
-3. Force push your branch to the `docs` branch: `git push --force origin docs`
-
-GitHub will then serve the updated artifacts as contained in the `docs` folder constructed from the build process. The update process should take less than a couple of minutes.

--- a/packages/doc-site/assets/CNAME
+++ b/packages/doc-site/assets/CNAME
@@ -1,0 +1,1 @@
+synchrocharts.com

--- a/packages/doc-site/styleguide.config.js
+++ b/packages/doc-site/styleguide.config.js
@@ -6,119 +6,123 @@ function kebabize(string) {
   }
   // uppercase after a non-uppercase or uppercase before non-uppercase
   const upper = /(?<!\p{Uppercase_Letter})\p{Uppercase_Letter}|\p{Uppercase_Letter}(?!\p{Uppercase_Letter})/gu;
-  return string.replace(upper, "-$&").replace(/^-/, "").toLowerCase();
+  return string
+    .replace(upper, '-$&')
+    .replace(/^-/, '')
+    .toLowerCase();
 }
 
 module.exports = {
-    title: 'Synchro Charts',
-    theme: {
-        fontFamily: {
-            base: '"Amazon Ember", Helvetica, Arial, sans-serif'
-        }
+  title: 'Synchro Charts',
+  theme: {
+    fontFamily: {
+      base: '"Amazon Ember", Helvetica, Arial, sans-serif',
     },
-    styleguideDir: 'app',
-    pagePerSection: true,
-    sections: [
-        {
-            name: 'Introduction',
-            content: 'docs/introduction.md',
-            exampleMode: 'hide',
-        },
-        {
-            name: 'Demo',
-            content: 'docs/demo.md',
-            exampleMode: 'hide',
-        },
-        {
-            name: 'Setup',
-            content: 'docs/setup.md',
-            exampleMode: 'hide',
-        },
-        {
-          name: 'WebGL context',
-          content: 'docs/webglContext.md',
-        },
-      {
-        name: 'Components',
-            sectionDepth: 2,
-            content: 'docs/components.md',
-            components: 'src/components/**/*.js',
-            ignore: 'src/components/chart-demo/**',
-        },
-        {
-            name: 'API',
-            content: 'docs/api.md',
-            sectionDepth: 2,
-            sections: [
-                {
-                  name: 'Properties',
-                  content: 'docs/properties.md',
-                },
-                {
-                  name: 'Events',
-                  content: 'docs/events.md',
-                },
-            ]
-        },
-        {
-            name: 'Features',
-            sectionDepth: 2,
-            content: 'docs/features.md',
-            sections: [
-                {
-                    name: 'Synchronization',
-                    content: 'docs/synchronization.md',
-                    exampleMode: 'hide',
-                },
-                {
-                  name: 'Live Mode',
-                  content: 'docs/liveMode.md',
-                },
-                {
-                    name: 'Performance',
-                    content: 'docs/performance.md',
-                    exampleMode: 'hide',
-                },
-                {
-                    name: 'Annotation',
-                    content: 'docs/annotation.md',
-                },
-                {
-                    name: 'Threshold',
-                    content: 'docs/threshold.md',
-                },
-                {
-                    name: 'Trends',
-                    content: 'docs/trendLine.md',
-                },
-                {
-                    name: 'Configuration updates',
-                    content: 'docs/widgetConfigurationUpdates.md',
-                }
-            ]
-        },
-        {
-          name: 'Contributing to Synchro Charts',
-          content: 'docs/contributing.md',
-        },
-        {
-            name: 'Limitations',
-            content: 'docs/limitations.md',
-        },
-        {
-            name: 'Accessibility',
-            content: 'docs/accessibility.md',
-        },
-        {
-            name: 'Browser Support',
-            content: 'docs/browserSupport.md',
-        }
-    ],
-    getComponentPathLine(componentPath) {
-        const name = path.basename(componentPath, '.js');
-        return `import { ${name} } from '@synchro-charts/react'; // <sc-${kebabize(name)}>`;
+  },
+  assetsDir: 'assets',
+  styleguideDir: 'app',
+  pagePerSection: true,
+  sections: [
+    {
+      name: 'Introduction',
+      content: 'docs/introduction.md',
+      exampleMode: 'hide',
     },
-    styleguideComponents: {
-        SectionsRenderer: path.join(__dirname, 'src/styleguide/Sections'),
+    {
+      name: 'Demo',
+      content: 'docs/demo.md',
+      exampleMode: 'hide',
     },
-}
+    {
+      name: 'Setup',
+      content: 'docs/setup.md',
+      exampleMode: 'hide',
+    },
+    {
+      name: 'WebGL context',
+      content: 'docs/webglContext.md',
+    },
+    {
+      name: 'Components',
+      sectionDepth: 2,
+      content: 'docs/components.md',
+      components: 'src/components/**/*.js',
+      ignore: 'src/components/chart-demo/**',
+    },
+    {
+      name: 'API',
+      content: 'docs/api.md',
+      sectionDepth: 2,
+      sections: [
+        {
+          name: 'Properties',
+          content: 'docs/properties.md',
+        },
+        {
+          name: 'Events',
+          content: 'docs/events.md',
+        },
+      ],
+    },
+    {
+      name: 'Features',
+      sectionDepth: 2,
+      content: 'docs/features.md',
+      sections: [
+        {
+          name: 'Synchronization',
+          content: 'docs/synchronization.md',
+          exampleMode: 'hide',
+        },
+        {
+          name: 'Live Mode',
+          content: 'docs/liveMode.md',
+        },
+        {
+          name: 'Performance',
+          content: 'docs/performance.md',
+          exampleMode: 'hide',
+        },
+        {
+          name: 'Annotation',
+          content: 'docs/annotation.md',
+        },
+        {
+          name: 'Threshold',
+          content: 'docs/threshold.md',
+        },
+        {
+          name: 'Trends',
+          content: 'docs/trendLine.md',
+        },
+        {
+          name: 'Configuration updates',
+          content: 'docs/widgetConfigurationUpdates.md',
+        },
+      ],
+    },
+    {
+      name: 'Contributing to Synchro Charts',
+      content: 'docs/contributing.md',
+    },
+    {
+      name: 'Limitations',
+      content: 'docs/limitations.md',
+    },
+    {
+      name: 'Accessibility',
+      content: 'docs/accessibility.md',
+    },
+    {
+      name: 'Browser Support',
+      content: 'docs/browserSupport.md',
+    },
+  ],
+  getComponentPathLine(componentPath) {
+    const name = path.basename(componentPath, '.js');
+    return `import { ${name} } from '@synchro-charts/react'; // <sc-${kebabize(name)}>`;
+  },
+  styleguideComponents: {
+    SectionsRenderer: path.join(__dirname, 'src/styleguide/Sections'),
+  },
+};


### PR DESCRIPTION
## Overview
The documentation site for synchro-charts is currently being manually deployed. This change adds a GitHub action that does the following:

On push:
- Checks out the repo
- Installs and builds the doc site with yarn
- Deploys the `docs` folder to the `docs-cd` branch

In addition, the doc-site build has been configured to copy over a CNAME file which will help GitHub pages resolve DNS to a custom domain (in this case, `synchrocharts.com`).

## Tests
Tests - https://github.com/boweihan/synchro-charts/actions/runs/1426511854
Deployment - https://github.com/boweihan/synchro-charts/runs/4119549911?check_suite_focus=true


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
