### PR TITLE
Fix exported component types; version bump

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
     "packages": ["packages/*"],
     "npmClient": "yarn",
-    "version": "0.1.0 ",
+    "version": "1.0.3",
     "useWorkspaces": true,
     "nohoist": ["parcel-bundler"]
   }

--- a/packages/doc-site/package.json
+++ b/packages/doc-site/package.json
@@ -2,7 +2,7 @@
   "name": "@synchro-charts/doc-site",
   "description": "Synchro Charts documentation site",
   "homepage": "https://synchrocharts.com",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "private": true,
   "dependencies": {
     "@awsui/components-react": "^3.0.182",

--- a/packages/synchro-charts-react/package.json
+++ b/packages/synchro-charts-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synchro-charts/react",
   "description": "Synchro Charts React",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com/"

--- a/packages/synchro-charts/package.json
+++ b/packages/synchro-charts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synchro-charts/core",
   "description": "Synchro Charts",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com/"

--- a/packages/synchro-charts/src/components.d.ts
+++ b/packages/synchro-charts/src/components.d.ts
@@ -261,7 +261,7 @@ export namespace Components {
         /**
           * Size overrides. these will take precident over any auto-calculated sizing
          */
-        "size"?: Size;
+        "size"?: MinimalSizeConfig;
     }
     interface ScSizeProviderStandard {
     }
@@ -1661,7 +1661,7 @@ declare namespace LocalJSX {
         /**
           * Size overrides. these will take precident over any auto-calculated sizing
          */
-        "size"?: Size;
+        "size"?: MinimalSizeConfig;
     }
     interface ScSizeProviderStandard {
     }

--- a/packages/synchro-charts/src/components/sc-size-provider/sc-size-provider.tsx
+++ b/packages/synchro-charts/src/components/sc-size-provider/sc-size-provider.tsx
@@ -5,11 +5,7 @@ import { rectScrollFixed } from '../common/webGLPositioning';
 import { RectScrollFixed } from '../../utils/types';
 import { renderChild } from './renderChild';
 import { webGLRenderer } from '../sc-webgl-context/webglContext';
-
-type Size = {
-  width: number;
-  height: number;
-};
+import { MinimalSizeConfig } from '../../utils/dataTypes';
 
 /**
  * The rate at which the layout will update for graphics projected onto some element.
@@ -31,7 +27,7 @@ export class ScSizeProvider {
   @Prop() renderFunc!: (rect: RectScrollFixed) => void;
 
   /** Size overrides. these will take precident over any auto-calculated sizing */
-  @Prop() size?: Size;
+  @Prop() size?: MinimalSizeConfig;
 
   /** The DOM Elements size as computed by the observer. corrected on resolution changes. */
   @State() computedSize: { width: number; height: number } | null = null;

--- a/packages/synchro-charts/src/interface.d.ts
+++ b/packages/synchro-charts/src/interface.d.ts
@@ -1,2 +1,3 @@
 export * from './models.d';
+export * from './utils/types';
 export * from './index';

--- a/packages/synchro-charts/src/utils/types.ts
+++ b/packages/synchro-charts/src/utils/types.ts
@@ -16,12 +16,3 @@ export interface StencilCSSProperty {
 // positioning within the render loop of webGL. This allows us to not have to update `Rects` at every 16ms during
 // scroll events.
 export type RectScrollFixed = Omit<DOMRect, 'toJSON'> & { density: number };
-
-// https://stackoverflow.com/a/51365037
-export type RecursivePartial<T> = {
-  [P in keyof T]?: T[P] extends (infer U)[]
-    ? RecursivePartial<U>[]
-    : T[P] extends object
-    ? RecursivePartial<T[P]>
-    : T[P];
-};


### PR DESCRIPTION
## Overview
- increasing minor versions and correcting version to be consistent across all packages
- Remove unused typescript types
- Fix size-provider such that it imports `Size`, which as an effect will fix the generation of the `components.d.ts` file which was previously generating a file with an unresolved type `Size`.

## Tests
https://github.com/awslabs/synchro-charts/runs/4155627052?check_suite_focus=true

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
