### PR TITLE
Support viewport duration updates on base charts

### DIFF
--- a/packages/synchro-charts/cypress/integration/charts/line-chart/sc-webgl-chart.spec.ts
+++ b/packages/synchro-charts/cypress/integration/charts/line-chart/sc-webgl-chart.spec.ts
@@ -282,8 +282,6 @@ describe('view port updating', () => {
   const NARROW_VIEWPORT_X_AXIS_LABEL = '12 PM'; // A label which renders when viewing the 'narrow' view port
   const WIDE_VIEWPORT_X_AXIS_LABEL = 'July'; // A label which renders when viewing the 'wide' view port
 
-  const TOGGLE_VIEWPORT_SELECTOR = '#toggle-view-port';
-
   /**
    * This ensures that when a new 'chart scene' is generated, it will still take the new viewport passed in the update.
    *
@@ -300,7 +298,7 @@ describe('view port updating', () => {
       cy.contains(WIDE_VIEWPORT_X_AXIS_LABEL).should('not.exist');
 
       /** Update viewport to wide viewport */
-      cy.get(TOGGLE_VIEWPORT_SELECTOR).click();
+      cy.get('#toggle-wide-view-port').click();
 
       /** First view port update is registered */
       cy.contains(NARROW_VIEWPORT_X_AXIS_LABEL).should('not.exist');
@@ -314,16 +312,30 @@ describe('view port updating', () => {
       cy.contains(NARROW_VIEWPORT_X_AXIS_LABEL).should('exist');
 
       /** Update viewport to wide viewport */
-      cy.get(TOGGLE_VIEWPORT_SELECTOR).click();
+      cy.get('#toggle-wide-view-port').click();
 
       /** First view port update is registered */
       cy.contains(NARROW_VIEWPORT_X_AXIS_LABEL).should('not.exist');
 
       /** Revert to original, narrow view port. This also triggers the creation of a new chart scene. */
-      cy.get(TOGGLE_VIEWPORT_SELECTOR).click();
+      cy.get('#toggle-narrow-view-port').click();
 
       /** Second view port update is registered */
       cy.contains(NARROW_VIEWPORT_X_AXIS_LABEL).should('exist');
+    });
+
+    it('takes new viewport when updated to a duration-based viewport', () => {
+      cy.visit(VIEWPORT_CHANGE_URL);
+
+      /** Has initially loaded */
+      cy.contains(NARROW_VIEWPORT_X_AXIS_LABEL).should('exist');
+
+      /** Update viewport to five minute duration viewport */
+      cy.get('#toggle-five-minute-view-port').click();
+
+      /** Neither narrow or wide labels should be available on duration-based viewports */
+      cy.contains(NARROW_VIEWPORT_X_AXIS_LABEL).should('not.exist');
+      cy.contains(WIDE_VIEWPORT_X_AXIS_LABEL).should('not.exist');
     });
   });
 });

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.spec.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.spec.tsx
@@ -163,6 +163,10 @@ describe('legend', () => {
 });
 
 describe('chart scene management', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
   const BUFFER_FACTOR = 2;
   const MIN_BUFFER_SIZE = 100;
   const DATA_STREAMS = [
@@ -209,6 +213,67 @@ describe('chart scene management', () => {
 
       expect(webGLRenderer.stopTick).toBeCalledTimes(1);
       expect(webGLRenderer.startTick).toBeCalledTimes(1);
+    });
+  });
+
+  describe('on viewport change', () => {
+    it('restarts the time loop for the current chart when duration is changed', async () => {
+      const { chart, page } = await newChartSpecPage({
+        viewport: {
+          duration: 1000,
+        },
+      });
+
+      update(chart, {
+        viewport: {
+          duration: '5m',
+        },
+      });
+
+      await page.waitForChanges();
+
+      expect(webGLRenderer.stopTick).toBeCalledTimes(1);
+      expect(webGLRenderer.startTick).toBeCalledTimes(1);
+    });
+
+    it('restarts the time loop for the current chart when viewport is changed from static to live', async () => {
+      const { chart, page } = await newChartSpecPage({
+        viewport: {
+          start: new Date(2000, 0, 0),
+          end: new Date(2000, 0, 1),
+        },
+      });
+
+      update(chart, {
+        viewport: {
+          duration: '5m',
+        },
+      });
+
+      await page.waitForChanges();
+
+      expect(webGLRenderer.stopTick).toBeCalledTimes(1);
+      expect(webGLRenderer.startTick).toBeCalledTimes(1);
+    });
+
+    it('does not adjust time loop for the current chart when viewport is changed from live to static', async () => {
+      const { chart, page } = await newChartSpecPage({
+        viewport: {
+          duration: '5m',
+        },
+      });
+
+      update(chart, {
+        viewport: {
+          start: new Date(2000, 0, 0),
+          end: new Date(2000, 0, 1),
+        },
+      });
+
+      await page.waitForChanges();
+
+      expect(webGLRenderer.stopTick).toBeCalledTimes(0);
+      expect(webGLRenderer.startTick).toBeCalledTimes(0);
     });
   });
 

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
@@ -299,6 +299,7 @@ export class ScWebglBaseChart {
 
     const { duration } = this.activeViewPort();
     if (this.scene != null && duration != null) {
+      webGLRenderer.stopTick({ manager: this.scene });
       webGLRenderer.startTick({ manager: this.scene, duration, chartSize: this.chartSizeConfig() });
     }
   }

--- a/packages/synchro-charts/src/testing/test-routes/charts/line-chart-viewport-change.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/line-chart-viewport-change.tsx
@@ -15,21 +15,38 @@ const WIDE_VIEWPORT: MinimalViewPortConfig = {
   group: VIEWPORT_GROUP,
 };
 
+const FIVE_MINUTE_VIEWPORT: MinimalViewPortConfig = {
+  duration: '5m',
+};
+
+const THIRTY_MINUTE_VIEWPORT: MinimalViewPortConfig = {
+  duration: '30m',
+};
+
 @Component({
   tag: 'line-chart-viewport-change',
 })
 export class LineChartViewportChange {
   @State() viewport: MinimalViewPortConfig = NARROW_VIEWPORT;
 
-  toggleViewPort = () => {
-    this.viewport = this.viewport !== NARROW_VIEWPORT ? NARROW_VIEWPORT : WIDE_VIEWPORT;
+  setViewPort = viewport => {
+    this.viewport = viewport;
   };
 
   render() {
     return (
       <div>
-        <button id="toggle-view-port" onClick={this.toggleViewPort}>
-          use {this.viewport === NARROW_VIEWPORT ? 'wide' : 'narrow'} viewport
+        <button id="toggle-narrow-view-port" onClick={() => this.setViewPort(NARROW_VIEWPORT)}>
+          use narrow viewport
+        </button>
+        <button id="toggle-wide-view-port" onClick={() => this.setViewPort(WIDE_VIEWPORT)}>
+          use wide viewport
+        </button>
+        <button id="toggle-five-minute-view-port" onClick={() => this.setViewPort(FIVE_MINUTE_VIEWPORT)}>
+          use 5 minute viewport
+        </button>
+        <button id="toggle-thirty-moinute-view-port" onClick={() => this.setViewPort(THIRTY_MINUTE_VIEWPORT)}>
+          use 30 minute viewport
         </button>
         <br />
         <br />


### PR DESCRIPTION
## Overview
Currently, when the viewport duration of a "live" base chart is updated (i.e. `{ duration: '5m'} to {duration: '10m'}`, the chart remains updated for a single tick before the new configuration gets overwritten by the old configuration.

This is happening because we are calling `webGLRenderer.startTick` to start a new time loop without first calling `webGLRenderer.stopTick`.

```typescript
// sc-webgl-base-chart.tsx - line:301
if (this.scene != null && duration != null) {
  webGLRenderer.stopTick({ manager: this.scene });  // <-- added in this PR
  webGLRenderer.startTick({ manager: this.scene, duration, chartSize: this.chartSizeConfig() });
}

// viewportHandler.ts - line:45
if (liveIdKey in this.viewportLiveId) {
  return; // duration update not registered to the ticker
}
```

This CR ensures we call stopTick before trying to call startTick on duration updates.

## Tests
https://github.com/boweihan/synchro-charts/actions/runs/1559597572

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
