### PR TITLE
fix: prevent status-timeline from regenerating new viewport on every render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.0.8 (2022-01-11)
+
+
+### Bug Fixes
+
+* prevent status-timeline from regenerating new viewport on every render ([de1a90e](https://github.com/awslabs/synchro-charts/commit/de1a90e21b44e4baefef167d0321841e8304d9ba))
+
+
+
+
+
 ## 1.0.7 (2021-12-14)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*"
     ],
     "npmClient": "yarn",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "useWorkspaces": true,
     "nohoist": [
         "parcel-bundler"

--- a/packages/doc-site/CHANGELOG.md
+++ b/packages/doc-site/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.0.8 (2022-01-11)
+
+**Note:** Version bump only for package @synchro-charts/doc-site
+
+
+
+
+
 ## 1.0.7 (2021-12-14)
 
 **Note:** Version bump only for package @synchro-charts/doc-site

--- a/packages/doc-site/package.json
+++ b/packages/doc-site/package.json
@@ -2,12 +2,12 @@
   "name": "@synchro-charts/doc-site",
   "description": "Synchro Charts documentation site",
   "homepage": "https://synchrocharts.com",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "dependencies": {
     "@awsui/components-react": "^3.0.182",
-    "@synchro-charts/core": "^1.0.7",
-    "@synchro-charts/react": "^1.0.7",
+    "@synchro-charts/core": "^1.0.8",
+    "@synchro-charts/react": "^1.0.8",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.4"

--- a/packages/synchro-charts-react/CHANGELOG.md
+++ b/packages/synchro-charts-react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.0.8 (2022-01-11)
+
+**Note:** Version bump only for package @synchro-charts/react
+
+
+
+
+
 ## 1.0.7 (2021-12-14)
 
 **Note:** Version bump only for package @synchro-charts/react

--- a/packages/synchro-charts-react/package.json
+++ b/packages/synchro-charts-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synchro-charts/react",
   "description": "Synchro Charts React",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "publishConfig": {
     "access": "public"
   },
@@ -35,7 +35,7 @@
     "react-dom": "16.x.x || 17.x.x"
   },
   "dependencies": {
-    "@synchro-charts/core": "^1.0.7"
+    "@synchro-charts/core": "^1.0.8"
   },
   "license": "Apache-2.0",
   "style": "dist/styles.css",

--- a/packages/synchro-charts/CHANGELOG.MD
+++ b/packages/synchro-charts/CHANGELOG.MD
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.0.8 (2022-01-11)
+
+
+### Bug Fixes
+
+* prevent status-timeline from regenerating new viewport on every render ([de1a90e](https://github.com/awslabs/synchro-charts/commit/de1a90e21b44e4baefef167d0321841e8304d9ba))
+
+
+
+
+
 ## 1.0.7 (2021-12-14)
 
 

--- a/packages/synchro-charts/package.json
+++ b/packages/synchro-charts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synchro-charts/core",
   "description": "Synchro Charts",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/synchro-charts/src/components/charts/sc-status-timeline/sc-status-timeline.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-status-timeline/sc-status-timeline.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop } from '@stencil/core';
+import { Component, h, Prop, State, Watch } from '@stencil/core';
 
 import {
   AlarmsConfig,
@@ -63,6 +63,12 @@ const tooltip = (alarms?: AlarmsConfig) => (props: Tooltip.Props) => {
   );
 };
 
+const getComponentViewport = (viewport: MinimalViewPortConfig): MinimalViewPortConfig => ({
+  ...viewport,
+  yMin: 0,
+  yMax: HEIGHT,
+});
+
 @Component({
   tag: 'sc-status-timeline',
   styleUrl: './sc-status-timeline.css',
@@ -84,6 +90,8 @@ export class ScStatusTimeline implements ChartConfig {
   @Prop() messageOverrides?: MessageOverrides;
   @Prop() alarms?: AlarmsConfig;
 
+  @State() componentViewport: MinimalViewPortConfig;
+
   /** Status */
   @Prop() isEditing: boolean = false;
   /** Memory Management */
@@ -100,6 +108,15 @@ export class ScStatusTimeline implements ChartConfig {
 
   componentWillRender() {
     validate(this);
+  }
+
+  componentWillLoad() {
+    this.componentViewport = getComponentViewport(this.viewport);
+  }
+
+  @Watch('viewport')
+  onViewportChange() {
+    this.componentViewport = getComponentViewport(this.viewport);
   }
 
   render() {
@@ -142,11 +159,7 @@ export class ScStatusTimeline implements ChartConfig {
                 size={chartSize}
                 dataStreams={this.dataStreams}
                 alarms={this.alarms}
-                viewport={{
-                  ...this.viewport,
-                  yMin: 0,
-                  yMax: HEIGHT,
-                }}
+                viewport={this.componentViewport}
                 minBufferSize={this.minBufferSize}
                 bufferFactor={this.bufferFactor}
                 isEditing={this.isEditing}


### PR DESCRIPTION

## Overview
Address a bug which was the root cause of https://github.com/awslabs/synchro-charts/issues/111 - the status timeline would 'jitter', due to a new reference being generated on every render.

* prevent `status-timeline` from creating a new viewport reference on every render
* increase version to 1.0.8

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
