### PR TITLE
fix: correct datastream documentation

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*"
     ],
     "npmClient": "yarn",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "useWorkspaces": true,
     "nohoist": [
         "parcel-bundler"

--- a/packages/doc-site/docs/properties.md
+++ b/packages/doc-site/docs/properties.md
@@ -127,13 +127,13 @@
     Raw data (non-aggregated) for the stream. Note that once `resolution` is greater than 0, then it will switch from
     reading the data from this `data` property to reading the data from the `aggregates` property.
   
-    - `x`: Date
+    - `x`: number
     
-      Represents the point in time at which the data point was measured.
+      Represents the point in time at which the data point was measured, in milliseconds since January 1, 1970 00:00:00 UTC, with leap seconds ignored. 
     
-    - `y`: number
+    - `y`: number or string or boolean 
     
-      The value measured within the data point.
+      The value measured within the data point. Type depends on the data streams `dataType`.
   
   - `resolution`: number
   
@@ -142,7 +142,7 @@
     
   - `dataType`: string
   
-    The type of data contained within this stream. Must match it's respective `dataStreamInfo`. Must be one of the following:
+    The type of data contained within this stream. Must be one of the following:
     - `NUMBER`: numerical data, such as `12.0`
     - `STRING`: string data, such as categorical data `"OK"`, `"WARNING"`, etc.
     - `BOOLEAN`: boolean data, such as `true` and `false`.
@@ -159,7 +159,7 @@
     - `resolution` (key): number
       The resolution (in milliseconds) of the data.
       
-      - data point(value): DataPoint[]
+      - data point (value): DataPoint[]
         The data points that are associated to this resolution.
         
   - `detailedName`: string

--- a/packages/doc-site/package.json
+++ b/packages/doc-site/package.json
@@ -2,12 +2,12 @@
   "name": "@synchro-charts/doc-site",
   "description": "Synchro Charts documentation site",
   "homepage": "https://synchrocharts.com",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "dependencies": {
     "@awsui/components-react": "^3.0.182",
-    "@synchro-charts/core": "^1.1.0",
-    "@synchro-charts/react": "^1.1.0",
+    "@synchro-charts/core": "^1.1.1",
+    "@synchro-charts/react": "^1.1.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.4"

--- a/packages/synchro-charts-react/package.json
+++ b/packages/synchro-charts-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synchro-charts/react",
   "description": "Synchro Charts React",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "publishConfig": {
     "access": "public"
   },
@@ -35,7 +35,7 @@
     "react-dom": "16.x.x || 17.x.x"
   },
   "dependencies": {
-    "@synchro-charts/core": "^1.1.0"
+    "@synchro-charts/core": "^1.1.1"
   },
   "license": "Apache-2.0",
   "style": "dist/styles.css",

--- a/packages/synchro-charts/package.json
+++ b/packages/synchro-charts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synchro-charts/core",
   "description": "Synchro Charts",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
@@ -97,7 +97,13 @@ export class ScWebglBaseChart {
   @Prop() visualizesAlarms: boolean;
   @Prop() displaysError: boolean = true;
   @Prop() alarms?: AlarmsConfig;
-  @Prop() shouldRerenderOnViewportChange?: ({ oldViewport, newViewport }) => boolean;
+  @Prop() shouldRerenderOnViewportChange?: ({
+    oldViewport,
+    newViewport,
+  }: {
+    oldViewport: MinimalViewPortConfig;
+    newViewport: MinimalViewPortConfig;
+  }) => boolean;
 
   /** if false, base chart will not display an empty state message when there is no data present. */
   @Prop() displaysNoDataPresentMsg?: boolean;


### PR DESCRIPTION
## Overview
Minor documentation fix around datastreams, remove references to the removed `dataStreamInfo` concept.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
