### PR TITLE
feat: Deploy docs only on push to main

### DIFF
--- a/.github/workflows/deploy-doc-site.yml
+++ b/.github/workflows/deploy-doc-site.yml
@@ -1,5 +1,8 @@
 name: Deploy Documentation Site
-on: [push]
+on:
+  push:
+    branches:
+      - main
 jobs:
   deploy-documentation-site:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## Overview
Deploy docs only on push to main

## Tests
none

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
