### PR TITLE
Remove prevent propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 # 3.0.0 (2022-02-27)
 
 
-### Features
+### Breaking changes
 
-* remove preventPropagation flag ([04b3d1f](https://github.com/awslabs/synchro-charts/commit/04b3d1f2b9798fb52ebc5644dfbf47cf0f5a0afa))
+* remove preventPropagation flag ([04b3d1f](https://github.com/awslabs/synchro-charts/commit/04b3d1f2b9798fb52ebc5644dfbf47cf0f5a0afa)) This will alter the behavior of how `dateRangeChange` events are emitted, so that each widget will emit a `dateRangeEvent` within a group, rather than just the widget which has the gesture acted upon.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 3.0.0 (2022-02-27)
+
+
+### Features
+
+* remove preventPropagation flag ([04b3d1f](https://github.com/awslabs/synchro-charts/commit/04b3d1f2b9798fb52ebc5644dfbf47cf0f5a0afa))
+
+
+
+
+
 ## 1.0.8 (2022-01-11)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*"
     ],
     "npmClient": "yarn",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "useWorkspaces": true,
     "nohoist": [
         "parcel-bundler"

--- a/packages/synchro-charts/CHANGELOG.MD
+++ b/packages/synchro-charts/CHANGELOG.MD
@@ -6,9 +6,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 # 3.0.0 (2022-02-27)
 
 
-### Features
+### Breaking changes
 
-* remove preventPropagation flag ([04b3d1f](https://github.com/awslabs/synchro-charts/commit/04b3d1f2b9798fb52ebc5644dfbf47cf0f5a0afa))
+* remove preventPropagation flag ([04b3d1f](https://github.com/awslabs/synchro-charts/commit/04b3d1f2b9798fb52ebc5644dfbf47cf0f5a0afa)) This will alter the behavior of how `dateRangeChange` events are emitted, so that each widget will emit a `dateRangeEvent` within a group, rather than just the widget which has the gesture acted upon.
 
 
 

--- a/packages/synchro-charts/CHANGELOG.MD
+++ b/packages/synchro-charts/CHANGELOG.MD
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 3.0.0 (2022-02-27)
+
+
+### Features
+
+* remove preventPropagation flag ([04b3d1f](https://github.com/awslabs/synchro-charts/commit/04b3d1f2b9798fb52ebc5644dfbf47cf0f5a0afa))
+
+
+
+
+
 ## 2.0.0 (2022-2-21)
 
 ### Bug Fixes

--- a/packages/synchro-charts/package.json
+++ b/packages/synchro-charts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synchro-charts/core",
   "description": "Synchro Charts",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
@@ -285,7 +285,6 @@ export class ScWebglBaseChart {
           end: this.end,
           manager: this.scene,
           duration: this.activeViewPort().duration,
-          preventPropagation: true,
         });
         this.updateAndRegisterChartScene({
           hasDataChanged: false,

--- a/packages/synchro-charts/src/components/viewportHandler/viewportHandler.spec.ts
+++ b/packages/synchro-charts/src/components/viewportHandler/viewportHandler.spec.ts
@@ -78,7 +78,7 @@ describe('syncing managers', () => {
     expect(manager2.updateViewPort).toBeCalledWith({ start: START, end: END });
   });
 
-  it('does not update any managers when propagate event is true', () => {
+  it('always updates any managers when syncViewPortGroup is called', () => {
     const groups = new ViewportHandler();
 
     const START = new Date(2000, 0, 0);
@@ -92,10 +92,10 @@ describe('syncing managers', () => {
     groups.add({ manager: manager2 });
 
     /** Sync the view port group of the first manager */
-    groups.syncViewPortGroup({ start: START, end: END, manager: manager1, preventPropagation: true });
+    groups.syncViewPortGroup({ start: START, end: END, manager: manager1 });
 
-    expect(manager1.updateViewPort).not.toBeCalled();
-    expect(manager2.updateViewPort).not.toBeCalled();
+    expect(manager1.updateViewPort).toBeCalled();
+    expect(manager2.updateViewPort).toBeCalled();
   });
 
   it('does not update manager not in same view port group', () => {

--- a/packages/synchro-charts/src/components/viewportHandler/viewportHandler.ts
+++ b/packages/synchro-charts/src/components/viewportHandler/viewportHandler.ts
@@ -135,7 +135,6 @@ export class ViewportHandler<T extends ViewPortManager> {
    * Sync all viewports sharing the group of the given chart scene, to have their viewport being at `start`,
    * and ending at `end`.
    *
-   * preventPropagation - if true, then we sync all viewports to the provided viewport. Otherwise it only updates the handlers internal state.
    * manager - the manager which is the source of this syncing
    */
   syncViewPortGroup = ({
@@ -143,13 +142,11 @@ export class ViewportHandler<T extends ViewPortManager> {
     end,
     manager,
     duration,
-    preventPropagation = false,
   }: {
     start: Date;
     end: Date;
     manager: T;
     duration?: number;
-    preventPropagation?: boolean;
   }) => {
     const key = manager.viewportGroup ? manager.viewportGroup : manager.id;
     // Either you are in a group or you are a single chart
@@ -159,24 +156,22 @@ export class ViewportHandler<T extends ViewPortManager> {
       this.stopTick({ manager, viewportGroup: manager.viewportGroup });
     }
 
-    if (!preventPropagation) {
-      const updateViewPort = (v: T) => {
-        v.updateViewPort({ start, end, duration });
-      };
+    const updateViewPort = (v: T) => {
+      v.updateViewPort({ start, end, duration });
+    };
 
-      if (manager.viewportGroup) {
-        /** Get all of the groups which belong within the viewport group */
-        const managers = this.viewportManagers.filter(({ viewportGroup: group }) => manager.viewportGroup === group);
+    if (manager.viewportGroup) {
+      /** Get all of the groups which belong within the viewport group */
+      const managers = this.viewportManagers.filter(({ viewportGroup: group }) => manager.viewportGroup === group);
 
-        /**  Sync all of the chart scenes within the viewport group. */
-        managers.forEach(updateViewPort);
-      } else {
-        /**
-         * No view port group defined, so only update the camera associated with the
-         * scene which emitted the event (no syncing of other charts.)
-         */
-        updateViewPort(manager);
-      }
+      /**  Sync all of the chart scenes within the viewport group. */
+      managers.forEach(updateViewPort);
+    } else {
+      /**
+       * No view port group defined, so only update the camera associated with the
+       * scene which emitted the event (no syncing of other charts.)
+       */
+      updateViewPort(manager);
     }
   };
 }


### PR DESCRIPTION
## Overview
* Remove preventPropagation flag so events are always propagated to all members of a viewport group
* bump major version number due to breaking behavior change

## Tests
[Unit Tests](https://github.com/awslabs/synchro-charts/runs/5346110552?check_suite_focus=true)
[Integ Tests](https://github.com/awslabs/synchro-charts/runs/5346110518?check_suite_focus=true)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
