### PR TITLE
feat: Add support for aggregated data in KPI and status grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 3.1.0 (2022-03-15)
+
+### Features
+
+* Add support for aggregated data in KPI and status grid ([e0dac46](https://github.com/awslabs/synchro-charts/commit/e0dac468c7d9c297eb520f14b2b2f71362bcbc0c))
+
+
+
+
 # 3.0.0 (2022-02-27)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*"
     ],
     "npmClient": "yarn",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "useWorkspaces": true,
     "nohoist": [
         "parcel-bundler"

--- a/packages/doc-site/CHANGELOG.md
+++ b/packages/doc-site/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 3.1.0 (2022-03-15)
+
+### Features
+
+* Add support for aggregated data in KPI and status grid ([e0dac46](https://github.com/awslabs/synchro-charts/commit/e0dac468c7d9c297eb520f14b2b2f71362bcbc0c))
+
 ## 1.0.8 (2022-01-11)
 
 **Note:** Version bump only for package @synchro-charts/doc-site

--- a/packages/doc-site/package.json
+++ b/packages/doc-site/package.json
@@ -2,12 +2,12 @@
   "name": "@synchro-charts/doc-site",
   "description": "Synchro Charts documentation site",
   "homepage": "https://synchrocharts.com",
-  "version": "2.0.0",
+  "version": "3.1.0",
   "private": true,
   "dependencies": {
     "@awsui/components-react": "^3.0.182",
     "@synchro-charts/core": "^2.0.0",
-    "@synchro-charts/react": "^2.0.0",
+    "@synchro-charts/react": "^3.1.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.4"

--- a/packages/synchro-charts-react/CHANGELOG.md
+++ b/packages/synchro-charts-react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 3.1.0 (2022-03-15)
+
+### Features
+
+* Add support for aggregated data in KPI and status grid ([e0dac46](https://github.com/awslabs/synchro-charts/commit/e0dac468c7d9c297eb520f14b2b2f71362bcbc0c))
+
+
+
 ## 1.0.8 (2022-01-11)
 
 **Note:** Version bump only for package @synchro-charts/react

--- a/packages/synchro-charts-react/package.json
+++ b/packages/synchro-charts-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synchro-charts/react",
   "description": "Synchro Charts React",
-  "version": "2.0.0",
+  "version": "3.1.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/synchro-charts/CHANGELOG.MD
+++ b/packages/synchro-charts/CHANGELOG.MD
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 3.1.0 (2022-03-15)
+
+### Features
+
+* Add support for aggregated data in KPI and status grid ([e0dac46](https://github.com/awslabs/synchro-charts/commit/e0dac468c7d9c297eb520f14b2b2f71362bcbc0c))
+
+
 # 3.0.0 (2022-02-27)
 
 

--- a/packages/synchro-charts/package.json
+++ b/packages/synchro-charts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synchro-charts/core",
   "description": "Synchro Charts",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.spec.ts
+++ b/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.spec.ts
@@ -186,7 +186,7 @@ describe('updating the viewport', () => {
   });
 });
 
-describe('live time frame', () => {
+describe('viewport with duration', () => {
   const POINT: DataPoint<number> = {
     x: ((DEFAULT_CHART_CONFIG.viewport as MinimalStaticViewport).end as Date).getTime(),
     y: 100,
@@ -392,5 +392,40 @@ describe('historical time frame', () => {
     });
 
     expect(widgetGrid.querySelector('sc-help-tooltip')).not.toBeNull();
+  });
+});
+
+describe('aggregated data', () => {
+  const POINT: DataPoint<number> = {
+    x: ((DEFAULT_CHART_CONFIG.viewport as MinimalStaticViewport).end as Date).getTime(),
+    y: 100,
+  };
+
+  it('displays aggregated data when resolution is available', async () => {
+    const { renderCell } = await widgetGridSpecPage({
+      viewport: DEFAULT_CHART_CONFIG.viewport,
+      dataStreams: [{ ...DATA_STREAM, aggregates: { [MINUTE_IN_MS]: [POINT] }, resolution: MINUTE_IN_MS }],
+    });
+
+    expect(renderCell).toBeCalledTimes(1);
+    expect(renderCell).toBeCalledWith(
+      expect.objectContaining({
+        propertyPoint: POINT,
+      } as Partial<CellOptions>)
+    );
+  });
+
+  it('does not display data when only aggregated data is available and the resolution is 0', async () => {
+    const { renderCell } = await widgetGridSpecPage({
+      viewport: DEFAULT_CHART_CONFIG.viewport,
+      dataStreams: [{ ...DATA_STREAM, aggregates: { [MINUTE_IN_MS]: [POINT] }, resolution: 0 }],
+    });
+
+    expect(renderCell).toBeCalledTimes(1);
+    expect(renderCell).toBeCalledWith(
+      expect.objectContaining({
+        propertyPoint: undefined,
+      } as Partial<CellOptions>)
+    );
   });
 });

--- a/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.tsx
+++ b/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.tsx
@@ -153,7 +153,7 @@ export class ScWidgetGrid implements ChartConfig {
         start: this.start,
         end: this.end,
       },
-      dataStreams: this.rawData(),
+      dataStreams: this.dataStreams,
       selectedDate: this.end,
       allowMultipleDates: true,
       dataAlignment: DATA_ALIGNMENT.EITHER,
@@ -167,12 +167,6 @@ export class ScWidgetGrid implements ChartConfig {
       dataStream,
       thresholds: getThresholds(this.annotations),
     });
-
-  /**
-   * return all the raw data, that is, data that has no form of aggregation ran upon it. The data represents some
-   * measurement, at a given point in time.
-   */
-  rawData = (): DataStream[] => this.dataStreams.filter(({ resolution }) => resolution === 0);
 
   render() {
     const isEnabled = this.duration != null;
@@ -205,7 +199,7 @@ export class ScWidgetGrid implements ChartConfig {
             const threshold =
               pointToEvaluateOn && infoToEvaluateOn && this.getBreachedThreshold(pointToEvaluateOn, infoToEvaluateOn);
 
-            const alarmStream = alarm && this.rawData().find(s => s.id === alarm.id);
+            const alarmStream = alarm && this.dataStreams.find(s => s.id === alarm.id);
             const primaryStream = alarm ? alarmStream : property;
 
             return (


### PR DESCRIPTION
## Overview
Support for displaying aggregated data in KPI and Status grid. Remove assumption that all alarm data must always be raw data.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
