### PR TITLE
v4.0.0: dateRangeChange, table aggregation, deprecate onRequestData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+# 4.0.0 (2022-03-25)
+
+### Bug Fixes
+
+### Breaking changes
+* emit dateRangeChange event on synchronized viewport changes ([9806222](https://github.com/awslabs/synchro-charts/commit/9806222400dc8811fa690dd697ba8b85939fcc35))
+* deprecate `onRequestData` property ([9806222](https://github.com/awslabs/synchro-charts/commit/9806222400dc8811fa690dd697ba8b85939fcc35))
+
+### Features
+
+* support aggregations in table ([8e104bb](https://github.com/awslabs/synchro-charts/commit/8e104bb7f4e8b0ede3087af6b960a222d10ed419))
+
+
+
 # 3.1.0 (2022-03-15)
 
 ### Features

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*"
     ],
     "npmClient": "yarn",
-    "version": "3.1.0",
+    "version": "4.0.0",
     "useWorkspaces": true,
     "nohoist": [
         "parcel-bundler"

--- a/packages/doc-site/CHANGELOG.md
+++ b/packages/doc-site/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 4.0.0 (2022-03-25)
+
+### Bug Fixes
+
+### Breaking changes
+* emit dateRangeChange event on synchronized viewport changes ([9806222](https://github.com/awslabs/synchro-charts/commit/9806222400dc8811fa690dd697ba8b85939fcc35))
+* deprecate `onRequestData` property ([9806222](https://github.com/awslabs/synchro-charts/commit/9806222400dc8811fa690dd697ba8b85939fcc35))
+
+### Features
+
+* support aggregations in table ([8e104bb](https://github.com/awslabs/synchro-charts/commit/8e104bb7f4e8b0ede3087af6b960a222d10ed419))
+
 # 3.1.0 (2022-03-15)
 
 ### Features

--- a/packages/doc-site/package.json
+++ b/packages/doc-site/package.json
@@ -2,12 +2,12 @@
   "name": "@synchro-charts/doc-site",
   "description": "Synchro Charts documentation site",
   "homepage": "https://synchrocharts.com",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "private": true,
   "dependencies": {
     "@awsui/components-react": "^3.0.182",
     "@synchro-charts/core": "^2.0.0",
-    "@synchro-charts/react": "^3.1.0",
+    "@synchro-charts/react": "^4.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.4"

--- a/packages/synchro-charts-react/CHANGELOG.md
+++ b/packages/synchro-charts-react/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 4.0.0 (2022-03-25)
+
+### Bug Fixes
+
+### Breaking changes
+* emit dateRangeChange event on synchronized viewport changes ([9806222](https://github.com/awslabs/synchro-charts/commit/9806222400dc8811fa690dd697ba8b85939fcc35))
+* deprecate `onRequestData` property ([9806222](https://github.com/awslabs/synchro-charts/commit/9806222400dc8811fa690dd697ba8b85939fcc35))
+
+### Features
+
+* support aggregations in table ([8e104bb](https://github.com/awslabs/synchro-charts/commit/8e104bb7f4e8b0ede3087af6b960a222d10ed419))
+
 # 3.1.0 (2022-03-15)
 
 ### Features

--- a/packages/synchro-charts-react/package.json
+++ b/packages/synchro-charts-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synchro-charts/react",
   "description": "Synchro Charts React",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/synchro-charts/CHANGELOG.MD
+++ b/packages/synchro-charts/CHANGELOG.MD
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 4.0.0 (2022-03-25)
+
+### Bug Fixes
+
+### Breaking changes
+* emit dateRangeChange event on synchronized viewport changes ([9806222](https://github.com/awslabs/synchro-charts/commit/9806222400dc8811fa690dd697ba8b85939fcc35))
+* deprecate `onRequestData` property ([9806222](https://github.com/awslabs/synchro-charts/commit/9806222400dc8811fa690dd697ba8b85939fcc35))
+
+### Features
+
+* support aggregations in table ([8e104bb](https://github.com/awslabs/synchro-charts/commit/8e104bb7f4e8b0ede3087af6b960a222d10ed419))
+
 # 3.1.0 (2022-03-15)
 
 ### Features

--- a/packages/synchro-charts/package.json
+++ b/packages/synchro-charts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synchro-charts/core",
   "description": "Synchro Charts",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/synchro-charts/src/components.d.ts
+++ b/packages/synchro-charts/src/components.d.ts
@@ -5,7 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { AlarmsConfig, DataPoint, DataStream, DataStreamInfo, MessageOverrides, MinimalSizeConfig, MinimalViewPortConfig, Primitive, RequestDataFn, SizeConfig, SizePositionConfig, TableColumn, ViewPort, ViewPortConfig } from "./utils/dataTypes";
+import { AlarmsConfig, DataPoint, DataStream, DataStreamInfo, MessageOverrides, MinimalSizeConfig, MinimalViewPortConfig, Primitive, SizeConfig, SizePositionConfig, TableColumn, ViewPort, ViewPortConfig } from "./utils/dataTypes";
 import { Annotations, Axis, LayoutConfig, Legend, LegendConfig, MovementConfig, ScaleConfig, Threshold, Tooltip, WidgetConfigurationUpdate } from "./components/charts/common/types";
 import { Trend, TrendResult } from "./components/charts/common/trends/types";
 import { DATA_ALIGNMENT, StatusIcon } from "./components/charts/common/constants";
@@ -45,7 +45,6 @@ export namespace Components {
         "messageOverrides"?: MessageOverrides;
         "minBufferSize": number;
         "movement"?: MovementConfig;
-        "requestData"?: RequestDataFn;
         "scale"?: ScaleConfig;
         "size"?: MinimalSizeConfig;
         "trends": Trend[];
@@ -179,7 +178,6 @@ export namespace Components {
         "messageOverrides"?: MessageOverrides;
         "minBufferSize": number;
         "movement"?: MovementConfig;
-        "requestData"?: RequestDataFn;
         "scale"?: ScaleConfig;
         "size"?: MinimalSizeConfig;
         "trends": Trend[];
@@ -222,7 +220,6 @@ export namespace Components {
         "messageOverrides"?: MessageOverrides;
         "minBufferSize": number;
         "movement"?: MovementConfig;
-        "requestData"?: RequestDataFn;
         "scale"?: ScaleConfig;
         "size"?: MinimalSizeConfig;
         "trends": Trend[];
@@ -312,7 +309,6 @@ export namespace Components {
         "messageOverrides"?: MessageOverrides;
         "minBufferSize": number;
         "movement"?: MovementConfig;
-        "requestData"?: RequestDataFn;
         "scale"?: ScaleConfig;
         "size"?: MinimalSizeConfig;
         /**
@@ -484,10 +480,6 @@ export namespace Components {
         "onUpdateLifeCycle"?: (viewport: ViewPortConfig) => void;
         "renderLegend": (props: Legend.Props) => HTMLElement;
         "renderTooltip": (props: Tooltip.Props) => HTMLElement;
-        /**
-          * Optionally provided callback to initiate a request for data. Used to ensure gestures emit events for request data.
-         */
-        "requestData"?: RequestDataFn;
         "shouldRerenderOnViewportChange"?: ({
     oldViewport,
     newViewport,
@@ -1451,7 +1443,6 @@ declare namespace LocalJSX {
         "messageOverrides"?: MessageOverrides;
         "minBufferSize"?: number;
         "movement"?: MovementConfig;
-        "requestData"?: RequestDataFn;
         "scale"?: ScaleConfig;
         "size"?: MinimalSizeConfig;
         "trends"?: Trend[];
@@ -1585,7 +1576,6 @@ declare namespace LocalJSX {
         "messageOverrides"?: MessageOverrides;
         "minBufferSize"?: number;
         "movement"?: MovementConfig;
-        "requestData"?: RequestDataFn;
         "scale"?: ScaleConfig;
         "size"?: MinimalSizeConfig;
         "trends"?: Trend[];
@@ -1628,7 +1618,6 @@ declare namespace LocalJSX {
         "messageOverrides"?: MessageOverrides;
         "minBufferSize"?: number;
         "movement"?: MovementConfig;
-        "requestData"?: RequestDataFn;
         "scale"?: ScaleConfig;
         "size"?: MinimalSizeConfig;
         "trends"?: Trend[];
@@ -1718,7 +1707,6 @@ declare namespace LocalJSX {
         "messageOverrides"?: MessageOverrides;
         "minBufferSize"?: number;
         "movement"?: MovementConfig;
-        "requestData"?: RequestDataFn;
         "scale"?: ScaleConfig;
         "size"?: MinimalSizeConfig;
         /**
@@ -1755,6 +1743,10 @@ declare namespace LocalJSX {
         "dataStreams": DataStream[];
         "liveModeOnlyMessage"?: string;
         "messageOverrides"?: MessageOverrides;
+        /**
+          * On view port date range change, this component emits a `dateRangeChange` event. This allows other data visualization components to sync to the same date range.
+         */
+        "onDateRangeChange"?: (event: CustomEvent<[Date, Date, string | undefined]>) => void;
         /**
           * Table column values
          */
@@ -1896,10 +1888,6 @@ declare namespace LocalJSX {
         "onWidgetUpdated"?: (event: CustomEvent<WidgetConfigurationUpdate>) => void;
         "renderLegend"?: (props: Legend.Props) => HTMLElement;
         "renderTooltip"?: (props: Tooltip.Props) => HTMLElement;
-        /**
-          * Optionally provided callback to initiate a request for data. Used to ensure gestures emit events for request data.
-         */
-        "requestData"?: RequestDataFn;
         "shouldRerenderOnViewportChange"?: ({
     oldViewport,
     newViewport,
@@ -1969,6 +1957,10 @@ declare namespace LocalJSX {
         "labelsConfig"?: LabelsConfig;
         "liveModeOnlyMessage"?: string;
         "messageOverrides"?: MessageOverrides;
+        /**
+          * On view port date range change, this component emits a `dateRangeChange` event. This allows other data visualization components to sync to the same date range.
+         */
+        "onDateRangeChange"?: (event: CustomEvent<[Date, Date, string | undefined]>) => void;
         "onWidgetUpdated"?: (event: CustomEvent<WidgetConfigurationUpdate>) => void;
         "renderCell"?: RenderCell;
         "viewport"?: MinimalViewPortConfig;

--- a/packages/synchro-charts/src/components/charts/sc-bar-chart/sc-bar-chart.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-bar-chart/sc-bar-chart.tsx
@@ -6,7 +6,6 @@ import {
   MessageOverrides,
   MinimalSizeConfig,
   MinimalViewPortConfig,
-  RequestDataFn,
 } from '../../../utils/dataTypes';
 import {
   Annotations,
@@ -52,7 +51,6 @@ export class ScBarChart implements ChartConfig {
   @Prop() gestures: boolean = true;
   @Prop() annotations: Annotations;
   @Prop() trends: Trend[];
-  @Prop() requestData?: RequestDataFn;
   @Prop() axis?: Axis.Options;
   @Prop() messageOverrides?: MessageOverrides;
 
@@ -75,7 +73,6 @@ export class ScBarChart implements ChartConfig {
             axis={this.axis}
             gestures={this.gestures}
             configId={this.widgetId}
-            requestData={this.requestData}
             legend={this.legend}
             annotations={this.annotations}
             trends={this.trends}

--- a/packages/synchro-charts/src/components/charts/sc-line-chart/sc-line-chart.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-line-chart/sc-line-chart.tsx
@@ -5,7 +5,6 @@ import {
   MessageOverrides,
   MinimalSizeConfig,
   MinimalViewPortConfig,
-  RequestDataFn,
 } from '../../../utils/dataTypes';
 import {
   Annotations,
@@ -51,7 +50,6 @@ export class ScLineChart implements ChartConfig {
   @Prop() gestures: boolean = true;
   @Prop() annotations: Annotations;
   @Prop() trends: Trend[];
-  @Prop() requestData?: RequestDataFn;
   @Prop() axis?: Axis.Options;
   @Prop() messageOverrides?: MessageOverrides;
 
@@ -75,7 +73,6 @@ export class ScLineChart implements ChartConfig {
             alarms={this.alarms}
             gestures={this.gestures}
             configId={this.widgetId}
-            requestData={this.requestData}
             legend={this.legend}
             annotations={this.annotations}
             trends={this.trends}

--- a/packages/synchro-charts/src/components/charts/sc-scatter-chart/sc-scatter-chart.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-scatter-chart/sc-scatter-chart.tsx
@@ -5,7 +5,6 @@ import {
   MessageOverrides,
   MinimalSizeConfig,
   MinimalViewPortConfig,
-  RequestDataFn,
 } from '../../../utils/dataTypes';
 import {
   Annotations,
@@ -51,7 +50,6 @@ export class ScScatterChart implements ChartConfig {
   @Prop() gestures: boolean = true;
   @Prop() annotations: Annotations;
   @Prop() trends: Trend[];
-  @Prop() requestData?: RequestDataFn;
   @Prop() axis?: Axis.Options;
   @Prop() messageOverrides?: MessageOverrides;
 
@@ -74,7 +72,6 @@ export class ScScatterChart implements ChartConfig {
             axis={this.axis}
             gestures={this.gestures}
             configId={this.widgetId}
-            requestData={this.requestData}
             legend={this.legend}
             annotations={this.annotations}
             trends={this.trends}

--- a/packages/synchro-charts/src/components/charts/sc-status-timeline/sc-status-timeline.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-status-timeline/sc-status-timeline.tsx
@@ -7,7 +7,6 @@ import {
   MinimalSizeConfig,
   MinimalViewPortConfig,
   SizeConfig,
-  RequestDataFn,
 } from '../../../utils/dataTypes';
 import {
   Annotations,
@@ -85,7 +84,6 @@ export class ScStatusTimeline implements ChartConfig {
   @Prop() widgetId!: string;
   @Prop() dataStreams!: DataStream[];
   @Prop() annotations?: Annotations;
-  @Prop() requestData?: RequestDataFn;
   @Prop() axis?: Axis.Options;
   @Prop() messageOverrides?: MessageOverrides;
   @Prop() alarms?: AlarmsConfig;
@@ -146,7 +144,6 @@ export class ScStatusTimeline implements ChartConfig {
                 }}
                 gestures={this.gestures}
                 configId={this.widgetId}
-                requestData={this.requestData}
                 annotations={{
                   ...this.annotations,
                   show: false,

--- a/packages/synchro-charts/src/components/common/constants.ts
+++ b/packages/synchro-charts/src/components/common/constants.ts
@@ -1,0 +1,3 @@
+import { SECOND_IN_MS } from '../../utils/time';
+
+export const DATE_RANGE_EMIT_EVENT_MS = 0.5 * SECOND_IN_MS;

--- a/packages/synchro-charts/src/components/sc-table/constructTableData.spec.ts
+++ b/packages/synchro-charts/src/components/sc-table/constructTableData.spec.ts
@@ -1,5 +1,5 @@
 import { constructTableData, cell, formatLiveModeOnlyMessage } from './constructTableData';
-import { DataPoint, DataStream, Primitive, TableColumn } from '../../utils/dataTypes';
+import { DataPoint, DataStream, TableColumn } from '../../utils/dataTypes';
 import { Threshold } from '../charts/common/types';
 import { DataType } from '../../utils/dataConstants';
 import { COMPARISON_OPERATOR } from '../charts/common/constants';
@@ -9,7 +9,7 @@ const tableColumn: TableColumn[] = [
   { header: 'Severity', rows: ['severity-cell-id-1'] },
   { header: 'Alarm', rows: ['alarm-cell-id-1'] },
 ];
-const DATA_STREAMS: DataStream<Primitive>[] = [
+const DATA_STREAMS: DataStream[] = [
   {
     id: 'rule-cell-id-1',
     name: 'rule',

--- a/packages/synchro-charts/src/components/sc-table/constructTableData.ts
+++ b/packages/synchro-charts/src/components/sc-table/constructTableData.ts
@@ -2,6 +2,7 @@ import { DataStream, Primitive, TableColumn } from '../../utils/dataTypes';
 import { breachedThreshold } from '../charts/common/annotations/breachedThreshold';
 import { Threshold } from '../charts/common/types';
 import { StatusIcon } from '../charts/common/constants';
+import { getDataPoints } from '../../utils/getDataPoints';
 
 export interface Cell {
   dataStream?: DataStream<Primitive>;
@@ -21,7 +22,8 @@ export const cell = (
   dataStreamId: string | undefined
 ): Cell => {
   const stream = dataStreams.find(({ id }) => id === dataStreamId);
-  const value = stream && stream.data[stream.data.length - 1] && stream.data[stream.data.length - 1].y;
+  const points = stream ? getDataPoints(stream, stream.resolution) : [];
+  const value = points[points.length - 1] && points[points.length - 1].y;
 
   const threshold =
     stream &&

--- a/packages/synchro-charts/src/components/sc-table/sc-table-cell/sc-table-cell.spec.tsx
+++ b/packages/synchro-charts/src/components/sc-table/sc-table-cell/sc-table-cell.spec.tsx
@@ -10,6 +10,7 @@ import { NO_VALUE_PRESENT } from '../../common/terms';
 import { ScErrorBadge } from '../../sc-error-badge/sc-error-badge';
 import { ScChartIcon } from '../../charts/chart-icon/sc-chart-icon';
 import { DataType } from '../../../utils/dataConstants';
+import { MINUTE_IN_MS } from '../../../utils/time';
 
 // this is mock output that passed down from `sc-table-base`
 const CELL: Cell = {
@@ -47,6 +48,25 @@ it('renders cell value', async () => {
   const { cell } = await cellSpecPage();
 
   expect(cell.innerHTML).toContain('y &lt; 30');
+});
+
+it('renders aggregated data', async () => {
+  const Y_VALUE = 1232.2;
+  const { cell } = await cellSpecPage({
+    cell: {
+      dataStream: {
+        id: 'some-id',
+        color: 'black',
+        name: 'name',
+        data: [],
+        dataType: DataType.NUMBER,
+        resolution: MINUTE_IN_MS,
+        aggregates: { [MINUTE_IN_MS]: [{ x: Date.now(), y: Y_VALUE }] },
+      },
+    },
+  });
+
+  expect(cell.innerHTML).toContain(Y_VALUE);
 });
 
 it('indicates no data is present when a data stream is present but with no data', async () => {

--- a/packages/synchro-charts/src/components/sc-table/sc-table-cell/sc-table-cell.tsx
+++ b/packages/synchro-charts/src/components/sc-table/sc-table-cell/sc-table-cell.tsx
@@ -3,6 +3,7 @@ import { Value } from '../../value/Value';
 import { Cell } from '../constructTableData';
 import { StatusIcon } from '../../charts/common/constants';
 import { Primitive } from '../../../utils/dataTypes';
+import { getDataPoints } from '../../../utils/getDataPoints';
 
 @Component({
   tag: 'sc-table-cell',
@@ -19,12 +20,14 @@ export class ScTableCell {
   value = (): Primitive | undefined => {
     const { dataStream = undefined } = this.cell || {};
 
-    if (dataStream == null || dataStream.data.length === 0) {
+    const points = dataStream ? getDataPoints(dataStream, dataStream.resolution) : [];
+
+    if (points.length === 0) {
       return undefined;
     }
 
     // data is sorted chronological, from old to more recent - making this the latest value.
-    return dataStream.data[dataStream.data.length - 1].y;
+    return points[points.length - 1].y;
   };
 
   render() {

--- a/packages/synchro-charts/src/testing/chartDescriptions/describePassedInProps.tsx
+++ b/packages/synchro-charts/src/testing/chartDescriptions/describePassedInProps.tsx
@@ -140,16 +140,5 @@ export const describePassedInProps = (newChartSpecPage: ChartSpecPage, disableLi
         expect(baseChart.axis).toEqual(AXIS);
       });
     });
-
-    describe('request data', () => {
-      it('sets the requested data', async () => {
-        const requestData = jest.fn();
-
-        const { chart } = await newChartSpecPage({ requestData });
-        const baseChart = chart.querySelector('sc-webgl-base-chart') as HTMLScWebglBaseChartElement;
-
-        expect(baseChart.requestData).toBe(requestData);
-      });
-    });
   });
 };

--- a/packages/synchro-charts/src/utils/dataTypes.ts
+++ b/packages/synchro-charts/src/utils/dataTypes.ts
@@ -245,5 +245,3 @@ export interface DataStream<T extends Primitive = Primitive> extends DataStreamI
  * a single point in time (which is an interval of time with a duration of zero).
  */
 export type Resolution = number;
-
-export type RequestDataFn = ({ start, end }: { start: Date; end: Date }) => void;


### PR DESCRIPTION

## Overview
- support aggregations in table
- emit dateRangeChange event on synchronized viewport changes: On events like pan, every widget within the `viewport.group` will now emit a `dateRangeChange` event. This is a breaking change.
- Deprecate the undocumented method, `requestData`. SynchroCharts is no longer concerned about the data requesting layer. If users want to replicate this behavior, it can be done instead by listening to the `dateRangeChange` method.
- update to version 4.0.0, due to breaking changes.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
