### PR TITLE
fix: typo in docs associatedStreams

### DIFF
--- a/packages/doc-site/docs/properties.md
+++ b/packages/doc-site/docs/properties.md
@@ -187,7 +187,7 @@
   
     (Optional) A readable human error message if the data source this data stream is associated to has an error.
   
-  - `associatedDataStreams`: Object[]
+  - `associatedStreams`: Object[]
     
     (Optional) Data streams that are associated alarms of the data streams.
 


### PR DESCRIPTION
## Overview
fix typo in associatedStreams

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
