### PR TITLE
fix: live mode when buffer size increases on webgl based charts

### DIFF
--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
@@ -718,7 +718,12 @@ export class ScWebglBaseChart {
         webGLRenderer.removeChartScene(this.scene.id);
         this.scene = updatedScene;
         const { duration } = this.activeViewPort();
-        webGLRenderer.addChartScene({ manager: updatedScene, duration, shouldSync: false });
+        webGLRenderer.addChartScene({
+          manager: updatedScene,
+          duration,
+          shouldSync: false,
+          chartSize: this.chartSizeConfig(),
+        });
         this.setChartRenderingPosition();
       }
 


### PR DESCRIPTION
## Overview
Provides a fix for https://github.com/awslabs/iot-app-kit/issues/107

When the amount of data surpasses the default buffer allocated for a chart, it must create a new chart scene with a larger amount of memory. This is the memory where vertex data is passed down into WebGL, and is used to render the WebGL portion of the chart visualization.

When the new chart scene is added in this scenario, it was incorrectly not supplying the chart size, which is required for live mode to work. This is because live mode uses the width of the chart, to determine the update frequency.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
