### PR TITLE
feat(messageOverrides): Move liveModeOnlyMessage into messageOverride…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Breaking changes
 
-* `liveModeOnlyMessage` property has been removed from components: ScKpi, ScStatusGrid, ScTable, ScTableBase, ScWidgetGrid, and moved to be a member of the `messageOverrides` property.
+* `liveModeOnlyMessage` property has been removed from components: ScKpi, ScStatusGrid, ScTable, ScTableBase, ScWidgetGrid, and moved to be a member of the `messageOverrides` property and renamed to `liveModeOnly`.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 5.0.0 (2022-06-21)
+
+### Breaking changes
+
+* `liveModeOnlyMessage` property has been removed from components: ScKpi, ScStatusGrid, ScTable, ScTableBase, ScWidgetGrid, and moved to be a member of the `messageOverrides` property.
+
+
+
+
+
 ## 4.0.1 (2022-05-19)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*"
     ],
     "npmClient": "yarn",
-    "version": "4.0.1",
+    "version": "5.0.0",
     "useWorkspaces": true,
     "nohoist": [
         "parcel-bundler"

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "test:packages": "lerna run test --stream --concurrency 1",
     "test:git": "git diff --exit-code",
     "pack": "lerna run pack",
-    "versionup:auto": "lerna version --conventional-commits --no-push --no-git-tag-version --yes",
-    "versionup:patch": "lerna version patch --conventional-commits --no-push --no-git-tag-version --yes",
-    "versionup:minor": "lerna version minor --conventional-commits --no-push --no-git-tag-version --yes",
-    "versionup:major": "lerna version major --conventional-commits --no-push --no-git-tag-version --yes",
+    "versionup:auto": "lerna version --conventional-commits --no-changelog --no-push --no-git-tag-version --yes",
+    "versionup:patch": "lerna version patch --conventional-commits --no-changelog --no-push --no-git-tag-version --yes",
+    "versionup:minor": "lerna version minor --conventional-commits --no-changelog --no-push --no-git-tag-version --yes",
+    "versionup:major": "lerna version major --conventional-commits --no-changelog --no-push --no-git-tag-version --yes",
     "publishToNpm": "lerna publish from-package --no-verify-access --yes"
   },
   "husky": {

--- a/packages/doc-site/CHANGELOG.md
+++ b/packages/doc-site/CHANGELOG.md
@@ -7,7 +7,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Breaking changes
 
-* `liveModeOnlyMessage` property has been removed from components: ScKpi, ScStatusGrid, ScTable, ScTableBase, ScWidgetGrid, and moved to be a member of the `messageOverrides` property.
+* `liveModeOnlyMessage` property has been removed from components: ScKpi, ScStatusGrid, ScTable, ScTableBase, ScWidgetGrid, and moved to be a member of the `messageOverrides` property and renamed to `liveModeOnly`.
 
 
 

--- a/packages/doc-site/CHANGELOG.md
+++ b/packages/doc-site/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 5.0.0 (2022-06-21)
+
+### Breaking changes
+
+* `liveModeOnlyMessage` property has been removed from components: ScKpi, ScStatusGrid, ScTable, ScTableBase, ScWidgetGrid, and moved to be a member of the `messageOverrides` property.
+
+
+
+
 ## 4.0.1 (2022-05-19)
 
 

--- a/packages/doc-site/docs/properties.md
+++ b/packages/doc-site/docs/properties.md
@@ -351,3 +351,39 @@
     The type of trend line to apply against the data. Must be equal to one of the following strings:
     
     - `linear-regression`: Least-squares linear regression algorithm to determine the line of best fit against the data.
+
+---
+
+- `messageOverrides`: Object
+
+    (Optional) Messages which can be customized. i.e. for internationalization, or business domain specific jargon.
+
+    MessageOverrides contains the following properties:
+
+    - `liveTimeFrameValueLabel`: string
+
+      value label utilized in some widgets
+
+    - `historicalTimeFrameValueLabel`: string
+
+      value label utilized in some widgets
+
+    - `noDataStreamsPresentHeader`: string
+      
+      message displayed when there are no data streams present
+
+    - `noDataStreamsPresentSubHeader`: string
+
+      message displayed when there are no data streams present
+
+    - `noDataPresentHeader`: string
+
+      message displayed when no streams have any data
+
+    - `noDataPresentSubHeader`: string
+
+      message displayed when no streams have any data
+
+    - `liveModeOnly`: string
+
+      message displayed when visualization displays only live data

--- a/packages/doc-site/package.json
+++ b/packages/doc-site/package.json
@@ -2,12 +2,12 @@
   "name": "@synchro-charts/doc-site",
   "description": "Synchro Charts documentation site",
   "homepage": "https://synchrocharts.com",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "private": true,
   "dependencies": {
     "@awsui/components-react": "^3.0.182",
     "@synchro-charts/core": "^2.0.0",
-    "@synchro-charts/react": "^4.0.1",
+    "@synchro-charts/react": "^5.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.4"

--- a/packages/synchro-charts-react/CHANGELOG.md
+++ b/packages/synchro-charts-react/CHANGELOG.md
@@ -7,7 +7,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Breaking changes
 
-* `liveModeOnlyMessage` property has been removed from components: ScKpi, ScStatusGrid, ScTable, ScTableBase, ScWidgetGrid, and moved to be a member of the `messageOverrides` property.
+* `liveModeOnlyMessage` property has been removed from components: ScKpi, ScStatusGrid, ScTable, ScTableBase, ScWidgetGrid, and moved to be a member of the `messageOverrides` property and renamed to `liveModeOnly`.
 
 
 

--- a/packages/synchro-charts-react/CHANGELOG.md
+++ b/packages/synchro-charts-react/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 5.0.0 (2022-06-21)
+
+### Breaking changes
+
+* `liveModeOnlyMessage` property has been removed from components: ScKpi, ScStatusGrid, ScTable, ScTableBase, ScWidgetGrid, and moved to be a member of the `messageOverrides` property.
+
+
+
+
 ## 4.0.1 (2022-05-19)
 
 

--- a/packages/synchro-charts-react/package.json
+++ b/packages/synchro-charts-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synchro-charts/react",
   "description": "Synchro Charts React",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/synchro-charts/CHANGELOG.md
+++ b/packages/synchro-charts/CHANGELOG.md
@@ -7,7 +7,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Breaking changes
 
-* `liveModeOnlyMessage` property has been removed from components: ScKpi, ScStatusGrid, ScTable, ScTableBase, ScWidgetGrid, and moved to be a member of the `messageOverrides` property.
+* `liveModeOnlyMessage` property has been removed from components: ScKpi, ScStatusGrid, ScTable, ScTableBase, ScWidgetGrid, and moved to be a member of the `messageOverrides` property and renamed to `liveModeOnly`.
 
 
 

--- a/packages/synchro-charts/CHANGELOG.md
+++ b/packages/synchro-charts/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 5.0.0 (2022-06-21)
+
+### Breaking changes
+
+* `liveModeOnlyMessage` property has been removed from components: ScKpi, ScStatusGrid, ScTable, ScTableBase, ScWidgetGrid, and moved to be a member of the `messageOverrides` property.
+
+
+
+
 ## 4.0.1 (2022-05-19)
 
 

--- a/packages/synchro-charts/package.json
+++ b/packages/synchro-charts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synchro-charts/core",
   "description": "Synchro Charts",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/synchro-charts/src/components.d.ts
+++ b/packages/synchro-charts/src/components.d.ts
@@ -107,7 +107,6 @@ export namespace Components {
         "annotations": Annotations;
         "dataStreams": DataStream[];
         "isEditing": boolean;
-        "liveModeOnlyMessage": string;
         "messageOverrides": MessageOverrides;
         "viewport": MinimalViewPortConfig;
         "widgetId": string;
@@ -284,7 +283,6 @@ export namespace Components {
           * Status Grid Specific configuration
          */
         "labelsConfig": LabelsConfig;
-        "liveModeOnlyMessage": string;
         "messageOverrides": MessageOverrides;
         "viewport": MinimalViewPortConfig;
         "widgetId": string;
@@ -342,7 +340,6 @@ export namespace Components {
     interface ScTable {
         "annotations": Annotations;
         "dataStreams": DataStream[];
-        "liveModeOnlyMessage": string;
         "messageOverrides": MessageOverrides;
         /**
           * Table column values
@@ -355,7 +352,6 @@ export namespace Components {
     interface ScTableBase {
         "columns": TableColumn[];
         "isEnabled": boolean;
-        "liveModeOnlyMessage": string;
         "messageOverrides": MessageOverrides;
         "rows": Row[];
     }
@@ -547,7 +543,6 @@ export namespace Components {
           * Chart API
          */
         "labelsConfig"?: LabelsConfig;
-        "liveModeOnlyMessage": string;
         "messageOverrides": MessageOverrides;
         "renderCell": RenderCell;
         "viewport": MinimalViewPortConfig;
@@ -1505,7 +1500,6 @@ declare namespace LocalJSX {
         "annotations"?: Annotations;
         "dataStreams": DataStream[];
         "isEditing"?: boolean;
-        "liveModeOnlyMessage"?: string;
         "messageOverrides"?: MessageOverrides;
         "viewport"?: MinimalViewPortConfig;
         "widgetId": string;
@@ -1682,7 +1676,6 @@ declare namespace LocalJSX {
           * Status Grid Specific configuration
          */
         "labelsConfig"?: LabelsConfig;
-        "liveModeOnlyMessage"?: string;
         "messageOverrides"?: MessageOverrides;
         "viewport"?: MinimalViewPortConfig;
         "widgetId": string;
@@ -1741,7 +1734,6 @@ declare namespace LocalJSX {
     interface ScTable {
         "annotations"?: Annotations;
         "dataStreams": DataStream[];
-        "liveModeOnlyMessage"?: string;
         "messageOverrides"?: MessageOverrides;
         /**
           * On view port date range change, this component emits a `dateRangeChange` event. This allows other data visualization components to sync to the same date range.
@@ -1758,7 +1750,6 @@ declare namespace LocalJSX {
     interface ScTableBase {
         "columns": TableColumn[];
         "isEnabled": boolean;
-        "liveModeOnlyMessage"?: string;
         "messageOverrides": MessageOverrides;
         "rows": Row[];
     }
@@ -1955,7 +1946,6 @@ declare namespace LocalJSX {
           * Chart API
          */
         "labelsConfig"?: LabelsConfig;
-        "liveModeOnlyMessage"?: string;
         "messageOverrides"?: MessageOverrides;
         /**
           * On view port date range change, this component emits a `dateRangeChange` event. This allows other data visualization components to sync to the same date range.

--- a/packages/synchro-charts/src/components/sc-kpi/sc-kpi.tsx
+++ b/packages/synchro-charts/src/components/sc-kpi/sc-kpi.tsx
@@ -5,9 +5,6 @@ import { RenderCell } from '../sc-widget-grid/types';
 import { Annotations, ChartConfig } from '../charts/common/types';
 import { validate } from '../common/validator/validate';
 
-const MSG =
-  'This visualization displays only live data. Choose a live time frame to display data in this visualization.';
-
 const renderCell: RenderCell = props => <sc-kpi-base {...props} />;
 
 @Component({
@@ -20,7 +17,6 @@ export class ScKpi implements ChartConfig {
   @Prop() widgetId!: string;
   @Prop() dataStreams!: DataStream[];
   @Prop() annotations: Annotations;
-  @Prop() liveModeOnlyMessage: string = MSG;
   @Prop() isEditing: boolean = false;
   @Prop() messageOverrides: MessageOverrides = {};
 
@@ -29,14 +25,13 @@ export class ScKpi implements ChartConfig {
   }
 
   render() {
-    const { viewport, widgetId, dataStreams, annotations, liveModeOnlyMessage, isEditing, messageOverrides } = this;
+    const { viewport, widgetId, dataStreams, annotations, isEditing, messageOverrides } = this;
     return (
       <sc-widget-grid
         viewport={viewport}
         widgetId={widgetId}
         dataStreams={dataStreams}
         annotations={annotations}
-        liveModeOnlyMessage={liveModeOnlyMessage}
         isEditing={isEditing}
         messageOverrides={messageOverrides}
         renderCell={renderCell}

--- a/packages/synchro-charts/src/components/sc-status-grid/sc-status-grid.tsx
+++ b/packages/synchro-charts/src/components/sc-status-grid/sc-status-grid.tsx
@@ -15,9 +15,6 @@ const renderCell: RenderCell = ({ labelsConfig, ...rest }: CellOptions) => (
   <sc-status-cell labelsConfig={{ ...DEFAULT_LABELS_CONFIG, ...labelsConfig }} {...rest} />
 );
 
-const MSG =
-  'This visualization displays only live data. Choose a live time frame to display data in this visualization.';
-
 @Component({
   tag: 'sc-status-grid',
   shadow: false,
@@ -29,21 +26,11 @@ export class ScStatusGrid implements ChartConfig {
   @Prop() widgetId!: string;
   @Prop() dataStreams!: DataStream[];
   @Prop() annotations: Annotations;
-  @Prop() liveModeOnlyMessage: string = MSG;
   @Prop() isEditing: boolean = false;
   @Prop() messageOverrides: MessageOverrides = {};
 
   render() {
-    const {
-      viewport,
-      widgetId,
-      dataStreams,
-      annotations,
-      liveModeOnlyMessage,
-      isEditing,
-      messageOverrides,
-      labelsConfig,
-    } = this;
+    const { viewport, widgetId, dataStreams, annotations, isEditing, messageOverrides, labelsConfig } = this;
     return (
       <sc-widget-grid
         labelsConfig={labelsConfig}
@@ -51,7 +38,6 @@ export class ScStatusGrid implements ChartConfig {
         widgetId={widgetId}
         dataStreams={dataStreams}
         annotations={annotations}
-        liveModeOnlyMessage={liveModeOnlyMessage}
         isEditing={isEditing}
         messageOverrides={messageOverrides}
         renderCell={renderCell}

--- a/packages/synchro-charts/src/components/sc-table/sc-table-base/sc-table-base.spec.tsx
+++ b/packages/synchro-charts/src/components/sc-table/sc-table-base/sc-table-base.spec.tsx
@@ -55,8 +55,9 @@ const tableBaseSpecPage = async (propOverrides: Partial<Components.ScTableBase> 
     rows: mockRows,
     columns: [],
     isEnabled: true,
-    liveModeOnlyMessage: 'liveModeOnlyMessage',
-    messageOverrides: {},
+    messageOverrides: {
+      liveModeOnlyMessage: 'liveModeOnlyMessage',
+    },
     ...propOverrides,
   };
 

--- a/packages/synchro-charts/src/components/sc-table/sc-table-base/sc-table-base.spec.tsx
+++ b/packages/synchro-charts/src/components/sc-table/sc-table-base/sc-table-base.spec.tsx
@@ -56,7 +56,7 @@ const tableBaseSpecPage = async (propOverrides: Partial<Components.ScTableBase> 
     columns: [],
     isEnabled: true,
     messageOverrides: {
-      liveModeOnlyMessage: 'liveModeOnlyMessage',
+      liveModeOnly: 'liveModeOnly',
     },
     ...propOverrides,
   };

--- a/packages/synchro-charts/src/components/sc-table/sc-table-base/sc-table-base.tsx
+++ b/packages/synchro-charts/src/components/sc-table/sc-table-base/sc-table-base.tsx
@@ -1,7 +1,7 @@
 import { Component, h, Prop } from '@stencil/core';
 import { formatLiveModeOnlyMessage, Row } from '../constructTableData';
 import { ScTableRows } from '../sc-table-row/sc-table-row';
-import { MessageOverrides, TableColumn } from '../../../utils/dataTypes';
+import { DEFAULT_MESSAGE_OVERRIDES, MessageOverrides, TableColumn } from '../../../utils/dataTypes';
 
 @Component({
   tag: 'sc-table-base',
@@ -12,11 +12,12 @@ export class ScTableBase {
   @Prop() columns!: TableColumn[];
   @Prop() rows!: Row[];
   @Prop() isEnabled!: boolean;
-  @Prop() liveModeOnlyMessage: string;
   @Prop() messageOverrides!: MessageOverrides;
 
   render() {
-    const { msgHeader, msgSubHeader } = formatLiveModeOnlyMessage(this.liveModeOnlyMessage);
+    const { msgHeader, msgSubHeader } = formatLiveModeOnlyMessage(
+      this.messageOverrides?.liveModeOnlyMessage ?? DEFAULT_MESSAGE_OVERRIDES.liveModeOnlyMessage
+    );
     return (
       <div class="awsui container">
         <table role="table">

--- a/packages/synchro-charts/src/components/sc-table/sc-table-base/sc-table-base.tsx
+++ b/packages/synchro-charts/src/components/sc-table/sc-table-base/sc-table-base.tsx
@@ -16,7 +16,7 @@ export class ScTableBase {
 
   render() {
     const { msgHeader, msgSubHeader } = formatLiveModeOnlyMessage(
-      this.messageOverrides?.liveModeOnlyMessage ?? DEFAULT_MESSAGE_OVERRIDES.liveModeOnlyMessage
+      this.messageOverrides?.liveModeOnly ?? DEFAULT_MESSAGE_OVERRIDES.liveModeOnly
     );
     return (
       <div class="awsui container">

--- a/packages/synchro-charts/src/components/sc-table/sc-table.spec.tsx
+++ b/packages/synchro-charts/src/components/sc-table/sc-table.spec.tsx
@@ -286,17 +286,17 @@ describe('rendering', () => {
     expect(table.querySelector('.disable-status')).not.toBeNull();
   });
 
-  it('while in a historical time frame, only display `liveModeOnlyMessage` for disable status', async () => {
+  it('while in a historical time frame, only display `liveModeOnly` for disable status', async () => {
     const NON_LIVE_VIEWPORT = {
       ...DEFAULT_CHART_CONFIG.viewport,
     };
-    const LIVE_MODE_MSG = 'liveModeOnlyMessage';
+    const LIVE_MODE_MSG = 'liveModeOnly';
     const { table } = await tableSpecPage({
       dataStreams: [],
       tableColumns: TABLE_COLUMNS,
       viewport: NON_LIVE_VIEWPORT,
       messageOverrides: {
-        liveModeOnlyMessage: LIVE_MODE_MSG,
+        liveModeOnly: LIVE_MODE_MSG,
       },
     });
 
@@ -306,7 +306,7 @@ describe('rendering', () => {
 
     const disableStatus = table.querySelector('.disable-status') as HTMLElement;
     expect(disableStatus).not.toBeNull();
-    expect(disableStatus.innerText).toEqual('liveModeOnlyMessage');
+    expect(disableStatus.innerText).toEqual('liveModeOnly');
   });
 
   it('table with no datastreamInfo shows only table header and empty status', async () => {

--- a/packages/synchro-charts/src/components/sc-table/sc-table.spec.tsx
+++ b/packages/synchro-charts/src/components/sc-table/sc-table.spec.tsx
@@ -295,7 +295,9 @@ describe('rendering', () => {
       dataStreams: [],
       tableColumns: TABLE_COLUMNS,
       viewport: NON_LIVE_VIEWPORT,
-      liveModeOnlyMessage: LIVE_MODE_MSG,
+      messageOverrides: {
+        liveModeOnlyMessage: LIVE_MODE_MSG,
+      },
     });
 
     const headers = table.querySelectorAll('th');

--- a/packages/synchro-charts/src/components/sc-table/sc-table.tsx
+++ b/packages/synchro-charts/src/components/sc-table/sc-table.tsx
@@ -11,9 +11,6 @@ import { parseDuration } from '../../utils/time';
 import { webGLRenderer } from '../sc-webgl-context/webglContext';
 import { DATE_RANGE_EMIT_EVENT_MS } from '../common/constants';
 
-const MSG =
-  'This visualization displays only live data. Choose a live time frame to display data in this visualization.';
-
 @Component({
   tag: 'sc-table',
   shadow: false,
@@ -30,7 +27,6 @@ export class ScTable implements ChartConfig {
   @Prop() dataStreams!: DataStream[];
   @Prop() annotations: Annotations;
   @Prop() trends: Trend[];
-  @Prop() liveModeOnlyMessage: string = MSG;
   @Prop() messageOverrides: MessageOverrides = {};
 
   /** Table column values */
@@ -110,7 +106,6 @@ export class ScTable implements ChartConfig {
         columns={this.tableColumns}
         rows={rows}
         isEnabled={isEnabled}
-        liveModeOnlyMessage={this.liveModeOnlyMessage}
         messageOverrides={this.messageOverrides}
       />
     );

--- a/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.spec.ts
+++ b/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.spec.ts
@@ -40,8 +40,9 @@ const widgetGridSpecPage = async (propOverrides: Partial<Components.ScWidgetGrid
   const widgetGrid = page.doc.createElement('sc-widget-grid') as CustomHTMLElement<Components.ScWidgetGrid>;
   const props: Components.ScStatusGrid = {
     annotations: {},
-    messageOverrides: {},
-    liveModeOnlyMessage: 'liveModeOnlyMessage',
+    messageOverrides: {
+      liveModeOnlyMessage: 'liveModeOnlyMessage',
+    },
     labelsConfig: {},
     widgetId: 'sc-status-grid-widget-id',
     isEditing: false,

--- a/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.spec.ts
+++ b/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.spec.ts
@@ -41,7 +41,7 @@ const widgetGridSpecPage = async (propOverrides: Partial<Components.ScWidgetGrid
   const props: Components.ScStatusGrid = {
     annotations: {},
     messageOverrides: {
-      liveModeOnlyMessage: 'liveModeOnlyMessage',
+      liveModeOnly: 'liveModeOnly',
     },
     labelsConfig: {},
     widgetId: 'sc-status-grid-widget-id',

--- a/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.tsx
+++ b/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.tsx
@@ -207,9 +207,7 @@ export class ScWidgetGrid implements ChartConfig {
       <div class={{ tall: !this.collapseVertically }}>
         {!isEnabled && (
           <div class="help-icon-container">
-            <sc-help-tooltip
-              message={this.messageOverrides?.liveModeOnlyMessage ?? DEFAULT_MESSAGE_OVERRIDES.liveModeOnlyMessage}
-            />
+            <sc-help-tooltip message={this.messageOverrides?.liveModeOnly ?? DEFAULT_MESSAGE_OVERRIDES.liveModeOnly} />
           </div>
         )}
         <sc-grid>

--- a/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.tsx
+++ b/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.tsx
@@ -1,7 +1,14 @@
 import { Component, Event, EventEmitter, h, Prop, State, Watch } from '@stencil/core';
 
 import throttle from 'lodash.throttle';
-import { DataPoint, DataStream, MessageOverrides, MinimalViewPortConfig, Primitive } from '../../utils/dataTypes';
+import {
+  DataPoint,
+  DataStream,
+  DEFAULT_MESSAGE_OVERRIDES,
+  MessageOverrides,
+  MinimalViewPortConfig,
+  Primitive,
+} from '../../utils/dataTypes';
 import { NameValue, updateName } from '../sc-data-stream-name/helper';
 import { ActivePoint, activePoints } from '../charts/sc-webgl-base-chart/activePoints';
 import { getThresholds } from '../charts/common/annotations/utils';
@@ -18,9 +25,6 @@ import { getDataStreamForEventing } from '../charts/common';
 import { validate } from '../common/validator/validate';
 import { webGLRenderer } from '../sc-webgl-context/webglContext';
 import { DATE_RANGE_EMIT_EVENT_MS } from '../common/constants';
-
-const MSG =
-  'This visualization displays only live data. Choose a live time frame to display data in this visualization.';
 
 const title = ({ alarm, property }: { alarm?: DataStream; property?: DataStream }): string => {
   if (property) {
@@ -62,7 +66,6 @@ export class ScWidgetGrid implements ChartConfig {
   @Prop() isEditing: boolean = false;
 
   @Prop() messageOverrides: MessageOverrides = {};
-  @Prop() liveModeOnlyMessage: string = MSG;
 
   /** Widget data stream names */
   @State() names: NameValue[] = [];
@@ -204,7 +207,9 @@ export class ScWidgetGrid implements ChartConfig {
       <div class={{ tall: !this.collapseVertically }}>
         {!isEnabled && (
           <div class="help-icon-container">
-            <sc-help-tooltip message={this.liveModeOnlyMessage} />
+            <sc-help-tooltip
+              message={this.messageOverrides?.liveModeOnlyMessage ?? DEFAULT_MESSAGE_OVERRIDES.liveModeOnlyMessage}
+            />
           </div>
         )}
         <sc-grid>

--- a/packages/synchro-charts/src/testing/test-routes/widget-test-route.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/widget-test-route.tsx
@@ -90,7 +90,7 @@ export class WidgetTestRoute {
           /** TODO: Port these over to the message overrides */
           invalidTagErrorHeader="invalidComponentTag.header"
           invalidTagErrorSubheader="invalidComponentTag.subheader"
-          liveModeOnlyMessage="invalidWidgetForHistoricalData.content"
+          liveModeOnly="invalidWidgetForHistoricalData.content"
         />
         <sc-webgl-context />
       </div>

--- a/packages/synchro-charts/src/utils/dataTypes.ts
+++ b/packages/synchro-charts/src/utils/dataTypes.ts
@@ -175,7 +175,7 @@ export type MessageOverrides = {
   /** no data present - msg displayed when no streams have any data */
   noDataPresentHeader?: string;
   noDataPresentSubHeader?: string;
-  liveModeOnlyMessage?: string;
+  liveModeOnly?: string;
 };
 export const DEFAULT_MESSAGE_OVERRIDES: Required<MessageOverrides> = {
   liveTimeFrameValueLabel: 'Value',
@@ -184,7 +184,7 @@ export const DEFAULT_MESSAGE_OVERRIDES: Required<MessageOverrides> = {
   noDataStreamsPresentSubHeader: "This widget doesn't have any properties or alarms.",
   noDataPresentHeader: 'No data',
   noDataPresentSubHeader: "There's no data to display for this time range.",
-  liveModeOnlyMessage:
+  liveModeOnly:
     'This visualization displays only live data. Choose a live time frame to display data in this visualization.',
 };
 

--- a/packages/synchro-charts/src/utils/dataTypes.ts
+++ b/packages/synchro-charts/src/utils/dataTypes.ts
@@ -175,6 +175,7 @@ export type MessageOverrides = {
   /** no data present - msg displayed when no streams have any data */
   noDataPresentHeader?: string;
   noDataPresentSubHeader?: string;
+  liveModeOnlyMessage?: string;
 };
 export const DEFAULT_MESSAGE_OVERRIDES: Required<MessageOverrides> = {
   liveTimeFrameValueLabel: 'Value',
@@ -183,6 +184,8 @@ export const DEFAULT_MESSAGE_OVERRIDES: Required<MessageOverrides> = {
   noDataStreamsPresentSubHeader: "This widget doesn't have any properties or alarms.",
   noDataPresentHeader: 'No data',
   noDataPresentSubHeader: "There's no data to display for this time range.",
+  liveModeOnlyMessage:
+    'This visualization displays only live data. Choose a live time frame to display data in this visualization.',
 };
 
 /** SVG Constants */


### PR DESCRIPTION
…s prop

## Overview
deprecate `liveModeOnlyMessage` property in components: ScKpi ScStatusGrid, ScTable, ScTableBase, ScWidgetGrid. This prop is moved in to the `messageOverrides` as a property.

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
