### PR TITLE
Update: Dev env doc updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,16 @@
   "main": "index.js",
   "repository": "git@github.com:awslabs/synchro-charts.git",
   "private": true,
+  "engines": {
+    "node": ">=16.0.0",
+    "yarn": ">=1.0.0 <2.0.0"
+  },
   "workspaces": [
     "packages/*"
   ],
   "scripts": {
     "postinstall": "husky install",
+    "bootstrap": "yarn install && yarn build",
     "build": "lerna run build --stream",
     "clean": "lerna run clean --concurrency 4",
     "lint:fix": "lerna run fix --stream --concurrency 4",

--- a/packages/doc-site/docs/developmentQuickStart.md
+++ b/packages/doc-site/docs/developmentQuickStart.md
@@ -1,0 +1,12 @@
+## Environment Setup
+Synchro Charts runs on node and uses yarn for package management. Specific versions are required in order to keep builds working with the current monorepo tooling.
+
+- Node: any `v16` or higher
+- Yarn: any `v1`, but not `v2` or higher
+
+## Building Synchro Charts
+With supported versions of node and yarn installed, you're ready to build and run Synchro Charts locally. 
+
+1. Run `yarn bootstrap` from the root of the repo. This will install dependencies and build all of the packages. Note: this is different from running `lerna bootstrap` which will install dependencies, but doesn't build packages.
+
+2. Navigate to `packages/synchro-charts` and run `yarn start`.

--- a/packages/doc-site/styleguide.config.js
+++ b/packages/doc-site/styleguide.config.js
@@ -106,6 +106,10 @@ module.exports = {
       content: 'docs/contributing.md',
     },
     {
+      name: 'Development Quick Start',
+      content: 'docs/developmentQuickStart.md',
+    },
+    {
       name: 'Limitations',
       content: 'docs/limitations.md',
     },


### PR DESCRIPTION
## Overview
The requirements and instructions for running synchro charts aren't very clear. Specific node and yarn versions are required, and running `lerna bootstrap` like many developers are used to in lerna monorepos doesn't make it clear that there is an additional build step to run. 

I added `engines` to the package json to warn developers when they use incompatible node or yarn versions, a new `bootstrap` command to run on yarn that both installs dependencies and build packages, and a new development quick start document.

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
