### PR TITLE
Fix #150: dateRangeChange incorrectly called

### DIFF
--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.spec.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.spec.tsx
@@ -32,6 +32,7 @@ import { ScWebglBaseChart } from './sc-webgl-base-chart';
 import { ScWebglAxis } from './sc-webgl-axis';
 import { chartScene, updateChartScene } from '../sc-line-chart/chartScene';
 import { DATA_ALIGNMENT, LEGEND_POSITION } from '../common/constants';
+import { SECOND_IN_MS } from '../../../utils/time';
 
 const VIEWPORT: ViewPort = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
 
@@ -480,6 +481,28 @@ describe('chart scene management', () => {
         end: UPDATED_END,
       })
     );
+  });
+
+  it('calls onUpdate without emitting dateRangeChanged event when chart is in live mode', async () => {
+    jest.useFakeTimers();
+
+    const mockEventListener = jest.fn();
+    document.addEventListener = mockEventListener;
+    await newChartSpecPage({
+      createChartScene: chartScene,
+      updateChartScene,
+      viewport: { duration: 500 },
+      minBufferSize: MIN_BUFFER_SIZE,
+      bufferFactor: BUFFER_FACTOR,
+      dataStreams: DATA_STREAMS,
+      onUpdateLifeCycle: jest.fn(),
+    });
+    mockEventListener.mockReset();
+
+    const secondsElapsed = 1;
+    jest.advanceTimersByTime(secondsElapsed * SECOND_IN_MS);
+
+    expect(mockEventListener).not.toHaveBeenCalledWith('dateRangeChanged');
   });
 });
 

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
@@ -540,15 +540,18 @@ export class ScWebglBaseChart {
    * Provide no `hasDataChanged` to prevent a re-processing of the chart scenes.
    */
   onUpdate = (
-    { start, end }: { start: Date; end: Date },
-
+    {
+      start,
+      end,
+      shouldBlockDateRangeChangedEvent,
+    }: { start: Date; end: Date; shouldBlockDateRangeChangedEvent?: boolean },
     hasDataChanged: boolean = false,
     hasSizeChanged: boolean = false,
     hasAnnotationChanged: boolean = false,
     shouldRerender: boolean = false
   ) => {
     const hasViewPortChanged = this.start.getTime() !== start.getTime() || this.end.getTime() !== end.getTime();
-    if (hasViewPortChanged) {
+    if (hasViewPortChanged && !shouldBlockDateRangeChangedEvent) {
       this.onDateRangeChange([start, end, this.viewport.group]);
     }
 

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/utils.ts
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/utils.ts
@@ -100,7 +100,16 @@ export const constructChartScene = ({
      */
     viewportGroup: viewport.group,
 
-    updateViewPort: ({ start, end }: { start: Date; end: Date }) => {
+    updateViewPort: ({
+      start,
+      end,
+      ...rest
+    }: {
+      start: Date;
+      end: Date;
+      duration?: number | undefined;
+      shouldBlockDateRangeChangedEvent?: boolean;
+    }) => {
       /**
        * Update threejs cameras position.
        * This will cause the shaders to have an updated uniform, utilized
@@ -117,7 +126,7 @@ export const constructChartScene = ({
        * for non-webGL based features, i.e. thresholds, axis, etc.
        */
       if (onUpdate) {
-        onUpdate({ start, end });
+        onUpdate({ start, end, ...rest });
       }
     },
   };

--- a/packages/synchro-charts/src/components/viewportHandler/types.ts
+++ b/packages/synchro-charts/src/components/viewportHandler/types.ts
@@ -2,7 +2,12 @@ export interface ViewPortManager {
   id: string;
   viewportGroup?: string;
   // Hook which is called with viewport is updated
-  updateViewPort: (viewportUpdate: { start: Date; end: Date; duration?: number }) => void;
+  updateViewPort: (viewportUpdate: {
+    start: Date;
+    end: Date;
+    duration?: number;
+    shouldBlockDateRangeChangedEvent?: boolean;
+  }) => void;
   // Disposes of all all scene, it's geometries, and any materials that are specific to the scene.
   // Dispose should be called whenever a chart scene is no longer used, otherwise the application
   // will leak memory

--- a/packages/synchro-charts/src/components/viewportHandler/viewportHandler.spec.ts
+++ b/packages/synchro-charts/src/components/viewportHandler/viewportHandler.spec.ts
@@ -371,4 +371,22 @@ describe('internal clock', () => {
     // @ts-ignore
     expect(manager1.updateViewPort.mock.calls.length).toBeGreaterThan(manager2.updateViewPort.mock.calls.length);
   });
+
+  it('blocks dateRangeChanged event emission when a duration is passed in', () => {
+    jest.useFakeTimers();
+    const groups = new ViewportHandler();
+    const VIEWPORT_GROUP_1 = 'view-port-group-1';
+    const manager = viewportManager(VIEWPORT_GROUP_1);
+
+    /** Create a viewport group and sync it's viewport */
+    groups.add({ manager, duration: 10 * SECOND_IN_MS, chartSize });
+
+    const secondsElapsed = 1;
+    jest.advanceTimersByTime(secondsElapsed * SECOND_IN_MS);
+    expect(manager.updateViewPort).toBeCalledWith(
+      expect.objectContaining({
+        shouldBlockDateRangeChangedEvent: true,
+      })
+    );
+  });
 });

--- a/packages/synchro-charts/src/components/viewportHandler/viewportHandler.ts
+++ b/packages/synchro-charts/src/components/viewportHandler/viewportHandler.ts
@@ -55,8 +55,15 @@ export class ViewportHandler<T extends ViewPortManager> {
 
       // Sets the new start and end in the viewport live id for the current manager
       this.viewportMap[viewPortMapKey] = { start: newStart, end: newEnd };
-      // Have manager update its own viewport
-      manager.updateViewPort({ start: newStart, end: newEnd, duration });
+
+      // Have manager update its own viewport, preventing 'dateRangeChange' events when in live mode
+      const isInLiveMode = Boolean(duration);
+      manager.updateViewPort({
+        start: newStart,
+        end: newEnd,
+        duration,
+        shouldBlockDateRangeChangedEvent: isInLiveMode,
+      });
     }, tickRate) as unknown) as number;
 
     this.viewportMap[viewPortMapKey] = { start: initStart, end: initEnd };


### PR DESCRIPTION
## Overview
Fixes https://github.com/awslabs/synchro-charts/issues/150.

When in live mode, the viewportHandler tick cycle was passing the updated viewport back to the rendered chart. The logic was set to emit the `dateRangeChange` event any time the viewport changed. When in live mode this isn't the desired behavior so a flag was added to be able to check for that and block the event from being emitted.

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
