### PR TITLE
chore(synchro-charts): utilize iot-app-kit viewportManager in KPI & grid

### DIFF
--- a/packages/synchro-charts/package.json
+++ b/packages/synchro-charts/package.json
@@ -96,6 +96,7 @@
     "write-file-webpack-plugin": "^4.5.0"
   },
   "dependencies": {
+    "@iot-app-kit/core": "^2.0.0",
     "@stencil/redux": "^0.1.1",
     "@types/d3": "^5.16.4",
     "d3-array": "^2.3.2",

--- a/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.spec.ts
+++ b/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.spec.ts
@@ -1,5 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing';
 
+import { viewportManager } from '@iot-app-kit/core';
 import { Components } from '../../components';
 import { CustomHTMLElement } from '../../utils/types';
 import { DATA_STREAMS } from '../charts/common/tests/chart/constants';
@@ -59,6 +60,10 @@ const widgetGridSpecPage = async (propOverrides: Partial<Components.ScWidgetGrid
   return { page, widgetGrid, renderCell };
 };
 
+beforeEach(() => {
+  viewportManager.reset();
+});
+
 describe('when enabled', () => {
   it('renders cell', async () => {
     const { renderCell } = await widgetGridSpecPage();
@@ -95,6 +100,25 @@ describe('when enabled', () => {
 });
 
 describe('updating the viewport', () => {
+  it('updates the viewport when the subscribed viewport group updates', async () => {
+    const GROUP = 'some-group';
+    const { renderCell, page } = await widgetGridSpecPage({
+      viewport: { start: new Date(2000, 0, 0), end: new Date(2001, 0, 0), group: GROUP },
+      dataStreams: [DATA_STREAM],
+    });
+
+    const UPDATED_VIEWPORT = { start: new Date(2002, 0, 0), end: new Date(2003, 0, 0) };
+    viewportManager.update(GROUP, UPDATED_VIEWPORT);
+
+    await page.waitForChanges();
+
+    expect(renderCell).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        viewport: UPDATED_VIEWPORT,
+      })
+    );
+  });
+
   it('updates the viewport and renders a cell with the data point that was previously outside of the viewport', async () => {
     const laterDate = new Date(
       ((DEFAULT_CHART_CONFIG.viewport as MinimalStaticViewport).end as Date).getTime() + MINUTE_IN_MS

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,718 @@
 # yarn lockfile v1
 
 
+"@aws-crypto/ie11-detection@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz#9c39f4a5558196636031a933ec1b4792de959d6a"
+  integrity sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==
+  dependencies:
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-browser@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz#741c9024df55ec59b51e5b1f5d806a4852699fb5"
+  integrity sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==
+  dependencies:
+    "@aws-crypto/ie11-detection" "^2.0.0"
+    "@aws-crypto/sha256-js" "^2.0.0"
+    "@aws-crypto/supports-web-crypto" "^2.0.0"
+    "@aws-crypto/util" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-js@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz#f1f936039bdebd0b9e2dd834d65afdc2aac4efcb"
+  integrity sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==
+  dependencies:
+    "@aws-crypto/util" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-js@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-2.0.2.tgz#c81e5d378b8a74ff1671b58632779986e50f4c99"
+  integrity sha512-iXLdKH19qPmIC73fVCrHWCSYjN/sxaAvZ3jNNyw6FclmHyjLKg0f69WlC9KTnyElxCR5MO9SKaG00VwlJwyAkQ==
+  dependencies:
+    "@aws-crypto/util" "^2.0.2"
+    "@aws-sdk/types" "^3.110.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/supports-web-crypto@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz#9f02aafad8789cac9c0ab5faaebb1ab8aa841338"
+  integrity sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==
+  dependencies:
+    tslib "^1.11.1"
+
+"@aws-crypto/util@^2.0.0", "@aws-crypto/util@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-2.0.2.tgz#adf5ff5dfbc7713082f897f1d01e551ce0edb9c0"
+  integrity sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==
+  dependencies:
+    "@aws-sdk/types" "^3.110.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-sdk/abort-controller@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/abort-controller/-/abort-controller-3.170.0.tgz#c56b38358525165dbbfbafa5ad7864ebf1bec965"
+  integrity sha512-Td5EJWr/M4ElgF/vSnX41jYRBXiA3n7QTaHxxz5Og8MoquUGnZR/tfmn2fgObMYQg6isjUhVa0Lw+Ltblz/+dA==
+  dependencies:
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-cognito-identity@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.170.0.tgz#0230c560b8037c7d1fe7d3c561efdb53237545e5"
+  integrity sha512-XNFBZd0uLnWwOVPO5JQrGkW/m79l7qGLIATn4ltvXQK92pRBw91Dlxry5F+x4PaVqRwrMZH7dmGpWZ8/DctjEQ==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/client-sts" "3.170.0"
+    "@aws-sdk/config-resolver" "3.170.0"
+    "@aws-sdk/credential-provider-node" "3.170.0"
+    "@aws-sdk/fetch-http-handler" "3.170.0"
+    "@aws-sdk/hash-node" "3.170.0"
+    "@aws-sdk/invalid-dependency" "3.170.0"
+    "@aws-sdk/middleware-content-length" "3.170.0"
+    "@aws-sdk/middleware-host-header" "3.170.0"
+    "@aws-sdk/middleware-logger" "3.170.0"
+    "@aws-sdk/middleware-recursion-detection" "3.170.0"
+    "@aws-sdk/middleware-retry" "3.170.0"
+    "@aws-sdk/middleware-serde" "3.170.0"
+    "@aws-sdk/middleware-signing" "3.170.0"
+    "@aws-sdk/middleware-stack" "3.170.0"
+    "@aws-sdk/middleware-user-agent" "3.170.0"
+    "@aws-sdk/node-config-provider" "3.170.0"
+    "@aws-sdk/node-http-handler" "3.170.0"
+    "@aws-sdk/protocol-http" "3.170.0"
+    "@aws-sdk/smithy-client" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    "@aws-sdk/url-parser" "3.170.0"
+    "@aws-sdk/util-base64-browser" "3.170.0"
+    "@aws-sdk/util-base64-node" "3.170.0"
+    "@aws-sdk/util-body-length-browser" "3.170.0"
+    "@aws-sdk/util-body-length-node" "3.170.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.170.0"
+    "@aws-sdk/util-defaults-mode-node" "3.170.0"
+    "@aws-sdk/util-user-agent-browser" "3.170.0"
+    "@aws-sdk/util-user-agent-node" "3.170.0"
+    "@aws-sdk/util-utf8-browser" "3.170.0"
+    "@aws-sdk/util-utf8-node" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-iotsitewise@^3.87.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-iotsitewise/-/client-iotsitewise-3.170.0.tgz#9014234785a69aea85c4a4031491e48e01045a45"
+  integrity sha512-VE5ODvjmp9AH5+DDojvbNYfPzaiiidUYntmOF0SJbyQ1j/TNZHXsCLwP4hfRGcVgfaXcjI+wmyAwx4LKy7jdlQ==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/client-sts" "3.170.0"
+    "@aws-sdk/config-resolver" "3.170.0"
+    "@aws-sdk/credential-provider-node" "3.170.0"
+    "@aws-sdk/fetch-http-handler" "3.170.0"
+    "@aws-sdk/hash-node" "3.170.0"
+    "@aws-sdk/invalid-dependency" "3.170.0"
+    "@aws-sdk/middleware-content-length" "3.170.0"
+    "@aws-sdk/middleware-host-header" "3.170.0"
+    "@aws-sdk/middleware-logger" "3.170.0"
+    "@aws-sdk/middleware-recursion-detection" "3.170.0"
+    "@aws-sdk/middleware-retry" "3.170.0"
+    "@aws-sdk/middleware-serde" "3.170.0"
+    "@aws-sdk/middleware-signing" "3.170.0"
+    "@aws-sdk/middleware-stack" "3.170.0"
+    "@aws-sdk/middleware-user-agent" "3.170.0"
+    "@aws-sdk/node-config-provider" "3.170.0"
+    "@aws-sdk/node-http-handler" "3.170.0"
+    "@aws-sdk/protocol-http" "3.170.0"
+    "@aws-sdk/smithy-client" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    "@aws-sdk/url-parser" "3.170.0"
+    "@aws-sdk/util-base64-browser" "3.170.0"
+    "@aws-sdk/util-base64-node" "3.170.0"
+    "@aws-sdk/util-body-length-browser" "3.170.0"
+    "@aws-sdk/util-body-length-node" "3.170.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.170.0"
+    "@aws-sdk/util-defaults-mode-node" "3.170.0"
+    "@aws-sdk/util-user-agent-browser" "3.170.0"
+    "@aws-sdk/util-user-agent-node" "3.170.0"
+    "@aws-sdk/util-utf8-browser" "3.170.0"
+    "@aws-sdk/util-utf8-node" "3.170.0"
+    "@aws-sdk/util-waiter" "3.170.0"
+    tslib "^2.3.1"
+    uuid "^8.3.2"
+
+"@aws-sdk/client-sso@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.170.0.tgz#21955a5dd00e6f10ce9208ab62be5f51c7c0f08c"
+  integrity sha512-IbSX3+ujJYl+Pe7amPnMa011+vYw7ExxYc8BEBJFibjyZHMBJz4rI6bnTL3sfC9DnvY6sgHYd1hJvlmh0UYJaQ==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/config-resolver" "3.170.0"
+    "@aws-sdk/fetch-http-handler" "3.170.0"
+    "@aws-sdk/hash-node" "3.170.0"
+    "@aws-sdk/invalid-dependency" "3.170.0"
+    "@aws-sdk/middleware-content-length" "3.170.0"
+    "@aws-sdk/middleware-host-header" "3.170.0"
+    "@aws-sdk/middleware-logger" "3.170.0"
+    "@aws-sdk/middleware-recursion-detection" "3.170.0"
+    "@aws-sdk/middleware-retry" "3.170.0"
+    "@aws-sdk/middleware-serde" "3.170.0"
+    "@aws-sdk/middleware-stack" "3.170.0"
+    "@aws-sdk/middleware-user-agent" "3.170.0"
+    "@aws-sdk/node-config-provider" "3.170.0"
+    "@aws-sdk/node-http-handler" "3.170.0"
+    "@aws-sdk/protocol-http" "3.170.0"
+    "@aws-sdk/smithy-client" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    "@aws-sdk/url-parser" "3.170.0"
+    "@aws-sdk/util-base64-browser" "3.170.0"
+    "@aws-sdk/util-base64-node" "3.170.0"
+    "@aws-sdk/util-body-length-browser" "3.170.0"
+    "@aws-sdk/util-body-length-node" "3.170.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.170.0"
+    "@aws-sdk/util-defaults-mode-node" "3.170.0"
+    "@aws-sdk/util-user-agent-browser" "3.170.0"
+    "@aws-sdk/util-user-agent-node" "3.170.0"
+    "@aws-sdk/util-utf8-browser" "3.170.0"
+    "@aws-sdk/util-utf8-node" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-sts@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.170.0.tgz#d112ade891db62c77a02cb3b22d16ec343615547"
+  integrity sha512-zI8sneNTtRWmyeZR9Ip3T3eU/PzVWlmYrS3k537ciE0z4dU/7usdsXg2NdyYfyBGydaNZ5TLdvbM9NMzCR0vaA==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/config-resolver" "3.170.0"
+    "@aws-sdk/credential-provider-node" "3.170.0"
+    "@aws-sdk/fetch-http-handler" "3.170.0"
+    "@aws-sdk/hash-node" "3.170.0"
+    "@aws-sdk/invalid-dependency" "3.170.0"
+    "@aws-sdk/middleware-content-length" "3.170.0"
+    "@aws-sdk/middleware-host-header" "3.170.0"
+    "@aws-sdk/middleware-logger" "3.170.0"
+    "@aws-sdk/middleware-recursion-detection" "3.170.0"
+    "@aws-sdk/middleware-retry" "3.170.0"
+    "@aws-sdk/middleware-sdk-sts" "3.170.0"
+    "@aws-sdk/middleware-serde" "3.170.0"
+    "@aws-sdk/middleware-signing" "3.170.0"
+    "@aws-sdk/middleware-stack" "3.170.0"
+    "@aws-sdk/middleware-user-agent" "3.170.0"
+    "@aws-sdk/node-config-provider" "3.170.0"
+    "@aws-sdk/node-http-handler" "3.170.0"
+    "@aws-sdk/protocol-http" "3.170.0"
+    "@aws-sdk/smithy-client" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    "@aws-sdk/url-parser" "3.170.0"
+    "@aws-sdk/util-base64-browser" "3.170.0"
+    "@aws-sdk/util-base64-node" "3.170.0"
+    "@aws-sdk/util-body-length-browser" "3.170.0"
+    "@aws-sdk/util-body-length-node" "3.170.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.170.0"
+    "@aws-sdk/util-defaults-mode-node" "3.170.0"
+    "@aws-sdk/util-user-agent-browser" "3.170.0"
+    "@aws-sdk/util-user-agent-node" "3.170.0"
+    "@aws-sdk/util-utf8-browser" "3.170.0"
+    "@aws-sdk/util-utf8-node" "3.170.0"
+    entities "2.2.0"
+    fast-xml-parser "3.19.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/config-resolver@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/config-resolver/-/config-resolver-3.170.0.tgz#c8557f63e53ee884d0d86a93b1c25ff6d27a0590"
+  integrity sha512-wliG8HCZ7YTOu248zn9gM/FoAGKRjnigPHmTs19XIi+ZtrxERHr0uQy5GCn6yseSu7FmAhjQHKDXNyZ13nCzPg==
+  dependencies:
+    "@aws-sdk/signature-v4" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    "@aws-sdk/util-config-provider" "3.170.0"
+    "@aws-sdk/util-middleware" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-cognito-identity@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.170.0.tgz#579f7bb1fdc1a19d7153d3549c81877df0dfb455"
+  integrity sha512-Va5mGHHy+KESCUkVfu1b7VB/v+5afctc8CRaPgX/dvLYD1NkBqqSgDOVsN79FzLSBY6dpQisOsoekjxMd2UmJQ==
+  dependencies:
+    "@aws-sdk/client-cognito-identity" "3.170.0"
+    "@aws-sdk/property-provider" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-env@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.170.0.tgz#d3aba5c79cdb7e6b0f39b40a838ed66f817e9a9b"
+  integrity sha512-sN4+u2zfTVii554CNdGHwuaNZ5+cPvj5pQrYXn+PtGL9U5jk3uBmZqZL//0TDx40uoBMx3k670BfkHv3diEJhw==
+  dependencies:
+    "@aws-sdk/property-provider" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-imds@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.170.0.tgz#9cca64ae34c4ef7f6ed9a695015bd0c2c9fa9880"
+  integrity sha512-BOrNx+V9mHEYM0/e9+0vQyWUGuf7aY9n/o4kOgaAhS7Mok/gIPT3N3NLyklCEZ19LE3aquxZ8KbIJKykPog6ww==
+  dependencies:
+    "@aws-sdk/node-config-provider" "3.170.0"
+    "@aws-sdk/property-provider" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    "@aws-sdk/url-parser" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-ini@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.170.0.tgz#58cb6b912a9b2fb83d6862a6fb97263ef203c0c8"
+  integrity sha512-QJBCDqfReGQ4LflFq3tYodGY2qXQr4AnTDz2V4VD7oWBMaBj7we8Bg8zvcOe6mE6vwRP+ZqPvfwmqN6pvoOSyA==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.170.0"
+    "@aws-sdk/credential-provider-imds" "3.170.0"
+    "@aws-sdk/credential-provider-sso" "3.170.0"
+    "@aws-sdk/credential-provider-web-identity" "3.170.0"
+    "@aws-sdk/property-provider" "3.170.0"
+    "@aws-sdk/shared-ini-file-loader" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-node@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.170.0.tgz#733058bff730ab686eac71547e4fea95a6180397"
+  integrity sha512-FZamoojMY1yc0194zK3hs4LR0qyPCdJmnRZhLWhDU4ERPUbnwL3iTlUCZ2JyNpVzCkVsWJggnui6n9at4zH2Xg==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.170.0"
+    "@aws-sdk/credential-provider-imds" "3.170.0"
+    "@aws-sdk/credential-provider-ini" "3.170.0"
+    "@aws-sdk/credential-provider-process" "3.170.0"
+    "@aws-sdk/credential-provider-sso" "3.170.0"
+    "@aws-sdk/credential-provider-web-identity" "3.170.0"
+    "@aws-sdk/property-provider" "3.170.0"
+    "@aws-sdk/shared-ini-file-loader" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-process@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.170.0.tgz#3ea42d34b5745aa0125b0a605d67b645d23b1c9f"
+  integrity sha512-HMdXPbiDxPiAKJ/iLidKYdaUnlcAeG5CDXYqQ485KMcH/Kdy19ne0bT1mE5w5+EspOKpvmu/Rt17EhATMoUxEg==
+  dependencies:
+    "@aws-sdk/property-provider" "3.170.0"
+    "@aws-sdk/shared-ini-file-loader" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-sso@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.170.0.tgz#5b7cd79dd9a09f639232592e48a0264ee57ffc18"
+  integrity sha512-v1fmVwpU3jxfzDWa5dWx3D0JulhMLc5zJPcO4sI9JG3yWd5/AFcaqKzg1Zxy99SNzRK0bvVZreb1djlgyPDZag==
+  dependencies:
+    "@aws-sdk/client-sso" "3.170.0"
+    "@aws-sdk/property-provider" "3.170.0"
+    "@aws-sdk/shared-ini-file-loader" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-web-identity@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.170.0.tgz#a3f284fcb8979da535235ac92f8658a5c01a98ae"
+  integrity sha512-REVY6H6j2jA9iDQbZ0RXePiifhVi3wpNdLiApFSjr+ssSPNaPCY1B+zSRQUjvYTWXXpieT51O8mot5cSWrYUrQ==
+  dependencies:
+    "@aws-sdk/property-provider" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-providers@^3.39.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-providers/-/credential-providers-3.170.0.tgz#7de548a01a254862d22eebfcc5816d4d6de217a1"
+  integrity sha512-/ClW6GTTWje3p3u6LEDP5PClCYbo/2dUf121WSEC3nji3cfOI5/3tMaRjQ+U2jmIjQ8cFyvzAw7IInm+v/I+Ng==
+  dependencies:
+    "@aws-sdk/client-cognito-identity" "3.170.0"
+    "@aws-sdk/client-sso" "3.170.0"
+    "@aws-sdk/client-sts" "3.170.0"
+    "@aws-sdk/credential-provider-cognito-identity" "3.170.0"
+    "@aws-sdk/credential-provider-env" "3.170.0"
+    "@aws-sdk/credential-provider-imds" "3.170.0"
+    "@aws-sdk/credential-provider-ini" "3.170.0"
+    "@aws-sdk/credential-provider-node" "3.170.0"
+    "@aws-sdk/credential-provider-process" "3.170.0"
+    "@aws-sdk/credential-provider-sso" "3.170.0"
+    "@aws-sdk/credential-provider-web-identity" "3.170.0"
+    "@aws-sdk/property-provider" "3.170.0"
+    "@aws-sdk/shared-ini-file-loader" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/fetch-http-handler@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.170.0.tgz#bef541cfcf212fd9ad231f8dcf2dfa8486e7801b"
+  integrity sha512-Q9LkFOTQD4JGF+mL+DRadUE80F5666LpFcSC0RTaljisOXykwotW8L2W9adX4uEGMmQQIJpdsInW2j31W+wF3w==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.170.0"
+    "@aws-sdk/querystring-builder" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    "@aws-sdk/util-base64-browser" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/hash-node@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-node/-/hash-node-3.170.0.tgz#c7e8fd983dae63d28ee356bc28ce382de29eae2c"
+  integrity sha512-Wtwt1buM4uLhXClSYXY/NlHkJs7yw4TVagpYN4leYpcJV2UfQpxgZR1hzjwao6dKherw7a7+Cvm28RpmbZ7/8A==
+  dependencies:
+    "@aws-sdk/types" "3.170.0"
+    "@aws-sdk/util-buffer-from" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/invalid-dependency@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/invalid-dependency/-/invalid-dependency-3.170.0.tgz#66e6dbb3e2a6084cf88a0ae65973bd2be758754d"
+  integrity sha512-FtoYTNjBzU2oGqsw142RFuTcq+JQfqVttcfQzFE0OCqoux6GbDK5qvNAl0vKFKTfNv/9s2BEcYIruC+BydEljw==
+  dependencies:
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/is-array-buffer@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/is-array-buffer/-/is-array-buffer-3.170.0.tgz#a34b82b0d7c534544db001837785ed086d99344c"
+  integrity sha512-yYXqgp8rilBckIvNRs22yAXHKcXb86/g+F+hsTZl38OJintTsLQB//O5v6EQTYhSW7T3wMe1NHDrjZ+hFjAy4Q==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-content-length@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-content-length/-/middleware-content-length-3.170.0.tgz#20016e38539a6cc2e9b48a35fa5a849d37c77d7d"
+  integrity sha512-w36bU0EWXyvR3HKkh1RQ95pM6F5Sl/rhcdIgmNU18Ju4cV1yUX/8qX2wDecN/FksxzxZrO61lMS7PmanDzhFhw==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-host-header@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.170.0.tgz#7897d1d4375374617d65e6e323fbd317fd4bd6e3"
+  integrity sha512-0w60Klecg1/S62SXjAQ5ZPUPbS6TnDtdmwW6cuROvsSOXnOMWffcr9Kwansb6BJuVnRQWF4YBuerMpfAaHBziA==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-logger@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.170.0.tgz#e99e38ec50c6beb581ff417401ba298a7aaf16fa"
+  integrity sha512-IMp1zvODHzwQ0nm0+z6dJjyZqVUA0YAoUaKDLZ+GIOtGDNENPRVyIeBO/8nhCVEV2ZXOymacdTXfKH4qBOF1sw==
+  dependencies:
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-recursion-detection@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.170.0.tgz#d3a0927c6fbefdee1cdb605a57588478c3586fe7"
+  integrity sha512-tO8EyVFJ9eE50WuzOAv6ysDefBRa3OJrV9/2KwjoVa2lFByrNp7UDP1DYYjKk2il4DLyYDWmGyrD+n9wJG91gw==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-retry@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-retry/-/middleware-retry-3.170.0.tgz#2b2b66010796010c14cf3b13b95766e3fbe26c38"
+  integrity sha512-SSxFznOr8m7cpTXeOfCklOiCGCZ9XP6VdlpXpwjuYVSb+7/dmELd5ILOv7u7fivnot8wMJp0CmZN/WAGsD8cJw==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.170.0"
+    "@aws-sdk/service-error-classification" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    "@aws-sdk/util-middleware" "3.170.0"
+    tslib "^2.3.1"
+    uuid "^8.3.2"
+
+"@aws-sdk/middleware-sdk-sts@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.170.0.tgz#5c1650765d059bdfaf6355e5e0fc1b45cb218804"
+  integrity sha512-gVcDIO5mYjiOlh6kGwX99S1OA/FH9izC40oI1bKxQr4w044ZZImvj5Z0n7+iySUx3VLPUOIGBuVi/Y5MwjBWQg==
+  dependencies:
+    "@aws-sdk/middleware-signing" "3.170.0"
+    "@aws-sdk/property-provider" "3.170.0"
+    "@aws-sdk/protocol-http" "3.170.0"
+    "@aws-sdk/signature-v4" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-serde@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-serde/-/middleware-serde-3.170.0.tgz#a4b5f8a6918d7c95613ef89c7a939ade9908144e"
+  integrity sha512-qIvH+cZlwFMfj59Hau6HTCErDOjswUfzmFWsntw+H6HWcBAMXmIbFpZGBKa0Wsg2mWtRTJ20rUMbJYz5y7t05Q==
+  dependencies:
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-signing@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-signing/-/middleware-signing-3.170.0.tgz#fab0dab1336fe7492597f779549d6e35b1e026c8"
+  integrity sha512-ymfwcHv8YDPOsKqzFtmonTYuL64jM4s5GdkEomwGaKx1LiDpnC8OVqw14HY9tjDTL1aktbxWCiKCR2lL3bV2OA==
+  dependencies:
+    "@aws-sdk/property-provider" "3.170.0"
+    "@aws-sdk/protocol-http" "3.170.0"
+    "@aws-sdk/signature-v4" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-stack@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-stack/-/middleware-stack-3.170.0.tgz#5f36fd9fe6bc6d40d93b83177227d6b075f32302"
+  integrity sha512-hspZvuXlmJQBepPrvlv3v7/g+BTJR8dmBz53BqS2J0f1f7Josv/jqBb0LYX9wf0HZ7T7LQsj/JvB1drBIlOBbw==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-user-agent@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.170.0.tgz#2c303f8d23c4ac3c49e4ce11d63da972a46df6ca"
+  integrity sha512-KYlRpEjZRxN3m5lQPB5WN22etuFW2mZaYyldTestH8lD0kkekvKFiaRzvvuohvJOkmrwBy2/8/rZXHkzs/fMUA==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/node-config-provider@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-config-provider/-/node-config-provider-3.170.0.tgz#87016983dfe8517497505f7522d607d107d06acc"
+  integrity sha512-DqKBLFk133D0ibFcZqLg2Db6gKSvjZK6SCeH0hAv0bOjn2fNfif8IdZJa7MBi7LB4Zi73aUgbAdQ6Z6YTW0Wow==
+  dependencies:
+    "@aws-sdk/property-provider" "3.170.0"
+    "@aws-sdk/shared-ini-file-loader" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/node-http-handler@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-http-handler/-/node-http-handler-3.170.0.tgz#77e2dd7bb9a4ea98ece1673d4c14b789b094f267"
+  integrity sha512-EJuZErUw7PFAAb4GFpw21liOV8oxp/L4wmVlaZ+coNkF9QhDSh6sr5HrExw1AGy+L+oOUicS0EnalPOe9dG1/g==
+  dependencies:
+    "@aws-sdk/abort-controller" "3.170.0"
+    "@aws-sdk/protocol-http" "3.170.0"
+    "@aws-sdk/querystring-builder" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/property-provider@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/property-provider/-/property-provider-3.170.0.tgz#01b470cbc10ab927bee5996f6784ef51a0369dfb"
+  integrity sha512-B/m86zfLBLUO688FW3xqXwFR5qY5YGja+KJKpFOiZ76NynU3qgxC7XuMB3m/yGIruiH3dXnKG1O21BhkvyDwoA==
+  dependencies:
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/protocol-http@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-http/-/protocol-http-3.170.0.tgz#c3e38c5efa10a0bc74c64b7df1a8be93c611f07d"
+  integrity sha512-Mz+551ecHlnRP6AHWX3C1qQRpW0Nm3q53oqXhqqEHDFGgciz99OCDOd/+fWD8jmmf3If7h4vFzVZiXbOlN5b8g==
+  dependencies:
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/querystring-builder@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-builder/-/querystring-builder-3.170.0.tgz#38c6480355a502a089e7cefa91db96de4e919476"
+  integrity sha512-geKHWspD5NIhJNAaDZ+t8oShJetUx4AJ6fLsh5NONtQgYJ8ddOUkjr6vKko7wZW9EhrSIDdTpd0BWZ+k7+FN9w==
+  dependencies:
+    "@aws-sdk/types" "3.170.0"
+    "@aws-sdk/util-uri-escape" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/querystring-parser@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-parser/-/querystring-parser-3.170.0.tgz#157050f5aed13408e1070aeb12146537c88a3af2"
+  integrity sha512-2wwaMlqbhFF5Qkkk3ZGadNSQ+ZSO4sGKpKJ2gf3nQ8mkjczBfePt+kNDZbD88Ja9Mcf2odJ0i1NaYBUpbBwYlA==
+  dependencies:
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/service-error-classification@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/service-error-classification/-/service-error-classification-3.170.0.tgz#ef3a64bd930a142698997dd719170e1a55e10470"
+  integrity sha512-nsqwtdmdBqoaU0tb1CpTM0oQ63FSpcpKTUlUMSQqywTqTe6jcDSvJRHqUgAWSepxAWqwDIj1rkBiPCyJDRfPmA==
+
+"@aws-sdk/shared-ini-file-loader@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.170.0.tgz#23a40276986799ea70cd2e73b7b45744e5e7f145"
+  integrity sha512-az0dVZ7s8c+O5fruCCvst+k+aPuhWh+4AMGi4w+UprTOWNST3iOKiThHs8NFGX7F7Izi/7rAnO6FtR3sTpW1VQ==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/signature-v4@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4/-/signature-v4-3.170.0.tgz#803be6963403d6d99e7d36d883802e9742e50fbf"
+  integrity sha512-NWfoDsRX4AL6NAplHmNCNXOw3vrqfW+/C4x1UbnlCnS05z6N1ZUeuKw03rByokke6HMeNaJIOSzA0MeWch6Dxw==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    "@aws-sdk/util-hex-encoding" "3.170.0"
+    "@aws-sdk/util-middleware" "3.170.0"
+    "@aws-sdk/util-uri-escape" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/smithy-client@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/smithy-client/-/smithy-client-3.170.0.tgz#b5a53b3c1a4faba4d2af2a5a86d23d2f92e2e2d0"
+  integrity sha512-wEypq2+U+XBQuqHBZ04xzO9DWfZLn4CppYupywUGx+j3ieRqIA1zVV3/iOi7dmgbp2vFbHOFU2HxwANWBmZmcA==
+  dependencies:
+    "@aws-sdk/middleware-stack" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/types@3.170.0", "@aws-sdk/types@^3.1.0", "@aws-sdk/types@^3.110.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.170.0.tgz#2fde14864ad0ba699656a35450660ac56070469f"
+  integrity sha512-Inbe+2SS7JpseFz9ThK9Q9L7zOVX61E2k6ZZZzIM1QVQ7i7hyfQW6mBXvK/8bH3+89nNaRdF3BN41aCHMdcEyA==
+
+"@aws-sdk/url-parser@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser/-/url-parser-3.170.0.tgz#8337bd70a437ecc015bf8c0f7ac4b207bf67a1ac"
+  integrity sha512-Q6HgjCsYa71Pc0q4YemxKqmXnGO2FUdcmvPii+d18820ej9GyQgTkaes0gb2+p1tEMy5DqT1H5cK0jgGGIL39w==
+  dependencies:
+    "@aws-sdk/querystring-parser" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-base64-browser@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64-browser/-/util-base64-browser-3.170.0.tgz#3352aeb2891f650fa0eda75d8be38ebdc6f98b43"
+  integrity sha512-uLP9Kp74+jc+UWI392LSWIaUj9eXZBhkAiSm8dXAyrr+5GFOKvmEdidFoZKKcFcZ2v3RMonDgFVcDBiZ33w7BQ==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-base64-node@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64-node/-/util-base64-node-3.170.0.tgz#434f719d467e04f553f3dc8991aec40483078607"
+  integrity sha512-sjpOmfyW0RWCLXU8Du0ZtwgFoxIuKQIyVygXJ4qxByoa3jIUJXf4U33uSRMy47V3JoogdZuKSpND9hiNk2wU4w==
+  dependencies:
+    "@aws-sdk/util-buffer-from" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-body-length-browser@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.170.0.tgz#4f88ad2493e7088a8b22972d4ff512a64f02fc7b"
+  integrity sha512-SqSWA++gsZgHw6tlcEXx9K6R6cVKNYzOq6bca+NR7jXvy1hfqiv9Gx5TZrG4oL4JziP8QA0fTklmI1uQJ4HBRA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-body-length-node@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-node/-/util-body-length-node-3.170.0.tgz#ef69fc0895338c2b15b5b4c9b201e72d4232cba1"
+  integrity sha512-sFb85ngsgfpamwDn22LC/+FkbDTNiddbMHptkajw+CAD2Rb4SJDp2PfXZ6k883BueJWhmxZ9+lApHZqYtgPdzw==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-buffer-from@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-buffer-from/-/util-buffer-from-3.170.0.tgz#efa9e74cd6fda5d711a99dc8a6f288afabe3b9fe"
+  integrity sha512-3ClE3wgN/Zw0ahfVAY5KQ/y3K2c+SYHwVUQaGSuVQlPOCDInGYjE/XEFwCeGJzncRPHIKDRPEsHCpm1uwgwEqQ==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-config-provider@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-config-provider/-/util-config-provider-3.170.0.tgz#85ad4dfa8102fe44b737c0aee23e63ae37ff9022"
+  integrity sha512-VV6lfss6Go00TF2hRVJnN8Uf2FOwC++1e8glaeU7fMWluYCBjwl+116mPOPFaxvkJCg0dui2tFroXioslM/rvQ==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-defaults-mode-browser@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.170.0.tgz#278affee7a267b8abd20d3f7f61f587f9bd278b8"
+  integrity sha512-+MDtZRPN01eCEShbpJa+SbTscQi4wBKNwJugMvWqpCu09JlbW2+esHDy227R3k9IgOQMqzefFHnFS4Za1JgYpg==
+  dependencies:
+    "@aws-sdk/property-provider" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    bowser "^2.11.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-defaults-mode-node@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.170.0.tgz#9df2bb357e94c3a68e279d7f49dfad69dcacc29f"
+  integrity sha512-vuQ1CAyWRqp2zpbz/1J6HvEnfVJlYw1AI4E0fevZfqGZbl+OS+yw1EbEJx0GjhnT9/G1vG6QEBO/t5FYuL1QeQ==
+  dependencies:
+    "@aws-sdk/config-resolver" "3.170.0"
+    "@aws-sdk/credential-provider-imds" "3.170.0"
+    "@aws-sdk/node-config-provider" "3.170.0"
+    "@aws-sdk/property-provider" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-hex-encoding@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.170.0.tgz#e81f0fd8c951e0da7ada8d3148ead9b15c57f2f8"
+  integrity sha512-BDYyMqaxX4/N7rYOIYlqgpZaBuHw3kNXKgOkWtJdzndIZbQX8HnyJ+rF0Pr1aVsOpVDM+fY1prERleFh/ZRTCg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-locate-window@^3.0.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-locate-window/-/util-locate-window-3.170.0.tgz#acc8717abe1e568de41d9b8ede33a49c6c1e108d"
+  integrity sha512-uQvn3ZaAokWcNSY+tNR71RGXPPncv5ejrpGa/MGOCioeBjkU5n5OJp7BdaTGouZu4fffeVpdZJ/ZNld8LWMgLw==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-middleware@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-middleware/-/util-middleware-3.170.0.tgz#8e9d6012ab929da7b60c9920dd2be7696b65a410"
+  integrity sha512-WitO1dRnrnZ/Zmt7QBUK9i+XnxWDy9M4kVqMo9gABd8pcBBp/T8ssyUK0R5gjWcYdnStKISux9XtTWUp2h1V8Q==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-uri-escape@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-uri-escape/-/util-uri-escape-3.170.0.tgz#1121fb47a59dab0f732b881742e9871c3690367c"
+  integrity sha512-Fof0urZ3Lx6z6LNKSEO6T4DNaNh6sLJaSWFaC6gtVDPux/C3R7wy2RQRDp0baHxE8m1KMB0XnKzHizJNrbDI1w==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-user-agent-browser@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.170.0.tgz#447ace82f9583250c926839426c461e9f60166c2"
+  integrity sha512-+LmkIAEelN/qkdvt1DqC7nVF4Iy+PV0m+e27gd4NRALakfxFRzYAK/gvI9w1P4wV8LRixFRrsxoKYeGp84Zoag==
+  dependencies:
+    "@aws-sdk/types" "3.170.0"
+    bowser "^2.11.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-user-agent-node@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.170.0.tgz#56393758c05eb3f1717ed791d08b3fbc19b3589b"
+  integrity sha512-iiMEWgSxGhe7iDVNJWy/vf8NSGznR6Zqoj8C50NEMQGyzKTOsaHs9TLe09/8vRECUxUn+sqpK+tSHYTJF9XXCA==
+  dependencies:
+    "@aws-sdk/node-config-provider" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-utf8-browser@3.170.0", "@aws-sdk/util-utf8-browser@^3.0.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.170.0.tgz#3fcea278e7a6fca4fef3d562300a3eea9a2f244f"
+  integrity sha512-tJby9krepSwDsBK+KQF5ACacZQ4LH1Aheh5Dy0pghxsN/9IRw7kMWTumuRCnSntLFFphDD7GM494/Dvnl1UCLA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-utf8-node@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-node/-/util-utf8-node-3.170.0.tgz#8f46d05bc887a7a8e3372a25e0f46035290a9aad"
+  integrity sha512-52QWGNoNQoyT2CuoQz6LjBKxHQtN/ceMFLW+9J1E0I1ni8XTuTYP52BlMe5484KkmZKsHOm+EWe4xuwwVetTxg==
+  dependencies:
+    "@aws-sdk/util-buffer-from" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-waiter@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-waiter/-/util-waiter-3.170.0.tgz#31f730127d5a370ee55375a21881b1aeb22beb26"
+  integrity sha512-SDOoiG+hLnVxPabMdrV6IjNxlRRqd1lfFHV97qNPTDSoOVm7KZnE/QeUENi7/QqGPxATDmNzv9xL0Y73MBr3iA==
+  dependencies:
+    "@aws-sdk/abort-controller" "3.170.0"
+    "@aws-sdk/types" "3.170.0"
+    tslib "^2.3.1"
+
 "@awsui/collection-hooks@^1.0.0":
   version "1.0.17"
   resolved "https://registry.yarnpkg.com/@awsui/collection-hooks/-/collection-hooks-1.0.17.tgz#6fad67e8bc610011ac3f3feac15bc8e352e7db3a"
@@ -1471,6 +2183,30 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
+"@iot-app-kit/core@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@iot-app-kit/core/-/core-2.0.0.tgz#f7fe3c581f7780b663d25855378844cf87348fc5"
+  integrity sha512-MBm4Z4TR3XxV7uXm5FPp8zNV5yWDoM2GbfCyutgXpycexo8OyPfkaTMs5oQObY6A/UqUn7eqvFDEy9VFYfCDAg==
+  dependencies:
+    "@aws-sdk/client-iotsitewise" "^3.87.0"
+    "@aws-sdk/credential-providers" "^3.39.0"
+    "@rollup/plugin-typescript" "^8.3.0"
+    "@synchro-charts/core" "^6.0.0"
+    d3-array "^2.3.2"
+    flush-promises "^1.0.2"
+    intervals-fn "^3.0.3"
+    lodash.isequal "^4.5.0"
+    lodash.isnumber "^3.0.3"
+    lodash.round "^4.0.4"
+    lodash.throttle "^4.1.1"
+    lodash.uniq "^4.5.0"
+    lodash.uniqby "^4.7.0"
+    parse-duration "^1.0.0"
+    redux "^4.0.4"
+    rxjs "^7.4.0"
+    typescript "4.4.4"
+    uuid "^3.3.2"
+
 "@istanbuljs/schema@^0.1.2":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
@@ -2519,6 +3255,23 @@
   resolved "https://registry.yarnpkg.com/@reach/observe-rect/-/observe-rect-1.2.0.tgz#d7a6013b8aafcc64c778a0ccb83355a11204d3b2"
   integrity sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==
 
+"@rollup/plugin-typescript@^8.3.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-8.5.0.tgz#7ea11599a15b0a30fa7ea69ce3b791d41b862515"
+  integrity sha512-wMv1/scv0m/rXx21wD2IsBbJFba8wGF3ErJIr6IKRfRj49S85Lszbxb4DCo8iILpluTjk2GAAu9CoZt4G3ppgQ==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    resolve "^1.17.0"
+
+"@rollup/pluginutils@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
+  integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+  dependencies:
+    "@types/estree" "0.0.39"
+    estree-walker "^1.0.1"
+    picomatch "^2.2.2"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz#a21117b19ee9be70c379ec1877537ef2e1c63301"
@@ -2973,6 +3726,11 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
 "@types/geojson@*":
   version "7946.0.8"
@@ -4538,6 +5296,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
+bowser@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
+  integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -6932,15 +7695,15 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0, enhanced-resolve@^4.5.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
+entities@2.2.0, entities@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
 entities@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
-
-entities@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
-  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
 env-paths@^2.2.0:
   version "2.2.1"
@@ -7424,6 +8187,11 @@ estree-walker@^0.6.1:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
   integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
 
+estree-walker@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
+  integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
+
 estree-walker@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.9.0.tgz#9116372f09c02fd88fcafb0c04343631012a0aa6"
@@ -7715,6 +8483,11 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-xml-parser@3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz#cb637ec3f3999f51406dd8ff0e6fc4d83e520d01"
+  integrity sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==
+
 fastest-levenshtein@^1.0.9:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
@@ -7943,6 +8716,11 @@ flatten@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
+
+flush-promises@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/flush-promises/-/flush-promises-1.0.2.tgz#4948fd58f15281fed79cbafc86293d5bb09b2ced"
+  integrity sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -9209,6 +9987,13 @@ internmap@^1.0.0:
   resolved "https://registry.yarnpkg.com/internmap/-/internmap-1.0.1.tgz#0017cc8a3b99605f0302f2b198d272e015e5df95"
   integrity sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==
 
+intervals-fn@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/intervals-fn/-/intervals-fn-3.0.3.tgz#a8bcb4788dbd9b206ee386bcaa14da11765f488f"
+  integrity sha512-8jHsv7lOAIWJLp1gl2PGRj6bvmEhp8XbtMe3oH1CHsaC63hGFlmiV6RsATLe9U/jtZpdLF+OXIbA0hvoyyrOzw==
+  dependencies:
+    ramda "^0.25.0"
+
 invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
@@ -9356,6 +10141,13 @@ is-core-module@^2.2.0, is-core-module@^2.4.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.5.0.tgz#f754843617c70bfd29b7bd87327400cda5c18491"
   integrity sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.9.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
+  integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
   dependencies:
     has "^1.0.3"
 
@@ -12689,7 +13481,7 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6:
+path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
@@ -12743,6 +13535,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
+
+picomatch@^2.2.2:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 pidtree@^0.3.0:
   version "0.3.1"
@@ -13944,6 +14741,11 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
+ramda@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
+  integrity sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==
+
 ramda@~0.27.1:
   version "0.27.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
@@ -14912,6 +15714,15 @@ resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.2
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
+resolve@^1.17.0:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+  dependencies:
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 resolve@^2.0.0-next.3:
   version "2.0.0-next.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.3.tgz#d41016293d4a8586a39ca5d9b5f15cbea1f55e46"
@@ -15069,6 +15880,13 @@ rxjs@^6.3.3, rxjs@^6.5.3, rxjs@^6.6.0:
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
+
+rxjs@^7.4.0:
+  version "7.5.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.6.tgz#0446577557862afd6903517ce7cae79ecb9662bc"
+  integrity sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==
+  dependencies:
+    tslib "^2.1.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -16144,6 +16962,11 @@ supports-color@^7.0.0, supports-color@^7.1.0, supports-color@^7.2.0:
   dependencies:
     has-flag "^4.0.0"
 
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
 svg-parser@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
@@ -16595,7 +17418,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -16604,6 +17427,11 @@ tslib@^2.0.1, tslib@^2.0.3, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tslib@^2.1.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsutils@^3.17.1:
   version "3.21.0"
@@ -16705,6 +17533,11 @@ typescript@3.9.7:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
+typescript@4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
+  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
 
 uglify-js@^3.1.4:
   version "3.14.1"
@@ -17068,6 +17901,11 @@ uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.0:
   version "2.3.0"


### PR DESCRIPTION
## Overview
Utilize the [viewport manager](https://github.com/awslabs/iot-app-kit/blob/main/docs/ViewportManager.md) from `@iot-app-kit/core` to synchronize the viewport groups.

This change will make it so that the viewport groups of the KPI and status grid do not sync with the other Synchro Charts components until they are also refactored to utilize the `viewportManager`, which is the next step after this PR is merged, and needs to happen before the next version release.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
