### PR TITLE
chore: bump d3-color to 3.1.0, add postinstall hook to fix export path

### DIFF
--- a/packages/synchro-charts/package.json
+++ b/packages/synchro-charts/package.json
@@ -49,7 +49,8 @@
     "copy:contributing": "cp ../../CONTRIBUTING.md CONTRIBUTING.md",
     "prepack": "yarn run copy:license && yarn run copy:notice && yarn run copy:code-of-conduct && yarn run copy:contributing",
     "prepublishOnly": "yarn release",
-    "pack": "yarn pack"
+    "pack": "yarn pack",
+    "postinstall": "node postinstall.js"
   },
   "devDependencies": {
     "@babel/core": "^7.6.4",
@@ -101,6 +102,7 @@
     "d3-array": "^2.3.2",
     "d3-axis": "^1.0.12",
     "d3-brush": "^1.1.3",
+    "d3-color": "3.1.0",
     "d3-drag": "^1.2.5",
     "d3-scale": "^3.2.0",
     "d3-selection": "^1.3.1",
@@ -121,6 +123,9 @@
     "tippy.js": "^5.2.0",
     "uuid": "^3.3.2",
     "validator": "^13.6.0"
+  },
+  "resolutions": {
+    "d3-color": "3.1.0"
   },
   "license": "Apache-2.0"
 }

--- a/packages/synchro-charts/postinstall.js
+++ b/packages/synchro-charts/postinstall.js
@@ -1,0 +1,10 @@
+// We need to use the UMD version of the d3-color package, but we also
+// need to bump to a version where the ESM version has been made the default
+// due to a vulnerability (see https://github.com/d3/d3-color/issues/97).
+// Yarn v1 does not understand the package.json "exports" property, so we
+// must write the UMD export path into the "main" property.
+const d3ColorPackageJsonPath = '/node_modules/d3-color/package.json';
+// eslint-disable-next-line import/no-dynamic-require
+const d3ColorPackageJson = require(process.cwd() + d3ColorPackageJsonPath);
+d3ColorPackageJson.main = d3ColorPackageJson.exports.umd;
+require('fs').writeFileSync(process.cwd() + d3ColorPackageJsonPath, JSON.stringify(d3ColorPackageJson, null, 2));

--- a/yarn.lock
+++ b/yarn.lock
@@ -6217,6 +6217,11 @@ d3-color@1:
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
   integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
 
+d3-color@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
 d3-dispatch@1:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.6.tgz#00d37bcee4dd8cd97729dd893a0ac29caaba5d58"


### PR DESCRIPTION
## Overview
d3-color 1.x is affected by [a CVE](https://security.snyk.io/vuln/SNYK-JS-D3COLOR-1076592). It is patched [only in 3.1.0](https://github.com/d3/d3-brush/issues/90) and the maintainer [refuses to backport the fix](https://github.com/d3/d3-color/issues/108), so we need to upgrade.

d3-color is a dependency of several of our dependencies that specify 1.x, so we need to force resolution to 3.1.0 in package.json. This is fine because 2 and 3 merely [drop support for old environments](https://github.com/d3/d3-color/releases) that we [already disallow](https://github.com/awslabs/synchro-charts/blob/main/package.json#L10) and do not introduce any other relevant breaking changes.

The only caveat is that newer versions switch to using the ESM source code as the package default export and expose the UMD-bundled version with the package.json `"exports"` property, but this property is [only recognized in yarn v2](https://github.com/yarnpkg/berry/issues/650) and we need to use the UMD version. A quick fix to make the package compatible with yarn v1 is to add a postinstall hook that rewrites the `"main"` export path to the UMD `"exports"` path, which I've done here.
  
## Tests
See below

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
