### PR TITLE
fix: switch to fork of d3-color 1.4.x with backtracking fix from 3.1.0 applied

### DIFF
--- a/packages/synchro-charts/package.json
+++ b/packages/synchro-charts/package.json
@@ -102,7 +102,7 @@
     "d3-array": "^2.3.2",
     "d3-axis": "^1.0.12",
     "d3-brush": "^1.1.3",
-    "d3-color": "3.1.0",
+    "d3-color-1-fix": "1.4.2",
     "d3-drag": "^1.2.5",
     "d3-scale": "^3.2.0",
     "d3-selection": "^1.3.1",
@@ -125,7 +125,7 @@
     "validator": "^13.6.0"
   },
   "resolutions": {
-    "d3-color": "3.1.0"
+    "d3-color": "d3-color-1-fix"
   },
   "license": "Apache-2.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6207,6 +6207,11 @@ d3-collection@1:
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
   integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
 
+d3-color-1-fix@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/d3-color-1-fix/-/d3-color-1-fix-1.4.2.tgz#1910c6fa6dc8d48f6d5d97ba694ca08ac06ee743"
+  integrity sha512-m1rQC2eF0aQFvmCXIeml97cIgBFTPwPTi31pYpgYdpyJEQI86U/ROUjdMcKDrUWgmlxVzqwq3MNYpE2DRHkGag==
+
 d3-color@1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"


### PR DESCRIPTION
Implements a better version of the fix from #167, pulling in a forked version of the offending dependency, in line with [the maintainer's recommendations](https://github.com/d3/d3-color/issues/108#issuecomment-1271705762) as well as [the path forward for other major projects](https://github.com/recharts/recharts/issues/3012#issuecomment-1284393411).

## Overview
Switches from patching d3-color 3.1.0 manually to using a forked version of d3-color 1.4.x with the 3.1.0 patch applied.

## Tests
See below.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
