### PR TITLE
fix: switch to fork of d3-color 1.4.x with backtracking fix from 3.1.0 applied

### DIFF
--- a/packages/synchro-charts/package.json
+++ b/packages/synchro-charts/package.json
@@ -101,6 +101,7 @@
     "d3-array": "^2.3.2",
     "d3-axis": "^1.0.12",
     "d3-brush": "^1.1.3",
+    "d3-color-1-fix": "1.4.2",
     "d3-drag": "^1.2.5",
     "d3-scale": "^3.2.0",
     "d3-selection": "^1.3.1",
@@ -121,6 +122,9 @@
     "tippy.js": "^5.2.0",
     "uuid": "^3.3.2",
     "validator": "^13.6.0"
+  },
+  "resolutions": {
+    "d3-color": "d3-color-1-fix"
   },
   "license": "Apache-2.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6207,6 +6207,11 @@ d3-collection@1:
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
   integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
 
+d3-color-1-fix@1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/d3-color-1-fix/-/d3-color-1-fix-1.4.2.tgz#1910c6fa6dc8d48f6d5d97ba694ca08ac06ee743"
+  integrity sha512-m1rQC2eF0aQFvmCXIeml97cIgBFTPwPTi31pYpgYdpyJEQI86U/ROUjdMcKDrUWgmlxVzqwq3MNYpE2DRHkGag==
+
 d3-color@1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"


### PR DESCRIPTION
## Overview
Implements a better version of the fix from #167. The maintainer of the package with the issue will not backport the fix to 1.x and [recommends](https://github.com/d3/d3-color/issues/108#issuecomment-1271705762) forking the package, and [other major projects](https://github.com/recharts/recharts/issues/3012#issuecomment-1284393411) are discussing forking the package as well.

Here I have forked the package, cherry-picked the fix onto 1.4.x, and published as a new package at 1.4.2. Then, we resolve `d3-color` to that package with [yarn's `resolutions` feature](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/#toc-why-would-you-want-to-do-this) (the second bullet point there describes our situation exactly).

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
