### PR TITLE
Release version 6.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 6.0.5 (2022-11-03)
+
+### Bug Fixes
+* fix: y-axis no longer cuts off digits, instead uses SI format with 2 significant digits ([#175](https://github.com/awslabs/synchro-charts/pull/175)) ([d03068d](https://github.com/awslabs/synchro-charts/pull/175/commits/d03068d2128e2b1400e60a8b59c6210ef2849a5d))
+
 ## 6.0.4 (2022-10-21)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*"
     ],
     "npmClient": "yarn",
-    "version": "6.0.4",
+    "version": "6.0.5",
     "useWorkspaces": true,
     "nohoist": [
         "parcel-bundler"

--- a/packages/doc-site/CHANGELOG.md
+++ b/packages/doc-site/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 6.0.5 (2022-11-03)
+
+### Bug Fixes
+* fix: y-axis no longer cuts off digits, instead uses SI format with 2 significant digits ([#175](https://github.com/awslabs/synchro-charts/pull/175)) ([d03068d](https://github.com/awslabs/synchro-charts/pull/175/commits/d03068d2128e2b1400e60a8b59c6210ef2849a5d))
+
 ## 6.0.4 (2022-10-21)
 
 ### Bug Fixes

--- a/packages/doc-site/package.json
+++ b/packages/doc-site/package.json
@@ -2,13 +2,12 @@
   "name": "@synchro-charts/doc-site",
   "description": "Synchro Charts documentation site",
   "homepage": "https://synchrocharts.com",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "private": true,
   "dependencies": {
     "@awsui/components-react": "^3.0.182",
-    "@synchro-charts/core": "^6.0.4",
-    "@synchro-charts/react": "^6.0.4",
-    "minimatch": "3.0.5",
+    "@synchro-charts/core": "^6.0.5",
+    "@synchro-charts/react": "^6.0.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.4"

--- a/packages/synchro-charts-react/CHANGELOG.md
+++ b/packages/synchro-charts-react/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 6.0.5 (2022-11-03)
+
+### Bug Fixes
+* fix: y-axis no longer cuts off digits, instead uses SI format with 2 significant digits ([#175](https://github.com/awslabs/synchro-charts/pull/175)) ([d03068d](https://github.com/awslabs/synchro-charts/pull/175/commits/d03068d2128e2b1400e60a8b59c6210ef2849a5d))
+
 ## 6.0.4 (2022-10-21)
 
 ### Bug Fixes

--- a/packages/synchro-charts-react/package.json
+++ b/packages/synchro-charts-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synchro-charts/react",
   "description": "Synchro Charts React",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "publishConfig": {
     "access": "public"
   },
@@ -35,7 +35,7 @@
     "react-dom": "16.x.x || 17.x.x"
   },
   "dependencies": {
-    "@synchro-charts/core": "^6.0.4"
+    "@synchro-charts/core": "^6.0.5"
   },
   "license": "Apache-2.0",
   "style": "dist/styles.css",

--- a/packages/synchro-charts/CHANGELOG.md
+++ b/packages/synchro-charts/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 6.0.5 (2022-11-03)
+
+### Bug Fixes
+* fix: y-axis no longer cuts off digits, instead uses SI format with 2 significant digits ([#175](https://github.com/awslabs/synchro-charts/pull/175)) ([d03068d](https://github.com/awslabs/synchro-charts/pull/175/commits/d03068d2128e2b1400e60a8b59c6210ef2849a5d))
+
 ## 6.0.4 (2022-10-21)
 
 ### Bug Fixes

--- a/packages/synchro-charts/package.json
+++ b/packages/synchro-charts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synchro-charts/core",
   "description": "Synchro Charts",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Overview
Release version 6.0.5

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
