### PR TITLE
chore: bump and resolve minimatch to 3.0.5, resolve d3-color-1-fix to npm

### DIFF
--- a/packages/doc-site/package.json
+++ b/packages/doc-site/package.json
@@ -8,12 +8,16 @@
     "@awsui/components-react": "^3.0.182",
     "@synchro-charts/core": "^6.0.4",
     "@synchro-charts/react": "^6.0.4",
+    "minimatch": "3.0.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.4"
   },
   "devDependencies": {
     "react-styleguidist": "^11.1.6"
+  },
+  "resolutions": {
+    "minimatch": "3.0.5"
   },
   "scripts": {
     "start": "styleguidist server",

--- a/packages/synchro-charts/package.json
+++ b/packages/synchro-charts/package.json
@@ -116,6 +116,7 @@
     "lodash.throttle": "^4.1.1",
     "lodash.uniq": "^4.5.0",
     "lodash.uniqby": "^4.7.0",
+    "minimatch": "3.0.5",
     "parse-duration": "^1.0.0",
     "redux": "^4.0.4",
     "resize-observer-polyfill": "^1.5.1",
@@ -125,7 +126,8 @@
     "validator": "^13.6.0"
   },
   "resolutions": {
-    "d3-color": "d3-color-1-fix"
+    "d3-color": "npm:d3-color-1-fix",
+    "minimatch": "3.0.5"
   },
   "license": "Apache-2.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11450,6 +11450,13 @@ minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.5.tgz#4da8f1290ee0f0f8e83d60ca69f8f134068604a3"
+  integrity sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimist-options@4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz"


### PR DESCRIPTION
## Overview
Resolves minimatch to 3.0.5 and addresses [resolutions field issue with Yarn 1.22](https://github.com/yarnpkg/yarn/issues/7680#issuecomment-967025399) for d3-color fork.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
