### PR TITLE
feat: add boolean primitive type

### DIFF
--- a/packages/synchro-charts/src/components/charts/common/annotations/utils.ts
+++ b/packages/synchro-charts/src/components/charts/common/annotations/utils.ts
@@ -81,6 +81,9 @@ const valueDisplayText = ({
   if (typeof value === 'string') {
     return value;
   }
+  if (typeof value === 'boolean') {
+    return String(value);
+  }
   return displayDate(value, resolution, viewport);
 };
 
@@ -206,6 +209,14 @@ export const isThresholdBreached = (value: Primitive, threshold: Threshold): boo
     throw new Error(`Unsupported string threshold comparison operator: ${thresholdComparison}`);
   }
 
+  if (typeof dataStreamValue === 'boolean' && typeof thresholdValue === 'boolean') {
+    if (thresholdComparison === COMPARISON_OPERATOR.EQUAL) {
+      return dataStreamValue === thresholdValue;
+    }
+
+    throw new Error(`Unsupported boolean threshold comparison operator: ${thresholdComparison}`);
+  }
+
   return false;
 };
 
@@ -258,7 +269,7 @@ export const getBreachedThreshold = (value: Primitive, thresholds: Threshold[]):
     return undefined;
   }
 
-  if (typeof value === 'string') {
+  if (typeof value === 'string' || typeof value === 'boolean') {
     return thresholds.find(threshold => isThresholdBreached(value, threshold)) || undefined;
   }
 

--- a/packages/synchro-charts/src/components/charts/common/types.ts
+++ b/packages/synchro-charts/src/components/charts/common/types.ts
@@ -105,8 +105,8 @@ type AnnotationLabel = {
   show: boolean;
 };
 
-export type AnnotationValue = number | string | Date;
-export type ThresholdValue = number | string;
+export type AnnotationValue = number | string | boolean | Date;
+export type ThresholdValue = number | string | boolean;
 
 export interface Annotation<T extends AnnotationValue> {
   color: string;
@@ -144,7 +144,7 @@ export interface Threshold<T extends ThresholdValue = ThresholdValue> extends An
 
 export type XAnnotation = Annotation<Date>;
 
-export type YAnnotation = Annotation<number | string> | Threshold;
+export type YAnnotation = Annotation<number | string | boolean> | Threshold;
 
 export interface Annotations {
   show?: boolean;

--- a/packages/synchro-charts/src/components/charts/sc-tooltip/sort.ts
+++ b/packages/synchro-charts/src/components/charts/sc-tooltip/sort.ts
@@ -4,7 +4,7 @@ import { DataPoint, Primitive } from '../../../utils/dataTypes';
  * Sorts points in order of their points values.
  * Places objects with no point at the end of the list.
  */
-export const sortTooltipPoints = (attr: (point: DataPoint<Primitive>) => number | string) => (
+export const sortTooltipPoints = (attr: (point: DataPoint<Primitive>) => number | string | boolean) => (
   a: { point?: DataPoint<Primitive> },
   b: { point?: DataPoint<Primitive> }
 ): number => {

--- a/packages/synchro-charts/src/components/sc-widget-grid/sc-grid-tooltip.tsx
+++ b/packages/synchro-charts/src/components/sc-widget-grid/sc-grid-tooltip.tsx
@@ -83,7 +83,10 @@ export class ScGridTooltip {
                   <div>
                     <div class="awsui-util-label">Status:</div>
                     <div>
-                      <strong style={{ color }}>{this.alarmPoint.y}</strong> since{' '}
+                      <strong style={{ color }}>
+                        <Value value={this.alarmPoint.y} />
+                      </strong>{' '}
+                      since{' '}
                       {new Date(this.alarmPoint.x).toLocaleString('en-US', {
                         hour12: true,
                         minute: 'numeric',

--- a/packages/synchro-charts/src/components/value/Value.tsx
+++ b/packages/synchro-charts/src/components/value/Value.tsx
@@ -16,6 +16,6 @@ export const Value = ({ isEnabled = true, value, unit }: { isEnabled?: boolean; 
     return [round(value), unit && <span class="unit"> {unit}</span>];
   }
 
-  /** Display String */
-  return [value, unit && <span class="unit"> {unit}</span>];
+  /** Display String or Booleans */
+  return [String(value), unit && <span class="unit"> {unit}</span>];
 };

--- a/packages/synchro-charts/src/utils/dataTypes.ts
+++ b/packages/synchro-charts/src/utils/dataTypes.ts
@@ -4,7 +4,7 @@ import { DataType, StreamType } from './dataConstants';
  * Types which represent the data and data streams.
  */
 
-export type Primitive = string | number;
+export type Primitive = string | number | boolean;
 
 export type Timestamp = number;
 


### PR DESCRIPTION
## Overview
allows for booleans in data, alarms, and annotations

KPI
<img width="557" alt="image" src="https://user-images.githubusercontent.com/28601414/202008133-3f1462b9-a58b-4f0c-9dab-f7df52c5c90d.png">

Grid
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/28601414/202008215-9050cd7d-fe11-4411-95f5-6cf17a58d855.png">

Timeline
<img width="523" alt="image" src="https://user-images.githubusercontent.com/28601414/202008451-b9616ac1-5d8d-44be-aa63-6621d53f91d2.png">

Table
<img width="552" alt="image" src="https://user-images.githubusercontent.com/28601414/202009229-da961d9b-b0bc-442f-a630-62fba40644d4.png">


## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
