### PR TITLE
feat(sc-grid-tooltip): Added input parameters

### DIFF
--- a/packages/synchro-charts/src/components.d.ts
+++ b/packages/synchro-charts/src/components.d.ts
@@ -10,7 +10,7 @@ import { Annotations, Axis, LayoutConfig, Legend, LegendConfig, MovementConfig, 
 import { Trend, TrendResult } from "./components/charts/common/trends/types";
 import { DATA_ALIGNMENT, StatusIcon } from "./components/charts/common/constants";
 import { POINT_TYPE } from "./components/charts/sc-webgl-base-chart/activePoints";
-import { DialMessages, DialSizeConfig, RecursivePartial } from "./components/sc-dial/utils/type";
+import { DialMessages, DialSizeConfig, RecursivePartial, TooltipMessage } from "./components/sc-dial/utils/type";
 import { RectScrollFixed } from "./utils/types";
 import { LabelsConfig } from "./components/common/types";
 import { Cell, Row } from "./components/sc-table/constructTableData";
@@ -137,8 +137,11 @@ export namespace Components {
         "alarmPoint"?: DataPoint;
         "breachedThreshold"?: Threshold;
         "isEnabled": boolean;
+        "messageOverrides": RecursivePartial<TooltipMessage>;
         "propertyPoint"?: DataPoint;
         "title": string;
+        "unit"?: string;
+        "value"?: number | string;
     }
     interface ScHelpTooltip {
         "message": string;
@@ -1597,8 +1600,11 @@ declare namespace LocalJSX {
         "alarmPoint"?: DataPoint;
         "breachedThreshold"?: Threshold;
         "isEnabled"?: boolean;
+        "messageOverrides"?: RecursivePartial<TooltipMessage>;
         "propertyPoint"?: DataPoint;
         "title"?: string;
+        "unit"?: string;
+        "value"?: number | string;
     }
     interface ScHelpTooltip {
         "message": string;

--- a/packages/synchro-charts/src/components/sc-dial/sc-dial-base/sc-dial-base.tsx
+++ b/packages/synchro-charts/src/components/sc-dial/sc-dial-base/sc-dial-base.tsx
@@ -63,6 +63,9 @@ export class ScDialBase {
         propertyPoint={this.propertyPoint}
         alarmPoint={this.alarmStream && this.propertyPoint}
         breachedThreshold={this.breachedThreshold}
+        unit={unit}
+        value={value}
+        messageOverrides={this.messages.tooltip}
         isEnabled
       >
         <div class="sc-dialbase-container">

--- a/packages/synchro-charts/src/components/sc-dial/utils/type.ts
+++ b/packages/synchro-charts/src/components/sc-dial/utils/type.ts
@@ -24,9 +24,17 @@ export type DialErrorMessages = {
   dataNotLimitsError: string;
 };
 
+export type TooltipMessage = {
+  tooltipValueTitles: string;
+  tooltipValueTimeDescribed: string;
+  tooltipStatusTitles: string;
+  tooltipStatusDescribed: string;
+};
+
 export type DialMessages = {
   error: DialErrorMessages;
   loading: string;
+  tooltip: TooltipMessage;
 };
 
 /**

--- a/packages/synchro-charts/src/components/sc-dial/utils/util.ts
+++ b/packages/synchro-charts/src/components/sc-dial/utils/util.ts
@@ -1,4 +1,4 @@
-import { DialErrorMessages, DialMessages } from './type';
+import { DialErrorMessages, DialMessages, TooltipMessage } from './type';
 
 const loading = 'Loading';
 
@@ -33,7 +33,15 @@ export const DefaultDialErrorMessages: DialErrorMessages = {
   dataNotLimitsError: 'Invalid data',
 };
 
+export const DefaultTooltipMessages: TooltipMessage = {
+  tooltipValueTitles: 'Latest value:',
+  tooltipValueTimeDescribed: 'at',
+  tooltipStatusTitles: 'Status:',
+  tooltipStatusDescribed: 'since',
+};
+
 export const DefaultDialMessages: DialMessages = {
   error: DefaultDialErrorMessages,
   loading,
+  tooltip: DefaultTooltipMessages,
 };

--- a/packages/synchro-charts/src/components/sc-widget-grid/sc-grid-tooltip.tsx
+++ b/packages/synchro-charts/src/components/sc-widget-grid/sc-grid-tooltip.tsx
@@ -1,10 +1,13 @@
 import { Component, Element, h, Prop } from '@stencil/core';
 
 import tippy, { Instance } from 'tippy.js';
+import merge from 'lodash.merge';
 import { TIPPY_SETTINGS } from '../common/toolTipSettings';
 import { DataPoint } from '../../utils/dataTypes';
 import { Value } from '../value/Value';
 import { Threshold } from '../charts/common/types';
+import { RecursivePartial, TooltipMessage } from '../sc-dial/utils/type';
+import { DefaultTooltipMessages } from '../sc-dial/utils/util';
 
 @Component({
   tag: 'sc-grid-tooltip',
@@ -18,8 +21,17 @@ export class ScGridTooltip {
   @Prop() propertyPoint?: DataPoint;
   @Prop() alarmPoint?: DataPoint;
   @Prop() breachedThreshold?: Threshold;
+  @Prop() unit?: string;
+  @Prop() value?: number | string;
+
+  @Prop() messageOverrides: RecursivePartial<TooltipMessage>;
 
   private tooltip: Instance | undefined;
+  private messages: TooltipMessage;
+
+  componentWillLoad() {
+    this.messages = merge(DefaultTooltipMessages, this.messageOverrides);
+  }
 
   componentDidLoad() {
     this.displayToolTip();
@@ -49,6 +61,10 @@ export class ScGridTooltip {
     const thereIsSomeData = this.propertyPoint != null || this.alarmPoint != null;
     const color = this.breachedThreshold ? this.breachedThreshold.color : undefined;
     const displaysMoreThanTitle = thereIsSomeData && this.isEnabled;
+    const icon = this.breachedThreshold ? this.breachedThreshold.icon : undefined;
+    const label = this.breachedThreshold ? this.breachedThreshold.label : undefined;
+    const unit = this.unit || '';
+    const value = this.value || this.propertyPoint?.y;
 
     return (
       <div class="tooltip-container">
@@ -61,12 +77,13 @@ export class ScGridTooltip {
               <div class="awsui-util-spacing-v-s">
                 {this.propertyPoint && (
                   <div>
-                    <div class="awsui-util-label">Latest value:</div>
+                    <div class="awsui-util-label">{this.messages.tooltipValueTitles}</div>
                     <div>
                       <strong style={{ color }}>
-                        <Value value={this.propertyPoint.y} />
+                        {icon && <sc-chart-icon name={icon} color={color} style={{ marginRight: '3px' }} />}
+                        <Value value={value} unit={unit} />
                       </strong>{' '}
-                      at{' '}
+                      {this.messages.tooltipValueTimeDescribed}{' '}
                       {new Date(this.propertyPoint.x).toLocaleString('en-US', {
                         hour12: true,
                         minute: 'numeric',
@@ -79,24 +96,28 @@ export class ScGridTooltip {
                   </div>
                 )}
 
-                {this.alarmPoint && (
-                  <div>
-                    <div class="awsui-util-label">Status:</div>
+                {label ? (
+                  <strong style={{ color }}>{this.breachedThreshold?.label?.text}</strong>
+                ) : (
+                  this.alarmPoint && (
                     <div>
-                      <strong style={{ color }}>{this.alarmPoint.y}</strong> since{' '}
-                      {new Date(this.alarmPoint.x).toLocaleString('en-US', {
-                        hour12: true,
-                        minute: 'numeric',
-                        hour: 'numeric',
-                        year: 'numeric',
-                        month: 'numeric',
-                        day: 'numeric',
-                      })}
-                      {this.breachedThreshold && this.breachedThreshold.description && (
-                        <div>({this.breachedThreshold.description})</div>
-                      )}
+                      <div class="awsui-util-label">{this.messages.tooltipValueTitles}</div>
+                      <div>
+                        <strong style={{ color }}>{this.alarmPoint.y}</strong> {this.messages.tooltipStatusDescribed}{' '}
+                        {new Date(this.alarmPoint.x).toLocaleString('en-US', {
+                          hour12: true,
+                          minute: 'numeric',
+                          hour: 'numeric',
+                          year: 'numeric',
+                          month: 'numeric',
+                          day: 'numeric',
+                        })}
+                        {this.breachedThreshold && this.breachedThreshold.description && (
+                          <div>({this.breachedThreshold.description})</div>
+                        )}
+                      </div>
                     </div>
-                  </div>
+                  )
                 )}
               </div>
             </div>


### PR DESCRIPTION
## Overview
Added input parameters at(sc-grid-tooltip): 
Two more inputs, `value`(optional) and `unit`(optional), are added.  
Changed the input parameter type of `messageOverrides` to solve the problem of hard coding.

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
