### PR TITLE
feat: add 'contains' operator to thresholds.

### DIFF
--- a/packages/doc-site/docs/threshold.md
+++ b/packages/doc-site/docs/threshold.md
@@ -666,3 +666,118 @@ const annotations = {
 ```
 
 Note that if severity is left undefined, any threshold with a defined severity will be considered higher priority.
+
+
+### Threshold strings
+A threshold value can be a string or an array of strings.
+
+If the threshold value is a string or an array of strings, the `comparisonOperator` must be `EQUAL` OR `CONTAINS`. The `EQUAL` operator requires the data value to strictly equal the threshold value. The `CONTAINS` operator requires the data value to partly match the threshold value.
+
+Threshold strings and arrays of strings are only supported on the `KPI`, `StatusGrid`, `StatusTimeline`, and `Table` components.
+
+```jsx
+import { Table } from "@synchro-charts/react";
+import { LEGEND_POSITION, DataType, COMPARISON_OPERATOR } from '@synchro-charts/core';
+const windTableColumn = {
+  header: 'Wind temperature',
+  rows:[
+    'wind-temperature-station-1',
+    'wind-temperature-station-2',
+    'wind-temperature-station-3',
+  ],
+};
+
+const carSpeedTableColumn = {
+  header: 'Car speed',
+  rows: [
+    'car-speed', 
+    'car-speed-2',
+    'car-speed-3',
+  ],
+};
+
+<div style={{ width: '100%', height: '300px' }}>
+  <Table
+    dataStreams={[
+      {
+        id: 'wind-temperature-station-1',
+        name: 'Wind temperature',
+        data: [{
+          x: new Date(2001, 0, 0).getTime(),
+          y: 'High',
+        }],
+        resolution: 0,
+        dataType: DataType.NUMBER,
+      },
+      {
+        id: 'wind-temperature-station-2',
+        name: 'Wind temperature',
+        data: [{
+          x: new Date(2001, 0, 0).getTime(),
+          y: 'Windy',
+        }],
+        resolution: 0,
+        dataType: DataType.NUMBER,
+      },
+      {
+        id: 'wind-temperature-station-3',
+        name: 'Wind temperature',
+        data: [{
+          x: new Date(2001, 0, 0).getTime(),
+          y: 'Low',
+        }],
+        resolution: 0,
+        dataType: DataType.NUMBER,
+      },
+      {
+        id: 'car-speed',
+        name: 'Car speed',
+        data: [{
+          x: new Date(2001, 0, 0).getTime(),
+          y: 'Very High',
+        }],
+        resolution: 0,
+        dataType: DataType.NUMBER,
+      },
+      {
+        id: 'car-speed-2',
+        name: 'Car speed',
+        data: [{
+          x: new Date(2001, 0, 0).getTime(),
+          y: 'Dangerous',
+        }],
+        resolution: 0,
+        dataType: DataType.NUMBER,
+      },
+      {
+        id: 'car-speed-3',
+        name: 'Car speed',
+        data: [{
+          x: new Date(2001, 0, 0).getTime(),
+          y: 'Very Low',
+        }],
+        resolution: 0,
+        dataType: DataType.NUMBER,
+      },
+    ]}
+    widgetId="widget-id"
+    annotations={{
+      y: [{
+        color: '#d13212',
+        value: ['High', 'Dangerous'],
+        comparisonOperator: COMPARISON_OPERATOR.CONTAINS,
+      }, {
+        color: '#ff9900',
+        value: 'Low',
+        comparisonOperator: COMPARISON_OPERATOR.CONTAINS,
+      }],
+    }}
+    legend= {{
+      width: 100,
+      position: LEGEND_POSITION.BOTTOM,
+    }}
+    viewport={{ duration: 1000 }}
+    tableColumns={[windTableColumn, carSpeedTableColumn]}
+  />
+</div>
+```

--- a/packages/doc-site/src/components/StatusGrid.md
+++ b/packages/doc-site/src/components/StatusGrid.md
@@ -5,8 +5,8 @@ import { LEGEND_POSITION, DataType, COMPARISON_OPERATOR, StreamType } from '@syn
   <StatusGrid
     dataStreams={[
       {
-        id: 'wind-temperture',
-        name: 'Wind temperture',
+        id: 'wind-temperature',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 15,
@@ -100,8 +100,8 @@ import { LEGEND_POSITION, DataType, COMPARISON_OPERATOR } from '@synchro-charts/
   <StatusGrid
     dataStreams={[
       {
-        id: 'wind-temperture',
-        name: 'Wind temperture',
+        id: 'wind-temperature',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0),
           y: 15,
@@ -147,8 +147,8 @@ import { LEGEND_POSITION, DataType, COMPARISON_OPERATOR } from '@synchro-charts/
   <StatusGrid
     dataStreams={[
       {
-        id: 'wind-temperture',
-        name: 'Wind temperture',
+        id: 'wind-temperature',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 15,

--- a/packages/doc-site/src/components/Table.md
+++ b/packages/doc-site/src/components/Table.md
@@ -1,14 +1,14 @@
 ```jsx
 import { LEGEND_POSITION, DataType, COMPARISON_OPERATOR } from '@synchro-charts/core';
 const windTableColumn = {
-  header: 'Wind temperture',
+  header: 'Wind temperature',
   rows:[
-    'wind-temperture-station-1',
-    'wind-temperture-station-2',
-    'wind-temperture-station-3',
-    'wind-temperture-station-4',
-    'wind-temperture-station-5',
-    'wind-temperture-station-6',
+    'wind-temperature-station-1',
+    'wind-temperature-station-2',
+    'wind-temperature-station-3',
+    'wind-temperature-station-4',
+    'wind-temperature-station-5',
+    'wind-temperature-station-6',
   ],
 };
 
@@ -28,8 +28,8 @@ const carSpeedTableColumn = {
   <Table
     dataStreams={[
       {
-        id: 'wind-temperture-station-1',
-        name: 'Wind temperture',
+        id: 'wind-temperature-station-1',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 15,
@@ -39,8 +39,8 @@ const carSpeedTableColumn = {
         dataType: DataType.NUMBER,
       },
       {
-        id: 'wind-temperture-station-2',
-        name: 'Wind temperture',
+        id: 'wind-temperature-station-2',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 30,
@@ -50,8 +50,8 @@ const carSpeedTableColumn = {
         dataType: DataType.NUMBER,
       },
       {
-        id: 'wind-temperture-station-3',
-        name: 'Wind temperture',
+        id: 'wind-temperature-station-3',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 40,
@@ -61,8 +61,8 @@ const carSpeedTableColumn = {
         dataType: DataType.NUMBER,
       },
       {
-        id: 'wind-temperture-station-4',
-        name: 'Wind temperture',
+        id: 'wind-temperature-station-4',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 50,
@@ -72,8 +72,8 @@ const carSpeedTableColumn = {
         dataType: DataType.NUMBER,
       },
       {
-        id: 'wind-temperture-station-5',
-        name: 'Wind temperture',
+        id: 'wind-temperature-station-5',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 60,
@@ -83,8 +83,8 @@ const carSpeedTableColumn = {
         dataType: DataType.NUMBER,
       },
       {
-        id: 'wind-temperture-station-6',
-        name: 'Wind temperture',
+        id: 'wind-temperature-station-6',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 70,
@@ -177,8 +177,8 @@ set of data streams under one column.
 An example of creating the table column:
 ```jsx static
 const windTableColumn = {
-  header: 'Wind temperture',
-  rows:['wind-temperture-station-1', 'wind-temperture-station-2'],
+  header: 'Wind temperature',
+  rows:['wind-temperature-station-1', 'wind-temperature-station-2'],
 };
 ```
 
@@ -192,14 +192,14 @@ In this example, we are showing temperatures from two different weather stations
 ```jsx
 import { LEGEND_POSITION, DataType, COMPARISON_OPERATOR } from '@synchro-charts/core';
 const windTableColumn = {
-  header: 'Wind temperture',
+  header: 'Wind temperature',
   rows:[
-    'wind-temperture-station-1',
-    'wind-temperture-station-2',
-    'wind-temperture-station-3',
-    'wind-temperture-station-4',
-    'wind-temperture-station-5',
-    'wind-temperture-station-6',
+    'wind-temperature-station-1',
+    'wind-temperature-station-2',
+    'wind-temperature-station-3',
+    'wind-temperature-station-4',
+    'wind-temperature-station-5',
+    'wind-temperature-station-6',
   ],
 };
 
@@ -219,8 +219,8 @@ const carSpeedTableColumn = {
   <Table
     dataStreams={[
       {
-        id: 'wind-temperture-station-1',
-        name: 'Wind temperture',
+        id: 'wind-temperature-station-1',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 15,
@@ -230,8 +230,8 @@ const carSpeedTableColumn = {
         dataType: DataType.NUMBER,
       },
       {
-        id: 'wind-temperture-station-2',
-        name: 'Wind temperture',
+        id: 'wind-temperature-station-2',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 30,
@@ -241,8 +241,8 @@ const carSpeedTableColumn = {
         dataType: DataType.NUMBER,
       },
       {
-        id: 'wind-temperture-station-3',
-        name: 'Wind temperture',
+        id: 'wind-temperature-station-3',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 40,
@@ -252,8 +252,8 @@ const carSpeedTableColumn = {
         dataType: DataType.NUMBER,
       },
       {
-        id: 'wind-temperture-station-4',
-        name: 'Wind temperture',
+        id: 'wind-temperature-station-4',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 50,
@@ -263,8 +263,8 @@ const carSpeedTableColumn = {
         dataType: DataType.NUMBER,
       },
       {
-        id: 'wind-temperture-station-5',
-        name: 'Wind temperture',
+        id: 'wind-temperature-station-5',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 60,
@@ -274,8 +274,8 @@ const carSpeedTableColumn = {
         dataType: DataType.NUMBER,
       },
       {
-        id: 'wind-temperture-station-6',
-        name: 'Wind temperture',
+        id: 'wind-temperature-station-6',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 70,
@@ -411,26 +411,26 @@ Like the KPI, table status icon currently supports:
 ```jsx
 import { LEGEND_POSITION, DataType, COMPARISON_OPERATOR, StatusIcon, StreamType } from '@synchro-charts/core';
 const windTableColumn = {
-    header: 'Wind temperture',
+    header: 'Wind temperature',
     rows:[
-      'wind-temperture-station-1', 
-      'wind-temperture-station-2',
-      'wind-temperture-station-3',
-      'wind-temperture-station-4',
-      'wind-temperture-station-5',
-      'wind-temperture-station-6',
+      'wind-temperature-station-1', 
+      'wind-temperature-station-2',
+      'wind-temperature-station-3',
+      'wind-temperature-station-4',
+      'wind-temperature-station-5',
+      'wind-temperature-station-6',
     ],
 };
 
 const windTempAlarm = {
   header: 'Status',
   rows:[
-    'wind-temperture-station-1-alarm', 
-    'wind-temperture-station-2-alarm',
-    'wind-temperture-station-3-alarm',
-    'wind-temperture-station-4-alarm',
-    'wind-temperture-station-5-alarm',
-    'wind-temperture-station-6-alarm',
+    'wind-temperature-station-1-alarm', 
+    'wind-temperature-station-2-alarm',
+    'wind-temperature-station-3-alarm',
+    'wind-temperature-station-4-alarm',
+    'wind-temperature-station-5-alarm',
+    'wind-temperature-station-6-alarm',
   ],
 };
 
@@ -438,8 +438,8 @@ const windTempAlarm = {
   <Table
     dataStreams={[
       {
-        id: 'wind-temperture-station-1',
-        name: 'Wind temperture',
+        id: 'wind-temperature-station-1',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 15,
@@ -449,8 +449,8 @@ const windTempAlarm = {
         dataType: DataType.NUMBER,
       },
       {
-        id: 'wind-temperture-station-2',
-        name: 'Wind temperture',
+        id: 'wind-temperature-station-2',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 30,
@@ -460,8 +460,8 @@ const windTempAlarm = {
         dataType: DataType.NUMBER,
       },
       {
-        id: 'wind-temperture-station-3',
-        name: 'Wind temperture',
+        id: 'wind-temperature-station-3',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 40,
@@ -471,8 +471,8 @@ const windTempAlarm = {
         dataType: DataType.NUMBER,
       },
       {
-        id: 'wind-temperture-station-4',
-        name: 'Wind temperture',
+        id: 'wind-temperature-station-4',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 50,
@@ -482,8 +482,8 @@ const windTempAlarm = {
         dataType: DataType.NUMBER,
       },
       {
-        id: 'wind-temperture-station-5',
-        name: 'Wind temperture',
+        id: 'wind-temperature-station-5',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 60,
@@ -493,8 +493,8 @@ const windTempAlarm = {
         dataType: DataType.NUMBER,
       },
       {
-        id: 'wind-temperture-station-6',
-        name: 'Wind temperture',
+        id: 'wind-temperature-station-6',
+        name: 'Wind temperature',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
           y: 70,
@@ -504,7 +504,7 @@ const windTempAlarm = {
         dataType: DataType.NUMBER,
       },
       {
-        id: 'wind-temperture-station-1-alarm',
+        id: 'wind-temperature-station-1-alarm',
         name: 'station 1 alarm',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
@@ -515,7 +515,7 @@ const windTempAlarm = {
         streamType: StreamType.ALARM,
       },
       {
-        id: 'wind-temperture-station-2-alarm',
+        id: 'wind-temperature-station-2-alarm',
         name: 'station 2 alarm',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
@@ -526,7 +526,7 @@ const windTempAlarm = {
         streamType: StreamType.ALARM,
       },
       {
-        id: 'wind-temperture-station-3-alarm',
+        id: 'wind-temperature-station-3-alarm',
         name: 'station 3 alarm',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
@@ -537,7 +537,7 @@ const windTempAlarm = {
         streamType: StreamType.ALARM,
       },
       {
-        id: 'wind-temperture-station-4-alarm',
+        id: 'wind-temperature-station-4-alarm',
         name: 'station 4 alarm',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
@@ -548,7 +548,7 @@ const windTempAlarm = {
         streamType: StreamType.ALARM,
       },
       {
-        id: 'wind-temperture-station-5-alarm',
+        id: 'wind-temperature-station-5-alarm',
         name: 'station 5 alarm',
         data: [{
           x: new Date(2001, 0, 0).getTime(),
@@ -559,7 +559,7 @@ const windTempAlarm = {
         streamType: StreamType.ALARM,
       },
       {
-        id: 'wind-temperture-station-6-alarm',
+        id: 'wind-temperature-station-6-alarm',
         name: 'station 6 alarm',
         data: [{
           x: new Date(2001, 0, 0).getTime(),

--- a/packages/synchro-charts/src/components/charts/common/annotations/utils.spec.ts
+++ b/packages/synchro-charts/src/components/charts/common/annotations/utils.spec.ts
@@ -232,45 +232,53 @@ describe('getValueAndText formatText', () => {
 
 describe('annotation logic', () => {
   describe.each`
-    key      | thresholdValue | operator                                  | expected
-    ${1}     | ${2}           | ${COMPARISON_OPERATOR.GREATER_THAN_EQUAL} | ${false}
-    ${1}     | ${2}           | ${COMPARISON_OPERATOR.GREATER_THAN}       | ${false}
-    ${1}     | ${2}           | ${COMPARISON_OPERATOR.LESS_THAN_EQUAL}    | ${true}
-    ${1}     | ${2}           | ${COMPARISON_OPERATOR.LESS_THAN}          | ${true}
-    ${1}     | ${1}           | ${COMPARISON_OPERATOR.GREATER_THAN_EQUAL} | ${true}
-    ${1}     | ${1}           | ${COMPARISON_OPERATOR.GREATER_THAN}       | ${false}
-    ${1}     | ${1}           | ${COMPARISON_OPERATOR.LESS_THAN_EQUAL}    | ${true}
-    ${1}     | ${1}           | ${COMPARISON_OPERATOR.LESS_THAN}          | ${false}
-    ${0}     | ${0}           | ${COMPARISON_OPERATOR.GREATER_THAN_EQUAL} | ${true}
-    ${0}     | ${0}           | ${COMPARISON_OPERATOR.GREATER_THAN}       | ${false}
-    ${0}     | ${0}           | ${COMPARISON_OPERATOR.LESS_THAN_EQUAL}    | ${true}
-    ${0}     | ${0}           | ${COMPARISON_OPERATOR.LESS_THAN}          | ${false}
-    ${-1}    | ${-1}          | ${COMPARISON_OPERATOR.GREATER_THAN_EQUAL} | ${true}
-    ${-1}    | ${-1}          | ${COMPARISON_OPERATOR.GREATER_THAN}       | ${false}
-    ${-1}    | ${-1}          | ${COMPARISON_OPERATOR.LESS_THAN_EQUAL}    | ${true}
-    ${-1}    | ${-1}          | ${COMPARISON_OPERATOR.LESS_THAN}          | ${false}
-    ${-1}    | ${0}           | ${COMPARISON_OPERATOR.GREATER_THAN_EQUAL} | ${false}
-    ${-1}    | ${0}           | ${COMPARISON_OPERATOR.GREATER_THAN}       | ${false}
-    ${-1}    | ${0}           | ${COMPARISON_OPERATOR.LESS_THAN_EQUAL}    | ${true}
-    ${-1}    | ${0}           | ${COMPARISON_OPERATOR.LESS_THAN}          | ${true}
-    ${1}     | ${0}           | ${COMPARISON_OPERATOR.GREATER_THAN_EQUAL} | ${true}
-    ${1}     | ${0}           | ${COMPARISON_OPERATOR.GREATER_THAN}       | ${true}
-    ${1}     | ${0}           | ${COMPARISON_OPERATOR.LESS_THAN_EQUAL}    | ${false}
-    ${1}     | ${0}           | ${COMPARISON_OPERATOR.LESS_THAN}          | ${false}
-    ${0}     | ${-1}          | ${COMPARISON_OPERATOR.GREATER_THAN_EQUAL} | ${true}
-    ${0}     | ${-1}          | ${COMPARISON_OPERATOR.GREATER_THAN}       | ${true}
-    ${0}     | ${-1}          | ${COMPARISON_OPERATOR.LESS_THAN_EQUAL}    | ${false}
-    ${0}     | ${-1}          | ${COMPARISON_OPERATOR.LESS_THAN}          | ${false}
-    ${1.5}   | ${1.5}         | ${COMPARISON_OPERATOR.EQUAL}              | ${true}
-    ${1.6}   | ${1.5}         | ${COMPARISON_OPERATOR.EQUAL}              | ${false}
-    ${0}     | ${0.1}         | ${COMPARISON_OPERATOR.EQUAL}              | ${false}
-    ${'UP'}  | ${'UP'}        | ${COMPARISON_OPERATOR.EQUAL}              | ${true}
-    ${'ON'}  | ${'OFF'}       | ${COMPARISON_OPERATOR.EQUAL}              | ${false}
-    ${''}    | ${'UP'}        | ${COMPARISON_OPERATOR.EQUAL}              | ${false}
-    ${'1'}   | ${1}           | ${COMPARISON_OPERATOR.EQUAL}              | ${true}
-    ${2e2}   | ${2e2}         | ${COMPARISON_OPERATOR.EQUAL}              | ${true}
-    ${'2e2'} | ${2e2}         | ${COMPARISON_OPERATOR.EQUAL}              | ${true}
-    ${NaN}   | ${NaN}         | ${COMPARISON_OPERATOR.EQUAL}              | ${false}
+    key          | thresholdValue      | operator                                  | expected
+    ${1}         | ${2}                | ${COMPARISON_OPERATOR.GREATER_THAN_EQUAL} | ${false}
+    ${1}         | ${2}                | ${COMPARISON_OPERATOR.GREATER_THAN}       | ${false}
+    ${1}         | ${2}                | ${COMPARISON_OPERATOR.LESS_THAN_EQUAL}    | ${true}
+    ${1}         | ${2}                | ${COMPARISON_OPERATOR.LESS_THAN}          | ${true}
+    ${1}         | ${1}                | ${COMPARISON_OPERATOR.GREATER_THAN_EQUAL} | ${true}
+    ${1}         | ${1}                | ${COMPARISON_OPERATOR.GREATER_THAN}       | ${false}
+    ${1}         | ${1}                | ${COMPARISON_OPERATOR.LESS_THAN_EQUAL}    | ${true}
+    ${1}         | ${1}                | ${COMPARISON_OPERATOR.LESS_THAN}          | ${false}
+    ${0}         | ${0}                | ${COMPARISON_OPERATOR.GREATER_THAN_EQUAL} | ${true}
+    ${0}         | ${0}                | ${COMPARISON_OPERATOR.GREATER_THAN}       | ${false}
+    ${0}         | ${0}                | ${COMPARISON_OPERATOR.LESS_THAN_EQUAL}    | ${true}
+    ${0}         | ${0}                | ${COMPARISON_OPERATOR.LESS_THAN}          | ${false}
+    ${-1}        | ${-1}               | ${COMPARISON_OPERATOR.GREATER_THAN_EQUAL} | ${true}
+    ${-1}        | ${-1}               | ${COMPARISON_OPERATOR.GREATER_THAN}       | ${false}
+    ${-1}        | ${-1}               | ${COMPARISON_OPERATOR.LESS_THAN_EQUAL}    | ${true}
+    ${-1}        | ${-1}               | ${COMPARISON_OPERATOR.LESS_THAN}          | ${false}
+    ${-1}        | ${0}                | ${COMPARISON_OPERATOR.GREATER_THAN_EQUAL} | ${false}
+    ${-1}        | ${0}                | ${COMPARISON_OPERATOR.GREATER_THAN}       | ${false}
+    ${-1}        | ${0}                | ${COMPARISON_OPERATOR.LESS_THAN_EQUAL}    | ${true}
+    ${-1}        | ${0}                | ${COMPARISON_OPERATOR.LESS_THAN}          | ${true}
+    ${1}         | ${0}                | ${COMPARISON_OPERATOR.GREATER_THAN_EQUAL} | ${true}
+    ${1}         | ${0}                | ${COMPARISON_OPERATOR.GREATER_THAN}       | ${true}
+    ${1}         | ${0}                | ${COMPARISON_OPERATOR.LESS_THAN_EQUAL}    | ${false}
+    ${1}         | ${0}                | ${COMPARISON_OPERATOR.LESS_THAN}          | ${false}
+    ${0}         | ${-1}               | ${COMPARISON_OPERATOR.GREATER_THAN_EQUAL} | ${true}
+    ${0}         | ${-1}               | ${COMPARISON_OPERATOR.GREATER_THAN}       | ${true}
+    ${0}         | ${-1}               | ${COMPARISON_OPERATOR.LESS_THAN_EQUAL}    | ${false}
+    ${0}         | ${-1}               | ${COMPARISON_OPERATOR.LESS_THAN}          | ${false}
+    ${1.5}       | ${1.5}              | ${COMPARISON_OPERATOR.EQUAL}              | ${true}
+    ${1.6}       | ${1.5}              | ${COMPARISON_OPERATOR.EQUAL}              | ${false}
+    ${0}         | ${0.1}              | ${COMPARISON_OPERATOR.EQUAL}              | ${false}
+    ${'UP'}      | ${'UP'}             | ${COMPARISON_OPERATOR.EQUAL}              | ${true}
+    ${'ON'}      | ${'OFF'}            | ${COMPARISON_OPERATOR.EQUAL}              | ${false}
+    ${''}        | ${'UP'}             | ${COMPARISON_OPERATOR.EQUAL}              | ${false}
+    ${'1'}       | ${1}                | ${COMPARISON_OPERATOR.EQUAL}              | ${true}
+    ${2e2}       | ${2e2}              | ${COMPARISON_OPERATOR.EQUAL}              | ${true}
+    ${'2e2'}     | ${2e2}              | ${COMPARISON_OPERATOR.EQUAL}              | ${true}
+    ${NaN}       | ${NaN}              | ${COMPARISON_OPERATOR.EQUAL}              | ${false}
+    ${'GO'}      | ${'STOP'}           | ${COMPARISON_OPERATOR.CONTAINS}           | ${false}
+    ${'STOP'}    | ${'STOPPED'}        | ${COMPARISON_OPERATOR.CONTAINS}           | ${false}
+    ${'STOP'}    | ${'STOP'}           | ${COMPARISON_OPERATOR.CONTAINS}           | ${true}
+    ${'STOPPED'} | ${'STOP'}           | ${COMPARISON_OPERATOR.CONTAINS}           | ${true}
+    ${'3 STOP'}  | ${'STOP'}           | ${COMPARISON_OPERATOR.CONTAINS}           | ${true}
+    ${'GO'}      | ${['STOP', 'AUTO']} | ${COMPARISON_OPERATOR.CONTAINS}           | ${false}
+    ${'STOP'}    | ${['STOP']}         | ${COMPARISON_OPERATOR.CONTAINS}           | ${true}
+    ${'STOP'}    | ${['STOP', 'AUTO']} | ${COMPARISON_OPERATOR.CONTAINS}           | ${true}
   `('Check if data point is within the threshold', ({ key, thresholdValue, operator, expected }) => {
     test(`Given the data value of
     ${key} and threshold value of ${thresholdValue} and

--- a/packages/synchro-charts/src/components/charts/common/constants.ts
+++ b/packages/synchro-charts/src/components/charts/common/constants.ts
@@ -24,6 +24,7 @@ export enum COMPARISON_OPERATOR {
   LESS_THAN_EQUAL = 'LTE',
   GREATER_THAN_EQUAL = 'GTE',
   EQUAL = 'EQ',
+  CONTAINS = 'CONTAINS',
 }
 
 export const COMPARATOR_MAP = {

--- a/packages/synchro-charts/src/utils/dataTypes.ts
+++ b/packages/synchro-charts/src/utils/dataTypes.ts
@@ -6,6 +6,8 @@ import { DataType, StreamType } from './dataConstants';
 
 export type Primitive = string | number | boolean;
 
+export type ThresholdDataTypes = string | string[] | number | boolean;
+
 export type Timestamp = number;
 
 export type DataPoint<T extends Primitive = Primitive> = { x: Timestamp; y: T };

--- a/packages/synchro-charts/src/utils/number.spec.ts
+++ b/packages/synchro-charts/src/utils/number.spec.ts
@@ -50,6 +50,7 @@ describe.each`
 describe.each`
   value           | expected
   ${'test'}       | ${false}
+  ${['test']}     | ${false}
   ${new Date()}   | ${false}
   ${NaN}          | ${false}
   ${'NaN'}        | ${false}

--- a/packages/synchro-charts/src/utils/number.ts
+++ b/packages/synchro-charts/src/utils/number.ts
@@ -1,4 +1,4 @@
-import { Primitive } from './dataTypes';
+import { ThresholdDataTypes } from './dataTypes';
 
 const MAX_PRECISION = 4;
 
@@ -26,5 +26,5 @@ export const round = (num: number): number => {
 /**
  * Checks if value can be used as a number
  */
-export const isNumeric = (value: Primitive): boolean =>
+export const isNumeric = (value: ThresholdDataTypes): boolean =>
   /^(\+|-)?(Infinity|\d+)(\.\d+)?e?((\+|-)?\d+)?$/.test(String(value));


### PR DESCRIPTION
## Overview
Adds a `contains` operator to thresholds and documentation for threshold strings and arrays of strings. Also noticed a typo of `temperature`, so updated that.

In order to extend the use case of matching strings, we're adding the ability for the user to match part of a threshold string. We've also extended the string matching to match at least one string in an array.

For example, if using the `contains` operator and the threshold value is `STOP` and the data value is `STOPPED`, the threshold will be breached.

If using the `contains` operator and the threshold value is an array of strings, like [`STOP`, `WARNING`], and the data value is `STOPPED`, the threshold will be breached.


## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
