### PR TITLE
chore: move check for unsupported data

### DIFF
--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
@@ -311,9 +311,6 @@ export class ScWebglBaseChart {
 
   @Watch('dataStreams')
   onDataStreamsChange() {
-    // avoid updating if new dataStream has unsupported data
-    if (!this.getHasSupportedData()) return;
-
     // Avoiding a deep equality check due to the cost on a potentially large object.
     this.onUpdate(this.activeViewPort(), true);
   }
@@ -561,6 +558,9 @@ export class ScWebglBaseChart {
     hasAnnotationChanged: boolean = false,
     shouldRerender: boolean = false
   ) => {
+    // avoid updating if dataStream has unsupported data
+    if (!this.getHasSupportedData()) return;
+
     const hasViewPortChanged = this.start.getTime() !== start.getTime() || this.end.getTime() !== end.getTime();
     if (hasViewPortChanged && !shouldBlockDateRangeChangedEvent) {
       this.onDateRangeChange([start, end, this.viewport.group]);


### PR DESCRIPTION
## Overview
moving the check for `hasSupportedData` since some `onUpdate` calls were still causing errors in appkit

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
