### PR TITLE
fix: threshold outside of y range include negative yMin rendering bug

### DIFF
--- a/packages/synchro-charts/src/components/sc-gauge/sc-gauge.tsx
+++ b/packages/synchro-charts/src/components/sc-gauge/sc-gauge.tsx
@@ -75,7 +75,7 @@ export class ScGauge {
 
     splitThresholds.L = splitThresholds.L.map(
       (threshold: GuageOuterRing): GuageOuterRing => {
-        const percent = (threshold.value as number) / distance;
+        const percent = ((threshold.value as number) - yMin) / distance;
         const showValue = threshold.value;
 
         return { ...threshold, percent, showValue };
@@ -88,7 +88,7 @@ export class ScGauge {
         let showValue: string | number;
         if (index === length - 1) {
           percent = 1;
-          showValue = distance;
+          showValue = yMax;
         } else {
           percent = (arrays[index + 1].value as number) / distance;
           showValue = `${arrays[index + 1].value}`;
@@ -99,7 +99,7 @@ export class ScGauge {
 
     const outerRingRange = splitThresholds.L.concat(splitThresholds.G);
 
-    return outerRingRange;
+    return outerRingRange.filter(item => item.percent <= 1 && item.percent >= 0);
   };
 
   render() {


### PR DESCRIPTION
## Overview
Provide an explanation of what the change is (gauge)
fix: threshold outside of y range rendering bug #199 
fix: negative yMin while threshold is present causes incorrect rendering of threshold arc #203

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
