### PR TITLE
feat(legend): add optional field `hidden` to LegendConfig

### DIFF
--- a/packages/synchro-charts/src/components/charts/common/types.ts
+++ b/packages/synchro-charts/src/components/charts/common/types.ts
@@ -44,6 +44,7 @@ export interface LegendConfig {
   legendLabels?: {
     title: string;
   };
+  hidden?: boolean;
 }
 
 /**
@@ -200,6 +201,7 @@ export interface ThresholdColorAndIcon {
   color: string | undefined;
   icon: StatusIcon | undefined;
 }
+
 export namespace Legend {
   export interface Props {
     config: LegendConfig;

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
@@ -910,7 +910,7 @@ export class ScWebglBaseChart {
             />
           )}
         </DataContainer>
-        {this.legend && (
+        {this.legend && !this.legend.hidden && (
           <ChartLegendContainer config={this.legend} legendHeight={LEGEND_HEIGHT} size={chartSizeConfig}>
             {this.renderLegendComponent({ isLoading: shouldDisplayAsLoading, thresholds, showDataStreamColor })}
           </ChartLegendContainer>


### PR DESCRIPTION
## Overview
Previously if we don't want to display legend on a chart, we need to remove the whole `legend:LegendConfig` object from widget definition by setting it as `undefined`. However, this brings a problem if users want to toggle legend back, users would lose all previous legend settings, and also increases complexity dealing with default values of legend config.

Adding this optional `hidden`  would help user to toggle legend off&on without losing any exist legend config. 

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
