### PR TITLE
chore:add optional aggregationType to dataStream

### DIFF
--- a/packages/doc-site/docs/annotation.md
+++ b/packages/doc-site/docs/annotation.md
@@ -28,6 +28,7 @@ const dataStreams = [{
   color: '#1d8102',
   name: 'Car Count',
   resolution: DAY_RESOLUTION, // one day
+  aggregationType: 'AVERAGE',
   aggregates: {
     [DAY_RESOLUTION]: [{
       x: new Date(2000, 1, 0).getTime(),
@@ -85,6 +86,7 @@ const dataStreams = [{
       dataType: 'NUMBER',
       resolution: 1000 * 60 * 24 * 60 * 24,
       color: '#1d8102',
+      aggregationType: 'AVERAGE',
       aggregates: {
         [1000 * 60 * 24 * 60 * 24]: [{
           x: new Date(2000, 1, 0).getTime(),
@@ -197,6 +199,7 @@ const dataStreams = [{
   color: '#1d8102',
   name: 'Car Count',
   resolution: DAY_RESOLUTION, // one day
+  aggregationType: 'AVERAGE',
   aggregates: {
     [DAY_RESOLUTION]: [{
       x: new Date(2000, 1, 0).getTime(),
@@ -254,6 +257,7 @@ const dataStreams = [{
       dataType: 'NUMBER',
       resolution: 1000 * 60 * 24 * 60 * 24,
       color: '#1d8102',
+      aggregationType: 'AVERAGE',
       aggregates: {
         [1000 * 60 * 24 * 60 * 24]: [{
           x: new Date(2000, 1, 0).getTime(),

--- a/packages/doc-site/docs/properties.md
+++ b/packages/doc-site/docs/properties.md
@@ -157,7 +157,14 @@
   - `name`: string
 
     A name by which to refer to the data stream. Utilized in the legend.
+
+  - `aggregationType`: string
   
+    (Optional) The type of aggregate data contained within the aggregates object:
+
+    **`AVERAGE`**
+    <!-- upcoming support **`COUNT`**, **`MAXIMUM`**, **`MINIMUM`**, **`STANDARD_DEVIATION`**, **`SUM`** -->
+
   - `aggregates`: Object
     
     (Optional) A map of resolution (in milliseconds) to its associated data points. The `resolution` in the `datastream`

--- a/packages/doc-site/docs/synchronization.md
+++ b/packages/doc-site/docs/synchronization.md
@@ -18,6 +18,7 @@ const DAY_RESOLUTION = 1000 * 60 * 60 * 24; // one day
           color: '#1d8102',
           name: 'Car Count',
           resolution: DAY_RESOLUTION, // one day
+          aggregationType: 'AVERAGE',
           aggregates: {
             [DAY_RESOLUTION]: [
               {
@@ -74,6 +75,7 @@ const DAY_RESOLUTION = 1000 * 60 * 60 * 24; // one day
           color: 'purple',
           name: 'Car Count',
           resolution: DAY_RESOLUTION, // one day
+          aggregationType: 'AVERAGE',
           aggregates: {
             [DAY_RESOLUTION]: [
               {
@@ -129,6 +131,7 @@ const DAY_RESOLUTION = 1000 * 60 * 60 * 24; // one day
           color: 'red',
           name: 'Car Count',
           resolution: DAY_RESOLUTION, // one day
+          aggregationType: 'AVERAGE',
           aggregates: {
             [DAY_RESOLUTION]: [
               {

--- a/packages/doc-site/docs/threshold.md
+++ b/packages/doc-site/docs/threshold.md
@@ -30,6 +30,7 @@ const dataStreams = [{
   color: '#1d8102',
   name: 'Car Count',
   resolution: DAY_RESOLUTION, // one day
+  aggregationType: 'AVERAGE',
   aggregates: {
     [DAY_RESOLUTION]: [{
       x: new Date(2000, 1, 0).getTime(),
@@ -87,6 +88,7 @@ const dataStreams = [{
       dataType: 'NUMBER',
       resolution: 1000 * 60 * 24 * 60 * 24,
       color: '#1d8102',
+      aggregationType: 'AVERAGE',
       aggregates: {
         [1000 * 60 * 24 * 60 * 24]: [{
           x: new Date(2000, 1, 0).getTime(),
@@ -227,6 +229,7 @@ const dataStreams = [{
   color: '#1d8102',
   name: 'Car Count',
   resolution: DAY_RESOLUTION, // one day
+  aggregationType: 'AVERAGE',
   aggregates: {
     [DAY_RESOLUTION]: [{
       x: new Date(2000, 1, 0).getTime(),
@@ -284,6 +287,7 @@ const dataStreams = [{
       dataType: 'NUMBER',
       resolution: 1000 * 60 * 24 * 60 * 24,
       color: '#1d8102',
+      aggregationType: 'AVERAGE',
       aggregates: {
         [1000 * 60 * 24 * 60 * 24]: [{
           x: new Date(2000, 1, 0).getTime(),
@@ -368,6 +372,7 @@ const dataStreams = [{
   color: 'black',
   name: 'Car Count',
   resolution: 1000 * 60 * 60 * 24, // one day
+  aggregationType: 'AVERAGE',
   aggregates: {
     [1000 * 60 * 60 * 24]: [{
       x: new Date(2000, 1, 0).getTime(),
@@ -443,6 +448,7 @@ const dataStreams = [{
   color: 'black',
   name: 'Car Count',
   resolution: 1000 * 60 * 60 * 24, // one day
+  aggregationType: 'AVERAGE',
   aggregates: {
     [1000 * 60 * 60 * 24]: [{
       x: new Date(2000, 1, 0).getTime(),
@@ -521,6 +527,7 @@ const dataStreams = [{
   color: 'black',
   name: 'Car Count',
   resolution: 1000 * 60 * 60 * 24, // one day
+  aggregationType: 'AVERAGE',
   aggregates: {
     [1000 * 60 * 60 * 24]: [{
       x: new Date(2000, 1, 0).getTime(),
@@ -597,6 +604,7 @@ const dataStreams = [{
   color: 'black',
   name: 'Car Count',
   resolution: 1000 * 60 * 60 * 24, // one day
+  aggregationType: 'AVERAGE',
   aggregates: {
     [1000 * 60 * 60 * 24]: [{
       x: new Date(2000, 1, 0).getTime(),

--- a/packages/doc-site/docs/trendLine.md
+++ b/packages/doc-site/docs/trendLine.md
@@ -21,6 +21,7 @@ import { ScatterChart } from "@synchro-charts/react";
       id: 'car-count',
       dataType: 'NUMBER',
       resolution: 1000 * 60 * 60 * 24, // one day
+      aggregationType: 'AVERAGE',
       aggregates: {
         [1000 * 60 * 60 * 24]: [{
           x: new Date(2000, 1, 0),

--- a/packages/doc-site/src/components/BarChart.md
+++ b/packages/doc-site/src/components/BarChart.md
@@ -17,6 +17,7 @@
         color: '#0073bb',
         name: 'Car Count',
         resolution: 1000 * 60 * 60 * 24 * 30, // one month
+        aggregationType: 'AVERAGE',
         aggregates: {
           [1000 * 60 * 60 * 24 * 30]: [{
             x: new Date(2000, 0, 0).getTime(),
@@ -41,6 +42,7 @@
         color: '#dd6b10',
         name: 'Boat Count',
         resolution: 1000 * 60 * 60 * 24 * 30, // one month
+        aggregationType: 'AVERAGE',
         aggregates: {
           [1000 * 60 * 60 * 24 * 30]: [{
             x: new Date(2000, 0, 0).getTime(),
@@ -92,6 +94,7 @@ import { DataType, COMPARISON_OPERATOR, StatusIcon } from '@synchro-charts/core'
         color: '#0073bb',
         name: 'Car Count',
         resolution: 1000 * 60 * 60 * 24 * 30, // one month
+        aggregationType: 'AVERAGE',
         aggregates: {
           [1000 * 60 * 60 * 24 * 30]: [{
             x: new Date(2000, 0, 0).getTime(),
@@ -116,6 +119,7 @@ import { DataType, COMPARISON_OPERATOR, StatusIcon } from '@synchro-charts/core'
         color: '#dd6b10',
         name: 'Boat Count',
         resolution: 1000 * 60 * 60 * 24 * 30, // one month
+        aggregationType: 'AVERAGE',
         aggregates: {
           [1000 * 60 * 60 * 24 * 30]: [{
             x: new Date(2000, 0, 0).getTime(),

--- a/packages/doc-site/src/components/LineChart.md
+++ b/packages/doc-site/src/components/LineChart.md
@@ -18,6 +18,7 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
         resolution: MONTH_RESOLUTION,
         name: 'Car Count',
         color: '#0073bb',
+        aggregationType: 'AVERAGE',
         aggregates: {
           [MONTH_RESOLUTION]: [
             {
@@ -45,6 +46,7 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
         name: 'Boat Count',
         color: '#dd6b10',
         resolution: MONTH_RESOLUTION,
+        aggregationType: 'AVERAGE',
         aggregates: {
           [MONTH_RESOLUTION]: [{
             x: new Date(2000, 0, 0).getTime(),
@@ -97,6 +99,7 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
         resolution: MONTH_RESOLUTION,
         name: 'Car Count',
         color: '#0073bb',
+        aggregationType: 'AVERAGE',
         aggregates: {
           [MONTH_RESOLUTION]: [
             {
@@ -124,6 +127,7 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
         color: '#dd6b10',
         name: 'Boat Count',
         resolution: MONTH_RESOLUTION,
+        aggregationType: 'AVERAGE',
         aggregates: {
           [MONTH_RESOLUTION]: [{
             x: new Date(2000, 0, 0).getTime(),

--- a/packages/doc-site/src/components/ScatterChart.md
+++ b/packages/doc-site/src/components/ScatterChart.md
@@ -18,6 +18,7 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
         resolution: MONTH_RESOLUTION,
         name: 'Car Count',
         color: '#0073bb',
+        aggregationType: 'AVERAGE',
         aggregates: {
           [MONTH_RESOLUTION]: [
             {
@@ -45,6 +46,7 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
         name: 'Boat Count',
         color: '#dd6b10',
         resolution: MONTH_RESOLUTION,
+        aggregationType: 'AVERAGE',
         aggregates: {
           [MONTH_RESOLUTION]: [{
             x: new Date(2000, 0, 0).getTime(),
@@ -97,6 +99,7 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
         resolution: MONTH_RESOLUTION,
         color: '#0073bb',
         name: 'Car Count',
+        aggregationType: 'AVERAGE',
         aggregates: {
           [MONTH_RESOLUTION]: [
             {
@@ -124,6 +127,7 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
         color: '#dd6b10',
         name: 'Boat Count',
         resolution: MONTH_RESOLUTION,
+        aggregationType: 'AVERAGE',
         aggregates: {
           [MONTH_RESOLUTION]: [{
             x: new Date(2000, 0, 0).getTime(),

--- a/packages/doc-site/src/components/StatusTimeline.md
+++ b/packages/doc-site/src/components/StatusTimeline.md
@@ -8,6 +8,7 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
       {
         id: 'car-speed-alarm',
         name: 'Car speed',
+        aggregationType: 'AVERAGE',
         aggregates: {
           [MONTH_RESOLUTION]: [{
             x: new Date(2000, 0, 0).getTime(),
@@ -115,6 +116,7 @@ const MONTH_RESOLUTION = 1000 * 60 * 60 * 24 * 30; // one month
       {
         id: 'car-speed-alarm',
         name: 'Car speed',
+        aggregationType: 'AVERAGE',
         aggregates: {
           [MONTH_RESOLUTION]: [{
             x: new Date(2000, 0, 0).getTime(),

--- a/packages/doc-site/src/components/chart-demo/dataUtil.js
+++ b/packages/doc-site/src/components/chart-demo/dataUtil.js
@@ -1,5 +1,5 @@
-import {DAY_IN_MS} from "./dateUtil";
-import {DataType} from "@synchro-charts/core";
+import { DAY_IN_MS } from "./dateUtil";
+import { DataType } from "@synchro-charts/core";
 
 export const getY = (x, duration) =>
   Math.sin(x / (duration * 8)) * 15 +
@@ -11,7 +11,7 @@ export const getY = (x, duration) =>
   Math.random() / 1000;
 
 export const getYby = (x, duration) =>
-  Math.sin(x / (duration * 3 )) * 15;
+  Math.sin(x / (duration * 3)) * 15;
 
 export const truncateDate = (num) => Math.floor(num / DAY_IN_MS) * DAY_IN_MS;
 
@@ -41,6 +41,7 @@ export const getRandomData = ({
     id: streamId,
     name: streamId,
     resolution,
+    aggregationType: resolution !== 0 ? 'AVERAGE' : undefined,
     data: [],
     aggregates: {
       [resolution]: dataPoints,

--- a/packages/synchro-charts/cypress/integration/charts/bar-chart/draggable-annotations.spec.ts
+++ b/packages/synchro-charts/cypress/integration/charts/bar-chart/draggable-annotations.spec.ts
@@ -15,6 +15,7 @@ import {
   ELEMENT_GROUP_SELECTOR,
 } from '../../../../src/components/charts/common/annotations/YAnnotations/YAnnotations';
 import { moveHandle, moveHandleFilter, moveHandleWithPause, parseTransformYValue } from '../utils-draggable';
+import { AggregateType } from '../../../../src/utils/dataTypes';
 
 const timelineParams: Partial<SearchQueryParams> = {
   componentTag: 'sc-bar-chart',
@@ -28,6 +29,7 @@ const timelineParams: Partial<SearchQueryParams> = {
       data: [],
       aggregates: { [MINUTE_IN_MS]: [TEST_DATA_POINT_STANDARD] },
       resolution: MINUTE_IN_MS,
+      aggregationType: AggregateType.AVERAGE,
       dataType: DataType.NUMBER,
     },
   ],

--- a/packages/synchro-charts/cypress/integration/charts/cross-resolution.spec.ts
+++ b/packages/synchro-charts/cypress/integration/charts/cross-resolution.spec.ts
@@ -7,6 +7,7 @@ import {
   visitDynamicWidget,
 } from '../../../src/testing/selectors';
 import { DATA_STREAM, DATA_STREAM_2 } from '../../../src/testing/__mocks__/mockWidgetProperties';
+import { AggregateType } from '../../../src/utils/dataTypes';
 
 beforeEach(() => {
   cy.viewport(SCREEN_SIZE.width, SCREEN_SIZE.height);
@@ -29,6 +30,7 @@ const RAW_DATA_STREAM = {
 const AGGREGATED_DATA_STREAM = {
   ...DATA_STREAM_2,
   resolution: DAY_IN_MS,
+  aggregationType: AggregateType.AVERAGE,
   aggregates: {
     [DAY_IN_MS]: [
       {

--- a/packages/synchro-charts/src/components.d.ts
+++ b/packages/synchro-charts/src/components.d.ts
@@ -393,6 +393,7 @@ export namespace Components {
         "visualizesAlarms": boolean;
     }
     interface ScTooltipRow {
+        "aggregationType"?: string;
         "color": string;
         "icon"?: StatusIcon;
         "label": string;
@@ -1847,6 +1848,7 @@ declare namespace LocalJSX {
         "visualizesAlarms": boolean;
     }
     interface ScTooltipRow {
+        "aggregationType"?: string;
         "color": string;
         "icon"?: StatusIcon;
         "label": string;

--- a/packages/synchro-charts/src/components/charts/common/tests/chart/constants.ts
+++ b/packages/synchro-charts/src/components/charts/common/tests/chart/constants.ts
@@ -1,4 +1,4 @@
-import { DataStream } from '../../../../../utils/dataTypes';
+import { AggregateType, DataStream } from '../../../../../utils/dataTypes';
 import { DataType } from '../../../../../utils/dataConstants';
 
 export const DATA_STREAMS: DataStream[] = [
@@ -6,6 +6,7 @@ export const DATA_STREAMS: DataStream[] = [
     name: 'some name',
     resolution: 1000,
     id: '1',
+    aggregationType: AggregateType.AVERAGE,
     aggregates: {
       1000: [
         { x: new Date(1995, 0, 1).getTime(), y: 0 },

--- a/packages/synchro-charts/src/components/charts/sc-bar-chart/barMesh.spec.ts
+++ b/packages/synchro-charts/src/components/charts/sc-bar-chart/barMesh.spec.ts
@@ -4,7 +4,7 @@ import { MONTH_IN_MS, DAY_IN_MS } from '../../../utils/time';
 import { getBarMargin, getBarWidth } from './displayLogic';
 import { getDistanceFromDuration } from '../common/getDistanceFromDuration';
 import { DataType } from '../../../utils/dataConstants';
-import { DataPoint, DataStream } from '../../../utils/dataTypes';
+import { AggregateType, DataPoint, DataStream } from '../../../utils/dataTypes';
 import { Threshold } from '../common/types';
 import { COMPARISON_OPERATOR } from '../common/constants';
 
@@ -30,6 +30,7 @@ const DATA_STREAMS: DataStream[] = [
     id: 'data-stream',
     name: 'some name',
     resolution: MONTH_IN_MS,
+    aggregationType: AggregateType.AVERAGE,
     aggregates: {
       [MONTH_IN_MS]: [DATA_POINT_1, DATA_POINT_2, DATA_POINT_3],
     },
@@ -174,6 +175,7 @@ describe('create bar mesh', () => {
           color: 'red',
           name: 'some name',
           resolution,
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [resolution]: [STREAM_1_DATA_POINT_1, STREAM_1_DATA_POINT_2],
           },
@@ -185,6 +187,7 @@ describe('create bar mesh', () => {
           color: 'blue',
           name: 'some name',
           resolution,
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [resolution]: [STREAM_2_DATA_POINT_1, STREAM_2_DATA_POINT_2],
           },
@@ -260,6 +263,7 @@ describe('create bar mesh', () => {
           name: 'some name',
           resolution,
           color: 'red',
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [resolution]: [STREAM_1_DATA_POINT_1, STREAM_1_DATA_POINT_2],
           },
@@ -276,6 +280,7 @@ describe('create bar mesh', () => {
           },
           data: [],
           dataType,
+          aggregationType: AggregateType.AVERAGE,
         },
         {
           id: 'data-stream-3',
@@ -287,6 +292,7 @@ describe('create bar mesh', () => {
           },
           data: [],
           dataType,
+          aggregationType: AggregateType.AVERAGE,
         },
       ],
       minBufferSize: 100,
@@ -374,6 +380,7 @@ describe('create bar mesh', () => {
           id: 'data-stream-1',
           resolution,
           data: [],
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [resolution]: [STREAM_1_DATA_POINT_1, STREAM_1_DATA_POINT_2],
           },
@@ -385,6 +392,7 @@ describe('create bar mesh', () => {
           id: 'data-stream-2',
           resolution,
           data: [],
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [resolution]: [STREAM_2_DATA_POINT_1],
           },
@@ -397,6 +405,7 @@ describe('create bar mesh', () => {
           resolution,
           color: 'black',
           name: 'data stream 3',
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [resolution]: [STREAM_3_DATA_POINT_1, STREAM_3_DATA_POINT_2],
           },
@@ -478,6 +487,7 @@ describe('update bar mesh', () => {
         id: 'data-stream',
         name: 'some name',
         resolution: MONTH_IN_MS,
+        aggregationType: AggregateType.AVERAGE,
         aggregates: {
           [MONTH_IN_MS]: [DATA_POINT_1, DATA_POINT_2],
         },
@@ -619,6 +629,7 @@ describe('update bar mesh', () => {
       name: 'data-stream-name',
       resolution: MONTH_IN_MS,
       data: [],
+      aggregationType: AggregateType.AVERAGE,
       aggregates: {
         [MONTH_IN_MS]: [DATA_POINT_1],
       },
@@ -666,6 +677,7 @@ describe('update bar mesh', () => {
         name: 'some name',
         resolution: MONTH_IN_MS,
         data: [],
+        aggregationType: AggregateType.AVERAGE,
         aggregates: {
           [MONTH_IN_MS]: [DATA_POINT_1],
         },
@@ -698,6 +710,7 @@ describe('update bar mesh', () => {
         name: 'some name',
         resolution: DAY_IN_MS,
         data: [],
+        aggregationType: AggregateType.AVERAGE,
         aggregates: {
           [DAY_IN_MS]: [DATA_POINT_1],
         },
@@ -733,6 +746,7 @@ describe('update bar mesh', () => {
         name: 'some name',
         resolution: MONTH_IN_MS,
         data: [],
+        aggregationType: AggregateType.AVERAGE,
         aggregates: {
           [MONTH_IN_MS]: [DATA_POINT_1],
         },
@@ -799,6 +813,7 @@ describe('threshold correctly effects the color buffer', () => {
           color: 'black',
           resolution: MONTH_IN_MS,
           data: [],
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [MONTH_IN_MS]: [DATA_POINT_1],
           },
@@ -843,6 +858,7 @@ describe('threshold correctly effects the color buffer', () => {
           name: 'some name',
           resolution: MONTH_IN_MS,
           data: [],
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [MONTH_IN_MS]: [DATA_POINT_1],
           },
@@ -886,6 +902,7 @@ describe('threshold correctly effects the color buffer', () => {
           name: 'some chart',
           color: 'purple',
           resolution: MONTH_IN_MS,
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [MONTH_IN_MS]: [DATA_POINT_1],
           },
@@ -897,6 +914,7 @@ describe('threshold correctly effects the color buffer', () => {
           name: 'some chart 2',
           color: 'blue',
           resolution: MONTH_IN_MS,
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [MONTH_IN_MS]: [DATA_POINT_2],
           },
@@ -933,6 +951,7 @@ describe('threshold correctly effects the color buffer', () => {
         name: 'some name',
         resolution: MONTH_IN_MS,
         data: [],
+        aggregationType: AggregateType.AVERAGE,
         aggregates: {
           [MONTH_IN_MS]: [DATA_POINT_1],
         },
@@ -995,6 +1014,7 @@ describe('threshold correctly effects the color buffer', () => {
         name: 'some name',
         resolution: MONTH_IN_MS,
         data: [],
+        aggregationType: AggregateType.AVERAGE,
         aggregates: {
           [MONTH_IN_MS]: [DATA_POINT_1],
         },
@@ -1071,6 +1091,7 @@ describe('threshold correctly effects the color buffer', () => {
           name: 'some name',
           resolution: MONTH_IN_MS,
           data: [],
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [MONTH_IN_MS]: [DATA_POINT_1],
           },
@@ -1101,6 +1122,7 @@ describe('threshold correctly effects the color buffer', () => {
           name: 'some name',
           resolution: MONTH_IN_MS,
           data: [],
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [MONTH_IN_MS]: [DATA_POINT_2],
           },
@@ -1144,6 +1166,7 @@ describe('threshold correctly effects the color buffer', () => {
           name: 'some name',
           resolution: MONTH_IN_MS,
           data: [],
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [MONTH_IN_MS]: [DATA_POINT_2],
           },
@@ -1174,6 +1197,7 @@ describe('threshold correctly effects the color buffer', () => {
           name: 'some name',
           resolution: MONTH_IN_MS,
           data: [],
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [MONTH_IN_MS]: [DATA_POINT_1],
           },
@@ -1204,6 +1228,7 @@ describe('threshold correctly effects the color buffer', () => {
         name: 'data-stream-name',
         resolution: MONTH_IN_MS,
         data: [],
+        aggregationType: AggregateType.AVERAGE,
         aggregates: {
           [MONTH_IN_MS]: [DATA_POINT_1],
         },
@@ -1215,6 +1240,7 @@ describe('threshold correctly effects the color buffer', () => {
         name: 'data-stream-name',
         resolution: MONTH_IN_MS,
         data: [],
+        aggregationType: AggregateType.AVERAGE,
         aggregates: {
           [MONTH_IN_MS]: [DATA_POINT_2],
         },
@@ -1300,6 +1326,7 @@ describe('threshold correctly effects the color buffer', () => {
         name: 'some name',
         resolution: MONTH_IN_MS,
         data: [],
+        aggregationType: AggregateType.AVERAGE,
         aggregates: {
           [MONTH_IN_MS]: [DATA_POINT_1],
         },

--- a/packages/synchro-charts/src/components/charts/sc-bar-chart/chartScene.spec.ts
+++ b/packages/synchro-charts/src/components/charts/sc-bar-chart/chartScene.spec.ts
@@ -1,5 +1,5 @@
 import { chartScene, updateChartScene } from './chartScene';
-import { DataPoint } from '../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../utils/dataTypes';
 import { MONTH_IN_MS } from '../../../utils/time';
 import { BarChartBarMesh } from './barMesh';
 import { DataType } from '../../../utils/dataConstants';
@@ -43,6 +43,7 @@ describe('bars', () => {
           name: 'some name',
           resolution: MONTH_IN_MS,
           data: [],
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [MONTH_IN_MS]: TEST_DATA_POINT,
           },

--- a/packages/synchro-charts/src/components/charts/sc-status-timeline/chartScene.spec.ts
+++ b/packages/synchro-charts/src/components/charts/sc-status-timeline/chartScene.spec.ts
@@ -1,5 +1,5 @@
 import { chartScene, updateChartScene } from './chartScene';
-import { DataPoint } from '../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../utils/dataTypes';
 import { MONTH_IN_MS } from '../../../utils/time';
 import { StatusChartStatusMesh } from './statusMesh';
 import { DataType } from '../../../utils/dataConstants';
@@ -43,6 +43,7 @@ describe('statuses', () => {
           name: 'some name',
           resolution: MONTH_IN_MS,
           data: [],
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [MONTH_IN_MS]: TEST_DATA_POINTS,
           },

--- a/packages/synchro-charts/src/components/charts/sc-tooltip/sc-tooltip-row.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-tooltip/sc-tooltip-row.tsx
@@ -13,8 +13,6 @@ import { getAggregationFrequency } from '../../sc-data-stream-name/helper';
 import { StatusIcon } from '../common/constants';
 
 const baseColor = '#000';
-const AGGREGATED_LEVEL = 'average';
-
 @Component({
   tag: 'sc-tooltip-row',
   styleUrl: 'sc-tooltip-row.css',
@@ -28,6 +26,7 @@ export class ScTooltipRow {
   @Prop() showDataStreamColor!: boolean;
   @Prop() pointType!: POINT_TYPE;
   @Prop() valueColor?: string = baseColor;
+  @Prop() aggregationType?: string;
   @Prop() icon?: StatusIcon;
 
   render() {
@@ -57,7 +56,7 @@ export class ScTooltipRow {
         </span>
         {this.resolution != null && (
           <div class="awsui-util-pb-s">
-            <small>{getAggregationFrequency(this.resolution, AGGREGATED_LEVEL)}</small>
+            <small>{getAggregationFrequency(this.resolution, this.aggregationType)}</small>
           </div>
         )}
       </div>

--- a/packages/synchro-charts/src/components/charts/sc-tooltip/sc-tooltip-rows.spec.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-tooltip/sc-tooltip-rows.spec.tsx
@@ -5,7 +5,7 @@ import { update } from '../common/tests/merge';
 import { ScTooltipRow } from './sc-tooltip-row';
 import { Threshold } from '../common/types';
 import { TrendResult } from '../common/trends/types';
-import { DataPoint, DataStream, DataStreamInfo } from '../../../utils/dataTypes';
+import { AggregateType, DataPoint, DataStream, DataStreamInfo } from '../../../utils/dataTypes';
 import { ScTooltipRows } from './sc-tooltip-rows';
 import { DEFAULT_CHART_CONFIG } from '../sc-webgl-base-chart/chartDefaults';
 
@@ -51,6 +51,7 @@ const DATA_STREAM: DataStream<number> = {
   id: 'data-stream-id',
   dataType: DataType.NUMBER,
   data: [],
+  aggregationType: AggregateType.AVERAGE,
   aggregates: { [MINUTE_IN_MS]: [DEFAULT_POINT] },
   resolution: MINUTE_IN_MS,
 };
@@ -61,6 +62,7 @@ const DATA_STREAM_2: DataStream<number> = {
   id: 'data-stream-id-2',
   dataType: DataType.NUMBER,
   data: [],
+  aggregationType: AggregateType.AVERAGE,
   aggregates: { [MINUTE_IN_MS]: [DEFAULT_POINT] },
   resolution: MINUTE_IN_MS,
 };
@@ -70,6 +72,7 @@ const STRING_STREAM: DataStream<string> = {
   name: 'string-stream-name',
   id: 'string-data-stream-id',
   dataType: DataType.STRING,
+  aggregationType: AggregateType.AVERAGE,
   aggregates: { [MINUTE_IN_MS]: [DEFAULT_STRING_POINT] },
   data: [],
   resolution: MINUTE_IN_MS,
@@ -138,7 +141,7 @@ it('renders one tooltip row with the streams point passed in', async () => {
 describe('showsBlankTooltipRows is true', () => {
   it('renders one tooltip row with no point passed in when no data present in the data stream', async () => {
     const { tooltipRows } = await newTooltipRowsSpecPage({
-      dataStreams: [{ ...DATA_STREAM, aggregates: {}, data: [] }],
+      dataStreams: [{ ...DATA_STREAM, aggregates: {}, aggregationType: AggregateType.AVERAGE, data: [] }],
       showBlankTooltipRows: true,
     });
 
@@ -150,7 +153,7 @@ describe('showsBlankTooltipRows is true', () => {
 
   it('renders one tooltip row with no point passed in when no data present in the data stream', async () => {
     const { tooltipRows } = await newTooltipRowsSpecPage({
-      dataStreams: [{ ...DATA_STREAM, aggregates: {}, data: [] }],
+      dataStreams: [{ ...DATA_STREAM, aggregates: {}, aggregationType: AggregateType.AVERAGE, data: [] }],
       sortPoints: true,
       showBlankTooltipRows: true,
     });
@@ -174,7 +177,9 @@ describe('showsBlankTooltipRows is false', () => {
 
   it('renders no tooltip rows when no data present in data stream and is sorting with non raw data', async () => {
     const { tooltipRows } = await newTooltipRowsSpecPage({
-      dataStreams: [{ ...DATA_STREAM, resolution: MINUTE_IN_MS, aggregates: {} }],
+      dataStreams: [
+        { ...DATA_STREAM, resolution: MINUTE_IN_MS, aggregationType: AggregateType.AVERAGE, aggregates: {} },
+      ],
       sortPoints: true,
       showBlankTooltipRows: false,
     });

--- a/packages/synchro-charts/src/components/charts/sc-tooltip/sc-tooltip-rows.tsx
+++ b/packages/synchro-charts/src/components/charts/sc-tooltip/sc-tooltip-rows.tsx
@@ -1,7 +1,7 @@
 import { Component, h, Prop } from '@stencil/core';
 
 import uniq from 'lodash.uniq';
-import { DataPoint, DataStream, DataStreamId, SizeConfig, ViewPort } from '../../../utils/dataTypes';
+import { AggregateType, DataPoint, DataStream, DataStreamId, SizeConfig, ViewPort } from '../../../utils/dataTypes';
 import { activePoints, POINT_TYPE } from '../sc-webgl-base-chart/activePoints';
 import { getAggregationFrequency } from '../../sc-data-stream-name/helper';
 import { displayDate } from '../../../utils/time';
@@ -16,7 +16,6 @@ import { StreamType } from '../../../utils/dataConstants';
 import { TrendResult } from '../common/trends/types';
 import { DATA_ALIGNMENT } from '../common/constants';
 
-const AGGREGATED_LEVEL = 'average';
 const TOOLTIP_ROW_HEIGHT = 21;
 const TOOLTIP_EMPTY_HEIGHT = 71;
 const X_OFFSET = 8;
@@ -221,7 +220,7 @@ export class ScTooltipRows {
               <small
                 class={{ 'awsui-util-d-b': true, 'awsui-util-mb-s': true, 'left-offset': !this.showDataStreamColor }}
               >
-                {getAggregationFrequency(minResolution, AGGREGATED_LEVEL)}
+                {getAggregationFrequency(minResolution, AggregateType.AVERAGE)}
               </small>
             )}
             {points.map(tooltipPoint => {
@@ -242,6 +241,7 @@ export class ScTooltipRows {
                   key={`${tooltipPoint.streamId}-${tooltipPoint.type}`}
                   showDataStreamColor={this.showDataStreamColor}
                   label={tooltipPoint.label || dataStream.name}
+                  aggregationType={dataStream.aggregationType}
                   resolution={isCrossResolution ? dataStream.resolution : undefined}
                   color={tooltipPoint.color || dataStream.color || 'black'}
                   point={tooltipPoint.point}

--- a/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/activePoints.spec.ts
+++ b/packages/synchro-charts/src/components/charts/sc-webgl-base-chart/activePoints.spec.ts
@@ -1,4 +1,4 @@
-import { DataPoint, ViewPort } from '../../../utils/dataTypes';
+import { AggregateType, DataPoint, ViewPort } from '../../../utils/dataTypes';
 import { activePoints } from './activePoints';
 import { HOUR_IN_MS, MINUTE_IN_MS, SECOND_IN_MS, YEAR_IN_MS } from '../../../utils/time';
 import { DATA_STREAM } from '../../../testing/__mocks__/mockWidgetProperties';
@@ -679,6 +679,7 @@ describe('aggregated data', () => {
           {
             ...DATA_STREAM,
             data: [],
+            aggregationType: AggregateType.AVERAGE,
             aggregates: { [MINUTE_IN_MS]: [DATA_POINT_IN_VIEWPORT_1, DATA_POINT_AFTER_VIEWPORT] },
             resolution: 0,
           },
@@ -698,6 +699,7 @@ describe('aggregated data', () => {
           {
             ...DATA_STREAM,
             data: [DATA_POINT_IN_VIEWPORT_1, DATA_POINT_AFTER_VIEWPORT],
+            aggregationType: AggregateType.AVERAGE,
             aggregates: { [MINUTE_IN_MS]: [] },
             resolution: MINUTE_IN_MS,
           },
@@ -717,6 +719,7 @@ describe('aggregated data', () => {
           {
             ...DATA_STREAM,
             data: [],
+            aggregationType: AggregateType.AVERAGE,
             aggregates: { [MINUTE_IN_MS]: [DATA_POINT_IN_VIEWPORT_1] },
             resolution: MINUTE_IN_MS,
           },
@@ -736,6 +739,7 @@ describe('aggregated data', () => {
           {
             ...DATA_STREAM,
             data: [],
+            aggregationType: AggregateType.AVERAGE,
             aggregates: { [MINUTE_IN_MS]: [DATA_POINT_IN_VIEWPORT_1], [HOUR_IN_MS]: [DATA_POINT_IN_VIEWPORT_2] },
             resolution: MINUTE_IN_MS,
           },

--- a/packages/synchro-charts/src/components/sc-data-stream-name/helper.spec.tsx
+++ b/packages/synchro-charts/src/components/sc-data-stream-name/helper.spec.tsx
@@ -1,51 +1,47 @@
+import { AggregateType } from '../../utils/dataTypes';
 import { getAggregationFrequency, updateName } from './helper';
 import { SECOND_IN_MS, MINUTE_IN_MS, HOUR_IN_MS, DAY_IN_MS } from '../../utils/time';
+import { aggregateToString } from '../../utils/aggregateToString';
 
 describe('aggregationFrequency', () => {
+  const aggregationLevel = AggregateType.AVERAGE;
+  const aggregateString = aggregateToString(aggregationLevel);
   it('returns 1 second aggregation frequency', () => {
-    const aggregationLevel = 'average';
     const aggregationFrequency = getAggregationFrequency(SECOND_IN_MS, aggregationLevel);
-    expect(aggregationFrequency).toBe(`1 second ${aggregationLevel}`);
+    expect(aggregationFrequency).toBe(`1 second ${aggregateString}`);
   });
 
   it('returns more than 1 second aggregation frequency', () => {
-    const aggregationLevel = 'average';
     const aggregationFrequency = getAggregationFrequency(SECOND_IN_MS * 2, aggregationLevel);
-    expect(aggregationFrequency).toBe(`2 seconds ${aggregationLevel}`);
+    expect(aggregationFrequency).toBe(`2 seconds ${aggregateString}`);
   });
 
   it('returns 1 min aggregation frequency', () => {
-    const aggregationLevel = 'average';
     const aggregationFrequency = getAggregationFrequency(MINUTE_IN_MS, aggregationLevel);
-    expect(aggregationFrequency).toBe(`1 minute ${aggregationLevel}`);
+    expect(aggregationFrequency).toBe(`1 minute ${aggregateString}`);
   });
 
   it('returns more than 1 min aggregation frequency', () => {
-    const aggregationLevel = 'average';
     const aggregationFrequency = getAggregationFrequency(MINUTE_IN_MS * 2, aggregationLevel);
-    expect(aggregationFrequency).toBe(`2 minutes ${aggregationLevel}`);
+    expect(aggregationFrequency).toBe(`2 minutes ${aggregateString}`);
   });
 
   it('returns 1 hr aggregation frequency', () => {
-    const aggregationLevel = 'average';
     const aggregationFrequency = getAggregationFrequency(HOUR_IN_MS, aggregationLevel);
-    expect(aggregationFrequency).toBe(`1 hour ${aggregationLevel}`);
+    expect(aggregationFrequency).toBe(`1 hour ${aggregateString}`);
   });
 
   it('returns more than 1 hr aggregation frequency', () => {
-    const aggregationLevel = 'average';
     const aggregationFrequency = getAggregationFrequency(HOUR_IN_MS * 2, aggregationLevel);
-    expect(aggregationFrequency).toBe(`2 hours ${aggregationLevel}`);
+    expect(aggregationFrequency).toBe(`2 hours ${aggregateString}`);
   });
 
   it('returns 1 day aggregation frequency', () => {
-    const aggregationLevel = 'average';
     const aggregationFrequency = getAggregationFrequency(DAY_IN_MS, aggregationLevel);
-    expect(aggregationFrequency).toBe(`1 day ${aggregationLevel}`);
+    expect(aggregationFrequency).toBe(`1 day ${aggregateString}`);
   });
 
   it('returns N/A for time span less than a second', () => {
-    const aggregationLevel = 'average';
     const aggregationFrequency = getAggregationFrequency(20, aggregationLevel);
     expect(aggregationFrequency).toBe('N/A');
   });

--- a/packages/synchro-charts/src/components/sc-data-stream-name/helper.ts
+++ b/packages/synchro-charts/src/components/sc-data-stream-name/helper.ts
@@ -1,25 +1,28 @@
 import update from 'immutability-helper';
+import { aggregateToString } from '../../utils/aggregateToString';
 import { convertMS } from '../../utils/time';
 
-export const getAggregationFrequency = (dataResolution: number, aggregatedLevel: string) => {
-  if (dataResolution === 0) {
+export const getAggregationFrequency = (dataResolution: number, aggregationType?: string) => {
+  if (dataResolution === 0 || !aggregationType) {
     return 'raw data';
   }
 
   const { day, hour, minute, seconds } = convertMS(dataResolution);
   const getPlural = (input: number) => (input > 1 ? 's' : '');
 
+  const aggregateString = aggregateToString(aggregationType);
+
   if (day !== 0) {
-    return `${day} day${getPlural(day)} ${aggregatedLevel}`;
+    return `${day} day${getPlural(day)} ${aggregateString}`;
   }
   if (hour !== 0) {
-    return `${hour} hour${getPlural(hour)} ${aggregatedLevel}`;
+    return `${hour} hour${getPlural(hour)} ${aggregateString}`;
   }
   if (minute !== 0) {
-    return `${minute} minute${getPlural(minute)} ${aggregatedLevel}`;
+    return `${minute} minute${getPlural(minute)} ${aggregateString}`;
   }
   if (seconds !== 0) {
-    return `${seconds} second${getPlural(seconds)} ${aggregatedLevel}`;
+    return `${seconds} second${getPlural(seconds)} ${aggregateString}`;
   }
 
   return 'N/A';

--- a/packages/synchro-charts/src/components/sc-table/sc-table-cell/sc-table-cell.spec.tsx
+++ b/packages/synchro-charts/src/components/sc-table/sc-table-cell/sc-table-cell.spec.tsx
@@ -11,6 +11,7 @@ import { ScErrorBadge } from '../../sc-error-badge/sc-error-badge';
 import { ScChartIcon } from '../../charts/chart-icon/sc-chart-icon';
 import { DataType } from '../../../utils/dataConstants';
 import { MINUTE_IN_MS } from '../../../utils/time';
+import { AggregateType } from '../../../utils/dataTypes';
 
 // this is mock output that passed down from `sc-table-base`
 const CELL: Cell = {
@@ -61,6 +62,7 @@ it('renders aggregated data', async () => {
         data: [],
         dataType: DataType.NUMBER,
         resolution: MINUTE_IN_MS,
+        aggregationType: AggregateType.AVERAGE,
         aggregates: { [MINUTE_IN_MS]: [{ x: Date.now(), y: Y_VALUE }] },
       },
     },

--- a/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.spec.ts
+++ b/packages/synchro-charts/src/components/sc-widget-grid/sc-widget-grid.spec.ts
@@ -6,7 +6,7 @@ import { DATA_STREAMS } from '../charts/common/tests/chart/constants';
 import { DEFAULT_CHART_CONFIG } from '../charts/sc-webgl-base-chart/chartDefaults';
 import { update } from '../charts/common/tests/merge';
 import { ScWidgetGrid } from './sc-widget-grid';
-import { DataPoint, MinimalStaticViewport, MinimalViewPortConfig } from '../../utils/dataTypes';
+import { AggregateType, DataPoint, MinimalStaticViewport, MinimalViewPortConfig } from '../../utils/dataTypes';
 import { DAY_IN_MS, MINUTE_IN_MS } from '../../utils/time';
 import { CellOptions, RenderCell } from './types';
 import {
@@ -405,7 +405,14 @@ describe('aggregated data', () => {
   it('displays aggregated data when resolution is available', async () => {
     const { renderCell } = await widgetGridSpecPage({
       viewport: DEFAULT_CHART_CONFIG.viewport,
-      dataStreams: [{ ...DATA_STREAM, aggregates: { [MINUTE_IN_MS]: [POINT] }, resolution: MINUTE_IN_MS }],
+      dataStreams: [
+        {
+          ...DATA_STREAM,
+          aggregationType: AggregateType.AVERAGE,
+          aggregates: { [MINUTE_IN_MS]: [POINT] },
+          resolution: MINUTE_IN_MS,
+        },
+      ],
     });
 
     expect(renderCell).toBeCalledTimes(1);
@@ -419,7 +426,14 @@ describe('aggregated data', () => {
   it('does not display data when only aggregated data is available and the resolution is 0', async () => {
     const { renderCell } = await widgetGridSpecPage({
       viewport: DEFAULT_CHART_CONFIG.viewport,
-      dataStreams: [{ ...DATA_STREAM, aggregates: { [MINUTE_IN_MS]: [POINT] }, resolution: 0 }],
+      dataStreams: [
+        {
+          ...DATA_STREAM,
+          aggregationType: AggregateType.AVERAGE,
+          aggregates: { [MINUTE_IN_MS]: [POINT] },
+          resolution: 0,
+        },
+      ],
     });
 
     expect(renderCell).toBeCalledTimes(1);

--- a/packages/synchro-charts/src/testing/dynamicWidgetUtils/constants.ts
+++ b/packages/synchro-charts/src/testing/dynamicWidgetUtils/constants.ts
@@ -1,4 +1,4 @@
-import { DataPoint, DataStream, DataStreamInfo } from '../../utils/dataTypes';
+import { AggregateType, DataPoint, DataStream, DataStreamInfo } from '../../utils/dataTypes';
 import { COMPARISON_OPERATOR, LEGEND_POSITION, StatusIcon } from '../../components/charts/common/constants';
 import { Annotations, LegendConfig, Threshold } from '../../components/charts/common/types';
 import { MINUTE_IN_MS } from '../../utils/time';
@@ -121,6 +121,7 @@ const mphStream: DataStream<number> = {
   dataType: dataStreamInfoWithAlarms.dataType,
   color: 'black',
   name: 'mph',
+  aggregationType: AggregateType.AVERAGE,
   aggregates: {
     [MINUTE_IN_MS]: getMPHData(),
   },

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-chart-y-range.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-chart-y-range.tsx
@@ -1,5 +1,5 @@
 import { Component, h, Prop } from '@stencil/core';
-import { DataPoint, DataStream } from '../../../utils/dataTypes';
+import { AggregateType, DataPoint, DataStream } from '../../../utils/dataTypes';
 import { MONTH_IN_MS } from '../../../utils/time';
 import { DataType } from '../../../utils/dataConstants';
 
@@ -44,6 +44,7 @@ const data: DataStream<number>[] = [
     dataType: DataType.NUMBER,
     color: 'black',
     name: 'test stream',
+    aggregationType: AggregateType.AVERAGE,
     aggregates: { [MONTH_IN_MS]: [POINT_1, POINT_2, POINT_3, POINT_4, POINT_5] },
     data: [],
     resolution: MONTH_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-bar-margin.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-bar-margin.tsx
@@ -2,7 +2,7 @@ import { Component, h, State } from '@stencil/core';
 
 import { MONTH_IN_MS } from '../../../../utils/time';
 import { DataType } from '../../../../utils/dataConstants';
-import { DataPoint, DataStream } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint, DataStream } from '../../../../utils/dataTypes';
 
 // viewport boundaries
 const Y_MIN = 0;
@@ -22,6 +22,7 @@ const DATA_STREAM_1: DataStream = {
   color: 'red',
   name: 'test stream',
   resolution: MONTH_IN_MS,
+  aggregationType: AggregateType.AVERAGE,
   aggregates: {
     [MONTH_IN_MS]: [
       { x: new Date(1998, 3, 0, 0).getTime(), y: 1000 },
@@ -37,6 +38,7 @@ const DATA_STREAM_2: DataStream = {
   color: 'orange',
   name: 'test stream2',
   resolution: MONTH_IN_MS,
+  aggregationType: AggregateType.AVERAGE,
   aggregates: {
     [MONTH_IN_MS]: [
       { x: new Date(1998, 3, 0, 0).getTime(), y: 2000 },

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-dynamic-buffer.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-dynamic-buffer.tsx
@@ -1,7 +1,7 @@
 import { Component, h, State } from '@stencil/core';
 
 import { MONTH_IN_MS } from '../../../../utils/time';
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { DataType } from '../../../../utils/dataConstants';
 
 // viewport boundaries
@@ -46,6 +46,7 @@ export class ScWebglBarChartDynamicBuffer {
                 id: 'test',
                 color: 'red',
                 name: 'test stream',
+                aggregationType: AggregateType.AVERAGE,
                 aggregates: {
                   [MONTH_IN_MS]: this.data,
                 },

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-dynamic-data-streams.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-dynamic-data-streams.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { DataStream } from '../../../../utils/dataTypes';
+import { AggregateType, DataStream } from '../../../../utils/dataTypes';
 import { MONTH_IN_MS } from '../../../../utils/time';
 import { Y_VALUE } from '../constants';
 import { DataType } from '../../../../utils/dataConstants';
@@ -57,6 +57,7 @@ export class ScWebglBarChartDynamicDataStreams {
         id: streamId,
         color: this.getColor(),
         name: `${streamId}-name`,
+        aggregationType: AggregateType.AVERAGE,
         aggregates: {
           [MONTH_IN_MS]: [leftPoint, middlePoint, rightPoint],
         },

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-dynamic-data.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-dynamic-data.tsx
@@ -1,7 +1,7 @@
 import { Component, h, State } from '@stencil/core';
 
 import { MONTH_IN_MS } from '../../../../utils/time';
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { DataType } from '../../../../utils/dataConstants';
 
 // viewport boundaries
@@ -58,6 +58,7 @@ export class ScWebglBarChartDynamicData {
                 color: 'red',
                 name: 'test stream',
                 resolution: MONTH_IN_MS,
+                aggregationType: AggregateType.AVERAGE,
                 aggregates: {
                   [MONTH_IN_MS]: this.data,
                 },

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-fast-viewport.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-fast-viewport.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { DataPoint, DataStream } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint, DataStream } from '../../../../utils/dataTypes';
 import { HOUR_IN_MS } from '../../../../utils/time';
 import { DataType } from '../../../../utils/dataConstants';
 
@@ -64,6 +64,7 @@ export class ScWebglBarChartFastViewport {
                 name: 'test stream',
                 data: [],
                 resolution: HOUR_IN_MS,
+                aggregationType: AggregateType.AVERAGE,
                 aggregates: {
                   [HOUR_IN_MS]: TEST_DATA_POINTS,
                 },

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-negative.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-negative.tsx
@@ -1,6 +1,6 @@
 import { Component, h } from '@stencil/core';
 import { MINUTE_IN_MS } from '../../../../utils/time';
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { DataType } from '../../../../utils/dataConstants';
 
 // viewport boundaries
@@ -35,6 +35,7 @@ export class ScWebglBarChartNegative {
               id: 'test',
               color: 'black',
               name: 'test stream',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: {
                 [MINUTE_IN_MS]: [TEST_DATA_POINT],
               },

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-positive-negative.component.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-positive-negative.component.tsx
@@ -1,6 +1,6 @@
 import { Component, h } from '@stencil/core';
 import { MINUTE_IN_MS } from '../../../../utils/time';
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { DataType } from '../../../../utils/dataConstants';
 
 // viewport boundaries
@@ -38,6 +38,7 @@ export class ScWebglBarChartPositiveNegative {
           dataStreams={[
             {
               id: 'test',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MINUTE_IN_MS]: [TEST_DATA_POINT, TEST_DATA_POINT_2] },
               data: [],
               resolution: MINUTE_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-standard.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-standard.tsx
@@ -1,6 +1,7 @@
 import { Component, h } from '@stencil/core';
 
 import { MINUTE_IN_MS } from '../../../../utils/time';
+import { AggregateType } from '../../../../utils/dataTypes';
 import { TEST_DATA_POINT_STANDARD, Y_MAX, Y_MIN, X_MIN, X_MAX } from '../constants';
 import { DataType } from '../../../..';
 
@@ -24,6 +25,7 @@ export class ScWebglBarChartStandard {
               color: 'black',
               name: 'test stream',
               data: [],
+              aggregationType: AggregateType.AVERAGE,
               aggregates: {
                 [MINUTE_IN_MS]: [TEST_DATA_POINT_STANDARD],
               },

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-start-from-zero.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-start-from-zero.tsx
@@ -1,6 +1,6 @@
 import { Component, h, State } from '@stencil/core';
 
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { MINUTE_IN_MS } from '../../../../utils/time';
 import { DataType } from '../../../../utils/dataConstants';
 
@@ -49,6 +49,7 @@ export class ScWebglBarChartStartFromZero {
                 color: 'purple',
                 name: 'test stream',
                 data: [],
+                aggregationType: AggregateType.AVERAGE,
                 aggregates: {
                   [MINUTE_IN_MS]: this.testData,
                 },

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-band.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-band.tsx
@@ -3,6 +3,7 @@ import { Component, h } from '@stencil/core';
 import { MINUTE_IN_MS } from '../../../../utils/time';
 import { TEST_DATA_POINT_STANDARD, Y_MAX, Y_MIN, X_MIN, X_MAX } from '../constants';
 import { COMPARISON_OPERATOR, DataType } from '../../../..';
+import { AggregateType } from '../../../../utils/dataTypes';
 
 /**
  * Testing route for the webGL rendering without being fully coupled to the chart.
@@ -22,6 +23,7 @@ export class ScWebglBarChartThresholdBand {
               id: 'test',
               color: 'black',
               name: 'test stream',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: {
                 [MINUTE_IN_MS]: [TEST_DATA_POINT_STANDARD],
               },

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-coloration.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-coloration.tsx
@@ -3,6 +3,7 @@ import { Component, h } from '@stencil/core';
 import { MINUTE_IN_MS } from '../../../../utils/time';
 import { TEST_DATA_POINT_STANDARD, Y_MAX, Y_MIN, X_MIN, X_MAX } from '../constants';
 import { COMPARISON_OPERATOR, DataType } from '../../../..';
+import { AggregateType } from '../../../../utils/dataTypes';
 
 /**
  * Testing route for the webGL rendering without being fully coupled to the chart.
@@ -24,6 +25,7 @@ export class ScWebglBarChartThresholdColoration {
               color: 'black',
               name: 'test stream',
               data: [],
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MINUTE_IN_MS]: [TEST_DATA_POINT_STANDARD] },
               resolution: MINUTE_IN_MS,
               dataType: DataType.NUMBER,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-exact-point.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-exact-point.tsx
@@ -3,6 +3,7 @@ import { Component, h } from '@stencil/core';
 import { MINUTE_IN_MS } from '../../../../utils/time';
 import { TEST_DATA_POINT_STANDARD, Y_MAX, Y_MIN, X_MIN, X_MAX } from '../constants';
 import { COMPARISON_OPERATOR, DataType } from '../../../..';
+import { AggregateType } from '../../../../utils/dataTypes';
 
 /**
  * Testing route for the webGL rendering without being fully coupled to the chart.
@@ -22,6 +23,7 @@ export class ScWebglBarChartThresholdExactPoint {
               color: 'black',
               name: 'test stream',
               data: [],
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MINUTE_IN_MS]: [TEST_DATA_POINT_STANDARD] },
               resolution: MINUTE_IN_MS,
               dataType: DataType.NUMBER,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-multiple-data-stream.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-multiple-data-stream.tsx
@@ -1,7 +1,7 @@
 import { Component, h } from '@stencil/core';
 
 import { YEAR_IN_MS } from '../../../../utils/time';
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { DataType } from '../../../../utils/dataConstants';
 import { COMPARISON_OPERATOR } from '../../../../components/charts/common/constants';
 
@@ -46,6 +46,7 @@ export class ScWebglBarChartThresholdMultipleDataStream {
           dataStreams={[
             {
               id: 'test',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: {
                 [YEAR_IN_MS]: [TEST_DATA_POINT, TEST_DATA_POINT_2],
               },
@@ -57,6 +58,7 @@ export class ScWebglBarChartThresholdMultipleDataStream {
             },
             {
               id: 'test2',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: {
                 [YEAR_IN_MS]: [TEST_2_DATA_POINT, TEST_2_DATA_POINT_2],
               },

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-multiple-thresholds.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-multiple-thresholds.tsx
@@ -3,6 +3,7 @@ import { Component, h } from '@stencil/core';
 import { MINUTE_IN_MS } from '../../../../utils/time';
 import { TEST_DATA_POINT_STANDARD, Y_MAX, Y_MIN, X_MIN, X_MAX } from '../constants';
 import { COMPARISON_OPERATOR, DataType } from '../../../..';
+import { AggregateType } from '../../../../utils/dataTypes';
 
 /**
  * Testing route for the webGL rendering without being fully coupled to the chart.
@@ -23,6 +24,7 @@ export class ScWebglBarChartThresholdMultipleThresholds {
               id: 'test',
               color: 'black',
               name: 'test stream',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: {
                 [MINUTE_IN_MS]: [TEST_DATA_POINT_STANDARD],
               },

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-no-coloration.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-no-coloration.tsx
@@ -3,6 +3,7 @@ import { Component, h } from '@stencil/core';
 import { MINUTE_IN_MS } from '../../../../utils/time';
 import { TEST_DATA_POINT_STANDARD, Y_MAX, Y_MIN, X_MIN, X_MAX } from '../constants';
 import { COMPARISON_OPERATOR, DataType } from '../../../..';
+import { AggregateType } from '../../../../utils/dataTypes';
 
 /**
  * Testing route for the webGL rendering without being fully coupled to the chart.
@@ -24,6 +25,7 @@ export class ScWebglBarChartThresholdNoColoration {
               color: 'black',
               name: 'test stream',
               data: [],
+              aggregationType: AggregateType.AVERAGE,
               aggregates: {
                 [MINUTE_IN_MS]: [TEST_DATA_POINT_STANDARD],
               },

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-unsupported-data-types.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-unsupported-data-types.tsx
@@ -2,6 +2,7 @@ import { Component, h } from '@stencil/core';
 import { MONTH_IN_MS } from '../../../../utils/time';
 import { Y_VALUE_STRING } from '../constants';
 import { DataType } from '../../../../utils/dataConstants';
+import { AggregateType } from '../../../../utils/dataTypes';
 
 // viewport boundaries
 const Y_MIN = 0;
@@ -32,6 +33,7 @@ export class ScWebglBarChartUnsupportedDataTypes {
                 id: 'test',
                 color: 'black',
                 name: 'test-name',
+                aggregationType: AggregateType.AVERAGE,
                 aggregates: {},
                 data: [
                   {

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration-exact-point.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration-exact-point.tsx
@@ -1,7 +1,7 @@
 import { Component, h } from '@stencil/core';
 
 import { MONTH_IN_MS } from '../../../utils/time';
-import { DataPoint } from '../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../utils/dataTypes';
 import { DataType } from '../../../utils/dataConstants';
 import { COMPARISON_OPERATOR } from '../../../components/charts/common/constants';
 
@@ -36,6 +36,7 @@ export class ScWebglChartThresholdColorationExactPoint {
               id: 'test',
               color: 'black',
               name: 'test stream',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MONTH_IN_MS]: [TEST_DATA_POINT, TEST_DATA_POINT_2] },
               data: [],
               resolution: MONTH_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-line-chart-dynamic-data-streams.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-line-chart-dynamic-data-streams.tsx
@@ -1,7 +1,7 @@
 import { Component, h, State } from '@stencil/core';
 import { Y_VALUE } from './constants';
 import { MINUTE_IN_MS } from '../../../utils/time';
-import { DataStream } from '../../../utils/dataTypes';
+import { AggregateType, DataStream } from '../../../utils/dataTypes';
 import { DataType } from '../../../utils/dataConstants';
 
 // viewport boundaries
@@ -46,6 +46,7 @@ export class ScWebglLineChartDynamicDataStreams {
         id: streamId,
         color: 'black',
         name: `${streamId}-name`,
+        aggregationType: AggregateType.AVERAGE,
         aggregates: { [MINUTE_IN_MS]: [leftPoint, middlePoint, rightPoint] },
         data: [],
         resolution: MINUTE_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-dynamic-data.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-dynamic-data.tsx
@@ -1,7 +1,7 @@
 import { Component, h, State } from '@stencil/core';
 import { Y_VALUE } from '../constants';
 import { MONTH_IN_MS } from '../../../../utils/time';
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { DataType } from '../../../../utils/dataConstants';
 
 // viewport boundaries
@@ -56,6 +56,7 @@ export class ScScatterChartDynamicData {
                 color: 'red',
                 name: 'test stream',
                 data: [],
+                aggregationType: AggregateType.AVERAGE,
                 aggregates: {
                   [MONTH_IN_MS]: this.data,
                 },

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-band.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-band.tsx
@@ -1,6 +1,6 @@
 import { Component, h } from '@stencil/core';
 
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { MONTH_IN_MS } from '../../../../utils/time';
 import { DataType } from '../../../../utils/dataConstants';
 import { COMPARISON_OPERATOR } from '../../../../components/charts/common/constants';
@@ -50,6 +50,7 @@ export class ScScatterChartThresholdColorationBand {
             {
               id: 'test',
               data: [],
+              aggregationType: AggregateType.AVERAGE,
               aggregates: {
                 [MONTH_IN_MS]: [TEST_DATA_POINT, TEST_DATA_POINT_2, TEST_DATA_POINT_3],
               },
@@ -63,6 +64,7 @@ export class ScScatterChartThresholdColorationBand {
               color: 'red',
               name: 'test stream2',
               data: [],
+              aggregationType: AggregateType.AVERAGE,
               aggregates: {
                 [MONTH_IN_MS]: [TEST_2_DATA_POINT, TEST_2_DATA_POINT_2],
               },

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-exact-point.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-exact-point.tsx
@@ -1,6 +1,6 @@
 import { Component, h } from '@stencil/core';
 
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { MONTH_IN_MS } from '../../../../utils/time';
 import { DataType } from '../../../../utils/dataConstants';
 import { COMPARISON_OPERATOR } from '../../../../components/charts/common/constants';
@@ -36,6 +36,7 @@ export class ScScatterChartThresholdColorationExactPoint {
               id: 'test',
               color: 'black',
               name: 'test stream',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MONTH_IN_MS]: [TEST_DATA_POINT, TEST_DATA_POINT_2] },
               data: [],
               resolution: MONTH_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-multiple-data-stream.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-multiple-data-stream.tsx
@@ -1,6 +1,6 @@
 import { Component, h } from '@stencil/core';
 
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { MONTH_IN_MS } from '../../../../utils/time';
 import { DataType } from '../../../../utils/dataConstants';
 import { COMPARISON_OPERATOR } from '../../../../components/charts/common/constants';
@@ -46,6 +46,7 @@ export class ScScatterChartThresholdColorationMultipleDataStream {
               id: 'test',
               color: 'black',
               name: 'test stream',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MONTH_IN_MS]: [TEST_DATA_POINT, TEST_DATA_POINT_2] },
               data: [],
               resolution: MONTH_IN_MS,
@@ -55,6 +56,7 @@ export class ScScatterChartThresholdColorationMultipleDataStream {
               id: 'test2',
               name: 'test stream2',
               color: 'red',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MONTH_IN_MS]: [TEST_2_DATA_POINT, TEST_2_DATA_POINT_2] },
               data: [],
               resolution: MONTH_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-multiple-thresholds.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-multiple-thresholds.tsx
@@ -1,6 +1,6 @@
 import { Component, h } from '@stencil/core';
 
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { MONTH_IN_MS } from '../../../../utils/time';
 import { DataType } from '../../../../utils/dataConstants';
 import { COMPARISON_OPERATOR } from '../../../../components/charts/common/constants';
@@ -51,6 +51,7 @@ export class ScWebglChartThresholdColorationMultipleThresholds {
               id: 'test',
               color: 'black',
               name: 'test stream',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MONTH_IN_MS]: [TEST_DATA_POINT, TEST_DATA_POINT_2, TEST_DATA_POINT_3] },
               data: [],
               resolution: MONTH_IN_MS,
@@ -60,6 +61,7 @@ export class ScWebglChartThresholdColorationMultipleThresholds {
               id: 'test2',
               color: 'red',
               name: 'test stream2',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MONTH_IN_MS]: [TEST_2_DATA_POINT, TEST_2_DATA_POINT_2] },
               data: [],
               resolution: MONTH_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration.tsx
@@ -1,5 +1,5 @@
 import { Component, h } from '@stencil/core';
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { MONTH_IN_MS } from '../../../../utils/time';
 import { DataType } from '../../../../utils/dataConstants';
 import { COMPARISON_OPERATOR } from '../../../../components/charts/common/constants';
@@ -34,6 +34,7 @@ export class ScScatterChartThresholdColoration {
               id: 'test',
               name: 'test stream',
               color: 'black',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MONTH_IN_MS]: [TEST_DATA_POINT, TEST_DATA_POINT_2] },
               data: [],
               resolution: MONTH_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-no-coloration.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-no-coloration.tsx
@@ -1,6 +1,6 @@
 import { Component, h } from '@stencil/core';
 
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { MONTH_IN_MS } from '../../../../utils/time';
 import { DataType } from '../../../../utils/dataConstants';
 import { COMPARISON_OPERATOR } from '../../../../components/charts/common/constants';
@@ -36,6 +36,7 @@ export class ScScatterChartThresholdNoColoration {
               id: 'test',
               name: 'test stream',
               color: 'black',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MONTH_IN_MS]: [TEST_DATA_POINT, TEST_DATA_POINT_2] },
               data: [],
               resolution: MONTH_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-trend-line-color-configuration.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-trend-line-color-configuration.tsx
@@ -1,6 +1,6 @@
 import { Component, h } from '@stencil/core';
 import { SECOND_IN_MS } from '../../../../utils/time';
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { DataType, TREND_TYPE } from '../../../../utils/dataConstants';
 import { LEGEND_POSITION } from '../../../../components/charts/common/constants';
 
@@ -40,6 +40,7 @@ export class ScScatterChartTrendLineColorConfiguration {
               id: 'test',
               color: 'red',
               name: 'test stream',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [SECOND_IN_MS]: TEST_DATA_POINTS },
               data: [],
               resolution: SECOND_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-trend-line-with-legend.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-trend-line-with-legend.tsx
@@ -1,6 +1,6 @@
 import { Component, h } from '@stencil/core';
 import { SECOND_IN_MS } from '../../../../utils/time';
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { DataType, TREND_TYPE } from '../../../../utils/dataConstants';
 import { LEGEND_POSITION } from '../../../../components/charts/common/constants';
 
@@ -40,6 +40,7 @@ export class ScScatterChartTrendLineWithLegend {
               id: 'test',
               color: 'black',
               name: 'test stream',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [SECOND_IN_MS]: TEST_DATA_POINTS },
               data: [],
               resolution: SECOND_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-unsupported-data-types.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-unsupported-data-types.tsx
@@ -1,5 +1,5 @@
 import { Component, h } from '@stencil/core';
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { MONTH_IN_MS } from '../../../../utils/time';
 import { DataType } from '../../../../utils/dataConstants';
 import { Y_VALUE_STRING } from '../constants';
@@ -34,6 +34,7 @@ export class ScScatterChartUnsupportedDataTypes {
               id: 'test',
               name: 'test stream',
               color: 'black',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MONTH_IN_MS]: [TEST_DATA_POINT, TEST_DATA_POINT_2] },
               data: [],
               resolution: MONTH_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-bar-chart/sc-multiple-bars.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-bar-chart/sc-multiple-bars.tsx
@@ -3,7 +3,7 @@ import { webGLRenderer } from '../../../../../components/sc-webgl-context/webglC
 import { chartScene } from '../../../../../components/charts/sc-bar-chart/chartScene';
 import { CHART_SIZE } from '../chartSize';
 import { HOUR_IN_MS } from '../../../../../utils/time';
-import { DataPoint } from '../../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../../utils/dataTypes';
 import { DataType } from '../../../../../utils/dataConstants';
 
 // viewport boundaries
@@ -50,6 +50,7 @@ export class ScMultipleBars {
           id: 'test-stream',
           name: 'test-stream-name',
           color: 'black',
+          aggregationType: AggregateType.AVERAGE,
           aggregates: { [HOUR_IN_MS * 5]: [TEST_DATA_POINT_1] },
           data: [],
           resolution: HOUR_IN_MS * 5,
@@ -59,6 +60,7 @@ export class ScMultipleBars {
           id: 'test-stream-2',
           name: 'test-stream-name-2',
           color: 'red',
+          aggregationType: AggregateType.AVERAGE,
           aggregates: { [HOUR_IN_MS * 5]: [TEST_DATA_POINT_2] },
           data: [],
           resolution: HOUR_IN_MS * 5,

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-bar-chart/sc-single-bar.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-bar-chart/sc-single-bar.tsx
@@ -4,7 +4,7 @@ import { chartScene } from '../../../../../components/charts/sc-bar-chart/chartS
 import { CHART_SIZE } from '../chartSize';
 import { DAY_IN_MS } from '../../../../../utils/time';
 import { DataType } from '../../../../../utils/dataConstants';
-import { DataPoint } from '../../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../../utils/dataTypes';
 
 // viewport boundaries
 const X_MIN = new Date(2000, 0, 0);
@@ -47,6 +47,7 @@ export class ScSingleBar {
           name: 'test-stream-name',
           color: 'black',
           data: [],
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [DAY_IN_MS]: [TEST_DATA_POINT_1],
           },

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-bar-chart/sc-single-colored-bar.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/sc-bar-chart/sc-single-colored-bar.tsx
@@ -3,7 +3,7 @@ import { webGLRenderer } from '../../../../../components/sc-webgl-context/webglC
 import { chartScene } from '../../../../../components/charts/sc-bar-chart/chartScene';
 import { CHART_SIZE } from '../chartSize';
 import { DAY_IN_MS } from '../../../../../utils/time';
-import { DataPoint } from '../../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../../utils/dataTypes';
 import { DataType } from '../../../../../utils/dataConstants';
 
 // viewport boundaries
@@ -48,6 +48,7 @@ export class ScSingleColoredBar {
           color: 'red',
           resolution: DAY_IN_MS,
           data: [],
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [DAY_IN_MS]: [TEST_DATA_POINT_1],
           },

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/status-timeline/multiple-statuses.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/status-timeline/multiple-statuses.tsx
@@ -4,7 +4,7 @@ import { chartScene } from '../../../../../components/charts/sc-status-timeline/
 import { CHART_SIZE } from '../chartSize';
 import { HOUR_IN_MS } from '../../../../../utils/time';
 import { HEIGHT } from '../../../../../components/charts/sc-status-timeline/constants';
-import { DataPoint } from '../../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../../utils/dataTypes';
 import { DataType } from '../../../../../utils/dataConstants';
 
 // viewport boundaries
@@ -42,6 +42,7 @@ export class MultipleStatuses {
       dataStreams: [
         {
           id: 'test-stream',
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [HOUR_IN_MS * 5]: [TEST_DATA_POINT_1],
           },
@@ -53,6 +54,7 @@ export class MultipleStatuses {
         },
         {
           id: 'test-stream-2',
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [HOUR_IN_MS * 5]: [TEST_DATA_POINT_2],
           },

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/status-timeline/single-colored-status.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/status-timeline/single-colored-status.tsx
@@ -4,7 +4,7 @@ import { chartScene } from '../../../../../components/charts/sc-status-timeline/
 import { CHART_SIZE } from '../chartSize';
 import { DAY_IN_MS } from '../../../../../utils/time';
 import { HEIGHT } from '../../../../../components/charts/sc-status-timeline/constants';
-import { DataPoint } from '../../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../../utils/dataTypes';
 import { DataType } from '../../../../../utils/dataConstants';
 
 // viewport boundaries
@@ -39,6 +39,7 @@ export class SingleColoredStatus {
           id: 'test-stream',
           name: 'test-stream-name',
           color: 'red',
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [DAY_IN_MS]: [TEST_DATA_POINT_1],
           },

--- a/packages/synchro-charts/src/testing/test-routes/charts/shaders/status-timeline/single-status.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/shaders/status-timeline/single-status.tsx
@@ -5,7 +5,7 @@ import { CHART_SIZE } from '../chartSize';
 import { DAY_IN_MS } from '../../../../../utils/time';
 import { HEIGHT } from '../../../../../components/charts/sc-status-timeline/constants';
 import { DataType } from '../../../../../utils/dataConstants';
-import { DataPoint } from '../../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../../utils/dataTypes';
 
 // viewport boundaries
 const X_MIN = new Date(2000, 0, 0);
@@ -40,6 +40,7 @@ export class ScSingleStatus {
           name: 'test-stream-name',
           color: 'black',
           resolution: DAY_IN_MS,
+          aggregationType: AggregateType.AVERAGE,
           aggregates: {
             [DAY_IN_MS]: [TEST_DATA_POINT_1],
           },

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-dynamic-buffer.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-dynamic-buffer.tsx
@@ -1,7 +1,7 @@
 import { Component, h, State } from '@stencil/core';
 
 import { MONTH_IN_MS } from '../../../../utils/time';
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { DataType } from '../../../../utils/dataConstants';
 
 // viewport boundaries
@@ -41,6 +41,7 @@ export class StatusTimelineDynamicBuffer {
                 id: 'test',
                 color: 'red',
                 name: 'test stream',
+                aggregationType: AggregateType.AVERAGE,
                 aggregates: { [MONTH_IN_MS]: this.data },
                 data: [],
                 resolution: MONTH_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-dynamic-data-streams.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-dynamic-data-streams.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { DataStream } from '../../../../utils/dataTypes';
+import { AggregateType, DataStream } from '../../../../utils/dataTypes';
 import { MONTH_IN_MS } from '../../../../utils/time';
 import { DataType } from '../../../../utils/dataConstants';
 
@@ -53,6 +53,7 @@ export class StatusTimelineDynamicDataStreams {
         id: streamId,
         color: this.getColor(),
         name: `${streamId}-name`,
+        aggregationType: AggregateType.AVERAGE,
         aggregates: { [MONTH_IN_MS]: [leftPoint, middlePoint, rightPoint] },
         data: [],
         resolution: MONTH_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-dynamic-data.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-dynamic-data.tsx
@@ -1,7 +1,7 @@
 import { Component, h, State } from '@stencil/core';
 
 import { MONTH_IN_MS } from '../../../../utils/time';
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { DataType } from '../../../../utils/dataConstants';
 
 // viewport boundaries
@@ -52,6 +52,7 @@ export class StatusTimelineDynamicData {
                 id: 'test',
                 name: 'test stream',
                 color: 'red',
+                aggregationType: AggregateType.AVERAGE,
                 aggregates: { [MONTH_IN_MS]: this.data },
                 data: [],
                 resolution: MONTH_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-fast-viewport.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-fast-viewport.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { DataPoint, DataStream } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint, DataStream } from '../../../../utils/dataTypes';
 import { HOUR_IN_MS } from '../../../../utils/time';
 import { DataType } from '../../../../utils/dataConstants';
 
@@ -59,6 +59,7 @@ export class StatusTimelineFastViewport {
                 id: 'test',
                 color: '#264653',
                 name: 'test stream',
+                aggregationType: AggregateType.AVERAGE,
                 aggregates: { [HOUR_IN_MS]: DATA_POINTS },
                 data: [],
                 resolution: HOUR_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-multiple-data-streams.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-multiple-data-streams.tsx
@@ -3,6 +3,7 @@ import { Component, h } from '@stencil/core';
 import { MINUTE_IN_MS } from '../../../../utils/time';
 import { TEST_DATA_POINT_STANDARD, Y_MAX, Y_MIN, X_MIN, X_MAX } from '../constants';
 import { DataType } from '../../../..';
+import { AggregateType } from '../../../../utils/dataTypes';
 
 @Component({
   tag: 'status-timeline-multiple-data-streams',
@@ -18,6 +19,7 @@ export class StatusTimelineMultipleDataStreams {
               id: 'test',
               color: 'black',
               name: 'test stream 1',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MINUTE_IN_MS]: [{ ...TEST_DATA_POINT_STANDARD, y: 70 }] },
               data: [],
               resolution: MINUTE_IN_MS,
@@ -27,6 +29,7 @@ export class StatusTimelineMultipleDataStreams {
               id: 'test2',
               color: 'blue',
               name: 'test stream 2',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MINUTE_IN_MS]: [{ ...TEST_DATA_POINT_STANDARD, y: 170 }] },
               data: [],
               resolution: MINUTE_IN_MS,
@@ -36,6 +39,7 @@ export class StatusTimelineMultipleDataStreams {
               id: 'test3',
               color: 'red',
               name: 'test stream 3',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MINUTE_IN_MS]: [{ ...TEST_DATA_POINT_STANDARD, y: 60 }] },
               data: [],
               resolution: MINUTE_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-status-margin.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-status-margin.tsx
@@ -1,7 +1,7 @@
 import { Component, h, State } from '@stencil/core';
 
 import { MONTH_IN_MS } from '../../../../utils/time';
-import { DataPoint, DataStream } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint, DataStream } from '../../../../utils/dataTypes';
 import { DataType } from '../../../../utils/dataConstants';
 
 // viewport boundaries
@@ -16,6 +16,7 @@ const DATA_STREAM_1: DataStream = {
   color: 'red',
   name: 'test stream',
   resolution: MONTH_IN_MS,
+  aggregationType: AggregateType.AVERAGE,
   aggregates: {
     [MONTH_IN_MS]: [
       { x: new Date(1998, 3, 0, 0).getTime(), y: 1000 },

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-band.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-band.tsx
@@ -2,7 +2,7 @@ import { Component, h } from '@stencil/core';
 
 import { MINUTE_IN_MS } from '../../../../utils/time';
 import { TEST_DATA_POINT_STANDARD, X_MAX, X_MIN, Y_MAX, Y_MIN } from '../constants';
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { DataType } from '../../../../utils/dataConstants';
 import { COMPARISON_OPERATOR } from '../../../../components/charts/common/constants';
 
@@ -37,6 +37,7 @@ export class StatusTimelineThresholdBand {
               id: 'test',
               color: 'black',
               name: 'test stream',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MINUTE_IN_MS]: [data] },
               data: [],
               resolution: MINUTE_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-coloration.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-coloration.tsx
@@ -3,6 +3,7 @@ import { Component, h } from '@stencil/core';
 import { MINUTE_IN_MS } from '../../../../utils/time';
 import { TEST_DATA_POINT_STANDARD, Y_MAX, Y_MIN, X_MIN, X_MAX } from '../constants';
 import { COMPARISON_OPERATOR, DataType } from '../../../..';
+import { AggregateType } from '../../../../utils/dataTypes';
 
 @Component({
   tag: 'status-timeline-threshold-coloration',
@@ -18,6 +19,7 @@ export class StatusTimelineThresholdColoration {
               id: 'test',
               color: 'black',
               name: 'test stream',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MINUTE_IN_MS]: [TEST_DATA_POINT_STANDARD] },
               data: [],
               resolution: MINUTE_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-exact-point.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-exact-point.tsx
@@ -3,6 +3,7 @@ import { Component, h } from '@stencil/core';
 import { MINUTE_IN_MS } from '../../../../utils/time';
 import { TEST_DATA_POINT_STANDARD, Y_MAX, Y_MIN, X_MIN, X_MAX } from '../constants';
 import { COMPARISON_OPERATOR, DataType } from '../../../..';
+import { AggregateType } from '../../../../utils/dataTypes';
 
 @Component({
   tag: 'status-timeline-threshold-coloration-exact-point',
@@ -18,6 +19,7 @@ export class StatusTimelineThresholdExactPoint {
               id: 'test',
               color: 'black',
               name: 'test stream',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MINUTE_IN_MS]: [TEST_DATA_POINT_STANDARD] },
               data: [],
               resolution: MINUTE_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-multiple-data-stream.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-multiple-data-stream.tsx
@@ -1,7 +1,7 @@
 import { Component, h } from '@stencil/core';
 
 import { YEAR_IN_MS } from '../../../../utils/time';
-import { DataPoint } from '../../../../utils/dataTypes';
+import { AggregateType, DataPoint } from '../../../../utils/dataTypes';
 import { COMPARISON_OPERATOR } from '../../../../components/charts/common/constants';
 import { DataType } from '../../../../utils/dataConstants';
 
@@ -45,6 +45,7 @@ export class StatusTimelineThresholdMultipleDataStream {
               id: 'test',
               color: 'black',
               name: 'test stream',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [YEAR_IN_MS]: [TEST_DATA_POINT, TEST_DATA_POINT_2] },
               data: [],
               resolution: YEAR_IN_MS,
@@ -54,6 +55,7 @@ export class StatusTimelineThresholdMultipleDataStream {
               id: 'test2',
               color: 'black',
               name: 'test stream',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [YEAR_IN_MS]: [TEST_2_DATA_POINT, TEST_2_DATA_POINT_2] },
               data: [],
               resolution: YEAR_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-multiple-thresholds.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-multiple-thresholds.tsx
@@ -3,6 +3,7 @@ import { Component, h } from '@stencil/core';
 import { MINUTE_IN_MS } from '../../../../utils/time';
 import { TEST_DATA_POINT_STANDARD, Y_MAX, Y_MIN, X_MIN, X_MAX } from '../constants';
 import { COMPARISON_OPERATOR, DataType } from '../../../..';
+import { AggregateType } from '../../../../utils/dataTypes';
 
 @Component({
   tag: 'status-timeline-threshold-coloration-multiple-thresholds',
@@ -18,6 +19,7 @@ export class StatusTimelineThresholdMultipleThresholds {
               id: 'test',
               color: 'black',
               name: 'test stream',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MINUTE_IN_MS]: [TEST_DATA_POINT_STANDARD] },
               data: [],
               resolution: MINUTE_IN_MS,

--- a/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-no-coloration.tsx
+++ b/packages/synchro-charts/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-no-coloration.tsx
@@ -3,6 +3,7 @@ import { Component, h } from '@stencil/core';
 import { MINUTE_IN_MS } from '../../../../utils/time';
 import { TEST_DATA_POINT_STANDARD, Y_MAX, Y_MIN, X_MIN, X_MAX } from '../constants';
 import { COMPARISON_OPERATOR, DataType } from '../../../..';
+import { AggregateType } from '../../../../utils/dataTypes';
 
 @Component({
   tag: 'status-timeline-threshold-no-coloration',
@@ -18,6 +19,7 @@ export class StatusTimelineThresholdNoColoration {
               id: 'test',
               color: 'black',
               name: 'test stream',
+              aggregationType: AggregateType.AVERAGE,
               aggregates: { [MINUTE_IN_MS]: [TEST_DATA_POINT_STANDARD] },
               data: [],
               resolution: MINUTE_IN_MS,

--- a/packages/synchro-charts/src/utils/aggregateToString.ts
+++ b/packages/synchro-charts/src/utils/aggregateToString.ts
@@ -1,0 +1,4 @@
+/* Convert aggregate type to lowercase string */
+export function aggregateToString(aggregate: string): string {
+  return aggregate.replace(/_/g, ' ').toLowerCase();
+}

--- a/packages/synchro-charts/src/utils/dataTypes.ts
+++ b/packages/synchro-charts/src/utils/dataTypes.ts
@@ -214,6 +214,15 @@ export const TREND_ICON_DASH_ARRAY = '1, 5';
  * A `resolution` of `0` implies that there is no aggregation occurring, and that the data represents a single point in time,
  * of which has no duration.
  */
+
+export const AggregateType = {
+  AVERAGE: 'AVERAGE',
+  COUNT: 'COUNT',
+  MAXIMUM: 'MAXIMUM',
+  MINIMUM: 'MINIMUM',
+  STANDARD_DEVIATION: 'STANDARD_DEVIATION',
+  SUM: 'SUM',
+};
 export interface DataStream<T extends Primitive = Primitive> extends DataStreamInfo {
   id: DataStreamId;
 
@@ -246,6 +255,7 @@ export interface DataStream<T extends Primitive = Primitive> extends DataStreamI
   isLoading?: boolean;
   isRefreshing?: boolean;
   error?: string;
+  aggregationType?: string;
   resolution: number; // length of aggregation period in milliseconds. 0 implies no aggregations.
 }
 


### PR DESCRIPTION
## Overview
Add optional aggregate to dataStream definition

## Tests
<img width="595" alt="Screenshot 2023-02-15 at 14 49 07" src="https://user-images.githubusercontent.com/28601414/219176216-57d26fae-3227-41c0-a923-75314635692d.png">
<img width="800" alt="Screenshot 2023-02-15 at 14 49 00" src="https://user-images.githubusercontent.com/28601414/219176229-fdc6b3b4-83f2-4981-935c-cc7e2b28128c.png">


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
