### PR TITLE
chore{workflow): bump down github-pages-deploy-action

### DIFF
--- a/.github/workflows/deploy-doc-site.yml
+++ b/.github/workflows/deploy-doc-site.yml
@@ -21,7 +21,7 @@ jobs:
           yarn build
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.4.1
+        uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
           branch: docs-cd
           folder: docs


### PR DESCRIPTION
## Overview
bump down github-pages-deploy-action to 4.1.5

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
