### PR TITLE
chore: remove deprecated `colorDataAcrossThresholds` flag

### DIFF
--- a/packages/iot-app-kit-visualizations/src/components/charts/common/types.ts
+++ b/packages/iot-app-kit-visualizations/src/components/charts/common/types.ts
@@ -151,7 +151,6 @@ export interface Annotations {
   x?: XAnnotation[];
   y?: YAnnotation[];
   thresholdOptions?: ThresholdOptions | boolean;
-  colorDataAcrossThresholds?: boolean;
 }
 
 export interface ThresholdBand {


### PR DESCRIPTION
`colorDataAcrossThresholds` is no longer used. Should use `thresholdOptions` instead.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
