### PR TITLE
feat(webgl-base-chart): replace dateChanged event emitter with setViewport

### DIFF
--- a/packages/doc-site/docs/events.md
+++ b/packages/doc-site/docs/events.md
@@ -11,15 +11,3 @@ Currently, this event is only fired when
 
   2. A y-annotation is dragged to a new value 
 
-### `dateRangeChange`
-
-An event which is fired upon manually enacted changes to the view port, such as panning or zooming into a chart.
-
-The structure is the following:
-
-```js static
-{
-  detail: [Date, Date, string | undefined];
-}
-```
-

--- a/packages/iot-app-kit-visualizations/src/components.d.ts
+++ b/packages/iot-app-kit-visualizations/src/components.d.ts
@@ -5,7 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { AlarmsConfig, DataPoint, DataStream, DataStreamInfo, MessageOverrides, MinimalSizeConfig, MinimalViewPortConfig, Primitive, SizeConfig, SizePositionConfig, ViewPort, ViewPortConfig } from "./utils/dataTypes";
+import { AlarmsConfig, AppKitViewport, DataPoint, DataStream, DataStreamInfo, MessageOverrides, MinimalSizeConfig, MinimalViewPortConfig, Primitive, SizeConfig, SizePositionConfig, ViewPort, ViewPortConfig } from "./utils/dataTypes";
 import { Annotations, Axis, LayoutConfig, Legend, LegendConfig, MovementConfig, ScaleConfig, Threshold, Tooltip, WidgetConfigurationUpdate } from "./components/charts/common/types";
 import { Trend, TrendResult } from "./components/charts/common/trends/types";
 import { DATA_ALIGNMENT, StatusIcon } from "./components/charts/common/constants";
@@ -40,6 +40,7 @@ export namespace Components {
         "minBufferSize": number;
         "movement"?: MovementConfig;
         "scale"?: ScaleConfig;
+        "setViewport": (viewport: AppKitViewport, lastUpdatedBy?: string) => void;
         "size"?: MinimalSizeConfig;
         "trends": Trend[];
         /**
@@ -133,6 +134,7 @@ export namespace Components {
         "minBufferSize": number;
         "movement"?: MovementConfig;
         "scale"?: ScaleConfig;
+        "setViewport": (viewport: AppKitViewport, lastUpdatedBy?: string) => void;
         "size"?: MinimalSizeConfig;
         "trends": Trend[];
         /**
@@ -175,6 +177,7 @@ export namespace Components {
         "minBufferSize": number;
         "movement"?: MovementConfig;
         "scale"?: ScaleConfig;
+        "setViewport": (viewport: AppKitViewport, lastUpdatedBy?: string) => void;
         "size"?: MinimalSizeConfig;
         "trends": Trend[];
         /**
@@ -237,6 +240,7 @@ export namespace Components {
         "minBufferSize": number;
         "movement"?: MovementConfig;
         "scale"?: ScaleConfig;
+        "setViewport": (viewport: AppKitViewport, lastUpdatedBy?: string) => void;
         "size"?: MinimalSizeConfig;
         /**
           * Chart API
@@ -387,6 +391,7 @@ export namespace Components {
         "onUpdateLifeCycle"?: (viewport: ViewPortConfig) => void;
         "renderLegend": (props: Legend.Props) => HTMLElement;
         "renderTooltip": (props: Tooltip.Props) => HTMLElement;
+        "setViewport": (viewport: AppKitViewport, lastUpdatedBy?: string) => void;
         "size": SizePositionConfig;
         "supportString": boolean;
         "supportedDataTypes": DataType[];
@@ -1290,6 +1295,7 @@ declare namespace LocalJSX {
         "minBufferSize"?: number;
         "movement"?: MovementConfig;
         "scale"?: ScaleConfig;
+        "setViewport"?: (viewport: AppKitViewport, lastUpdatedBy?: string) => void;
         "size"?: MinimalSizeConfig;
         "trends"?: Trend[];
         /**
@@ -1383,6 +1389,7 @@ declare namespace LocalJSX {
         "minBufferSize"?: number;
         "movement"?: MovementConfig;
         "scale"?: ScaleConfig;
+        "setViewport"?: (viewport: AppKitViewport, lastUpdatedBy?: string) => void;
         "size"?: MinimalSizeConfig;
         "trends"?: Trend[];
         /**
@@ -1425,6 +1432,7 @@ declare namespace LocalJSX {
         "minBufferSize"?: number;
         "movement"?: MovementConfig;
         "scale"?: ScaleConfig;
+        "setViewport"?: (viewport: AppKitViewport, lastUpdatedBy?: string) => void;
         "size"?: MinimalSizeConfig;
         "trends"?: Trend[];
         /**
@@ -1487,6 +1495,7 @@ declare namespace LocalJSX {
         "minBufferSize"?: number;
         "movement"?: MovementConfig;
         "scale"?: ScaleConfig;
+        "setViewport"?: (viewport: AppKitViewport, lastUpdatedBy?: string) => void;
         "size"?: MinimalSizeConfig;
         /**
           * Chart API
@@ -1633,16 +1642,13 @@ declare namespace LocalJSX {
         "messageOverrides"?: MessageOverrides;
         "minBufferSize": number;
         /**
-          * On view port date range change, this component emits a `dateRangeChange` event. This allows other data visualization components to sync to the same date range.
-         */
-        "onDateRangeChange"?: (event: CustomEvent<[Date, Date, string | undefined]>) => void;
-        /**
           * Optionally hooks to integrate custom logic into the base chart
          */
         "onUpdateLifeCycle"?: (viewport: ViewPortConfig) => void;
         "onWidgetUpdated"?: (event: CustomEvent<WidgetConfigurationUpdate>) => void;
         "renderLegend"?: (props: Legend.Props) => HTMLElement;
         "renderTooltip"?: (props: Tooltip.Props) => HTMLElement;
+        "setViewport"?: (viewport: AppKitViewport, lastUpdatedBy?: string) => void;
         "size": SizePositionConfig;
         "supportString"?: boolean;
         "supportedDataTypes"?: DataType[];

--- a/packages/iot-app-kit-visualizations/src/components/charts/sc-bar-chart/sc-bar-chart.tsx
+++ b/packages/iot-app-kit-visualizations/src/components/charts/sc-bar-chart/sc-bar-chart.tsx
@@ -2,6 +2,7 @@ import { Component, h, Prop } from '@stencil/core';
 
 import {
   AlarmsConfig,
+  AppKitViewport,
   DataStream,
   MessageOverrides,
   MinimalSizeConfig,
@@ -56,6 +57,7 @@ export class ScBarChart implements ChartConfig {
   @Prop() alarms?: AlarmsConfig;
   @Prop() gestures: boolean = true;
   @Prop() annotations: Annotations;
+  @Prop() setViewport: (viewport: AppKitViewport, lastUpdatedBy?: string) => void;
   @Prop() trends: Trend[];
   @Prop() axis?: Axis.Options;
   @Prop() messageOverrides?: MessageOverrides;
@@ -93,6 +95,7 @@ export class ScBarChart implements ChartConfig {
             dataStreams={this.dataStreams}
             alarms={this.alarms}
             viewport={this.viewport}
+            setViewport={this.setViewport}
             minBufferSize={this.minBufferSize}
             bufferFactor={this.bufferFactor}
             isEditing={this.isEditing}

--- a/packages/iot-app-kit-visualizations/src/components/charts/sc-line-chart/sc-line-chart.tsx
+++ b/packages/iot-app-kit-visualizations/src/components/charts/sc-line-chart/sc-line-chart.tsx
@@ -1,6 +1,7 @@
 import { Component, Prop, h } from '@stencil/core';
 import {
   AlarmsConfig,
+  AppKitViewport,
   DataStream,
   MessageOverrides,
   MinimalSizeConfig,
@@ -58,6 +59,7 @@ export class ScLineChart implements ChartConfig {
   @Prop() trends: Trend[];
   @Prop() axis?: Axis.Options;
   @Prop() messageOverrides?: MessageOverrides;
+  @Prop() setViewport: (viewport: AppKitViewport, lastUpdatedBy?: string) => void;
 
   /** Status */
   @Prop() isEditing: boolean = false;
@@ -92,6 +94,7 @@ export class ScLineChart implements ChartConfig {
             }}
             dataStreams={this.dataStreams}
             viewport={this.viewport}
+            setViewport={this.setViewport}
             minBufferSize={this.minBufferSize}
             bufferFactor={this.bufferFactor}
             isEditing={this.isEditing}

--- a/packages/iot-app-kit-visualizations/src/components/charts/sc-scatter-chart/sc-scatter-chart.tsx
+++ b/packages/iot-app-kit-visualizations/src/components/charts/sc-scatter-chart/sc-scatter-chart.tsx
@@ -1,6 +1,7 @@
 import { Component, Prop, h } from '@stencil/core';
 import {
   AlarmsConfig,
+  AppKitViewport,
   DataStream,
   MessageOverrides,
   MinimalSizeConfig,
@@ -58,6 +59,7 @@ export class ScScatterChart implements ChartConfig {
   @Prop() trends: Trend[];
   @Prop() axis?: Axis.Options;
   @Prop() messageOverrides?: MessageOverrides;
+  @Prop() setViewport: (viewport: AppKitViewport, lastUpdatedBy?: string) => void;
 
   /** Status */
   @Prop() isEditing: boolean = false;
@@ -92,6 +94,7 @@ export class ScScatterChart implements ChartConfig {
             dataStreams={this.dataStreams}
             alarms={this.alarms}
             viewport={this.viewport}
+            setViewport={this.setViewport}
             minBufferSize={this.minBufferSize}
             bufferFactor={this.bufferFactor}
             isEditing={this.isEditing}

--- a/packages/iot-app-kit-visualizations/src/components/charts/sc-status-timeline/sc-status-timeline.tsx
+++ b/packages/iot-app-kit-visualizations/src/components/charts/sc-status-timeline/sc-status-timeline.tsx
@@ -2,6 +2,7 @@ import { Component, h, Prop, State, Watch } from '@stencil/core';
 
 import {
   AlarmsConfig,
+  AppKitViewport,
   DataStream,
   MessageOverrides,
   MinimalSizeConfig,
@@ -88,6 +89,7 @@ export class ScStatusTimeline implements ChartConfig {
   @Prop() axis?: Axis.Options;
   @Prop() messageOverrides?: MessageOverrides;
   @Prop() alarms?: AlarmsConfig;
+  @Prop() setViewport: (viewport: AppKitViewport, lastUpdatedBy?: string) => void;
 
   @State() componentViewport: MinimalViewPortConfig;
 
@@ -159,6 +161,7 @@ export class ScStatusTimeline implements ChartConfig {
                 dataStreams={this.dataStreams}
                 alarms={this.alarms}
                 viewport={this.componentViewport}
+                setViewport={this.setViewport}
                 minBufferSize={this.minBufferSize}
                 bufferFactor={this.bufferFactor}
                 isEditing={this.isEditing}

--- a/packages/iot-app-kit-visualizations/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.spec.tsx
+++ b/packages/iot-app-kit-visualizations/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.spec.tsx
@@ -70,6 +70,7 @@ const newChartSpecPage = async (chartProps: Partial<Components.IotAppKitVisWebgl
     displaysError: true,
     createChartScene: chartScene,
     viewport: VIEWPORT,
+    setViewport: () => {},
     gestures: true,
     size: {
       ...CHART_CONFIG.size,
@@ -490,15 +491,16 @@ describe('chart scene management', () => {
     );
   });
 
-  it('calls onUpdate without emitting dateRangeChanged event when chart is in live mode', async () => {
+  it('calls onUpdate without setting viewport event when chart is in live mode', async () => {
     jest.useFakeTimers();
 
     const mockEventListener = jest.fn();
-    document.addEventListener = mockEventListener;
+    const mockSetViewport = jest.fn();
     await newChartSpecPage({
       createChartScene: chartScene,
       updateChartScene,
       viewport: { duration: 500 },
+      setViewport: mockSetViewport,
       minBufferSize: MIN_BUFFER_SIZE,
       bufferFactor: BUFFER_FACTOR,
       dataStreams: DATA_STREAMS,
@@ -509,7 +511,7 @@ describe('chart scene management', () => {
     const secondsElapsed = 1;
     jest.advanceTimersByTime(secondsElapsed * SECOND_IN_MS);
 
-    expect(mockEventListener).not.toHaveBeenCalledWith('dateRangeChanged');
+    expect(mockSetViewport).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/iot-app-kit-visualizations/src/components/charts/sc-webgl-base-chart/utils.ts
+++ b/packages/iot-app-kit-visualizations/src/components/charts/sc-webgl-base-chart/utils.ts
@@ -108,7 +108,7 @@ export const constructChartScene = ({
       start: Date;
       end: Date;
       duration?: number | undefined;
-      shouldBlockDateRangeChangedEvent?: boolean;
+      shouldBlockSetViewport?: boolean;
     }) => {
       /**
        * Update threejs cameras position.

--- a/packages/iot-app-kit-visualizations/src/components/viewportHandler/types.ts
+++ b/packages/iot-app-kit-visualizations/src/components/viewportHandler/types.ts
@@ -6,7 +6,7 @@ export interface ViewPortManager {
     start: Date;
     end: Date;
     duration?: number;
-    shouldBlockDateRangeChangedEvent?: boolean;
+    shouldBlockSetViewport?: boolean;
   }) => void;
   // Disposes of all all scene, it's geometries, and any materials that are specific to the scene.
   // Dispose should be called whenever a chart scene is no longer used, otherwise the application

--- a/packages/iot-app-kit-visualizations/src/components/viewportHandler/viewportHandler.spec.ts
+++ b/packages/iot-app-kit-visualizations/src/components/viewportHandler/viewportHandler.spec.ts
@@ -204,7 +204,7 @@ describe('syncing managers', () => {
     expect(manager2.updateViewPort).not.toBeCalled();
   });
 
-  it('blocks dateRangeChanged event emission when a duration is passed in', () => {
+  it('blocks setViewport event emission when a duration is passed in', () => {
     const groups = new ViewportHandler();
 
     const VIEWPORT_GROUP = 'view-port-group-1';
@@ -219,7 +219,7 @@ describe('syncing managers', () => {
 
     expect(manager.updateViewPort).toBeCalledWith(
       expect.objectContaining({
-        shouldBlockDateRangeChangedEvent: true,
+        shouldBlockSetViewport: true,
       })
     );
   });
@@ -392,7 +392,7 @@ describe('internal clock', () => {
     expect(manager1.updateViewPort.mock.calls.length).toBeGreaterThan(manager2.updateViewPort.mock.calls.length);
   });
 
-  it('blocks dateRangeChanged event emission when a duration is passed in', () => {
+  it('blocks setViewport event emission when a duration is passed in', () => {
     jest.useFakeTimers();
     const groups = new ViewportHandler();
     const VIEWPORT_GROUP_1 = 'view-port-group-1';
@@ -405,12 +405,12 @@ describe('internal clock', () => {
     jest.advanceTimersByTime(secondsElapsed * SECOND_IN_MS);
     expect(manager.updateViewPort).toBeCalledWith(
       expect.objectContaining({
-        shouldBlockDateRangeChangedEvent: true,
+        shouldBlockSetViewport: true,
       })
     );
   });
 
-  it('blocks dateRangeChanged event emission when viewport group with duration updated', () => {
+  it('blocks setViewport event emission when viewport group with duration updated', () => {
     const groups = new ViewportHandler();
     const VIEWPORT_GROUP_1 = 'view-port-group-1';
     const manager = viewportManager(VIEWPORT_GROUP_1);
@@ -423,7 +423,7 @@ describe('internal clock', () => {
     expect(manager.updateViewPort).toBeCalledWith(
       expect.objectContaining({
         duration,
-        shouldBlockDateRangeChangedEvent: true,
+        shouldBlockSetViewport: true,
       })
     );
   });

--- a/packages/iot-app-kit-visualizations/src/components/viewportHandler/viewportHandler.ts
+++ b/packages/iot-app-kit-visualizations/src/components/viewportHandler/viewportHandler.ts
@@ -55,13 +55,13 @@ export class ViewportHandler<T extends ViewPortManager> {
       // Sets the new start and end in the viewport live id for the current manager
       this.viewportMap[viewPortMapKey] = { start: newStart, end: newEnd };
 
-      // Have manager update its own viewport, preventing 'dateRangeChange' events when in live mode
+      // Have manager update its own viewport, preventing 'setViewport' when in live mode
       const isInLiveMode = Boolean(duration);
       manager.updateViewPort({
         start: newStart,
         end: newEnd,
         duration,
-        shouldBlockDateRangeChangedEvent: isInLiveMode,
+        shouldBlockSetViewport: isInLiveMode,
       });
     }, tickRate) as unknown) as number;
 
@@ -116,11 +116,11 @@ export class ViewportHandler<T extends ViewPortManager> {
      * the current viewport groups time span.
      */
     if (manager.viewportGroup && this.viewportMap[manager.viewportGroup] && shouldSync) {
-      const shouldBlockDateRangeChangedEvent = Boolean(duration);
+      const shouldBlockSetViewport = Boolean(duration);
       manager.updateViewPort({
         ...this.viewportMap[manager.viewportGroup],
         duration,
-        shouldBlockDateRangeChangedEvent,
+        shouldBlockSetViewport,
       });
     }
     // If duration is not null, this means that we want to have live mode
@@ -169,7 +169,7 @@ export class ViewportHandler<T extends ViewPortManager> {
 
     const updateViewPort = (v: T) => {
       const isInLiveMode = Boolean(duration);
-      v.updateViewPort({ start, end, duration, shouldBlockDateRangeChangedEvent: isInLiveMode });
+      v.updateViewPort({ start, end, duration, shouldBlockSetViewport: isInLiveMode });
     };
 
     if (manager.viewportGroup) {

--- a/packages/iot-app-kit-visualizations/src/testing/chartDescriptions/newChartSpecPage.ts
+++ b/packages/iot-app-kit-visualizations/src/testing/chartDescriptions/newChartSpecPage.ts
@@ -58,6 +58,7 @@ export const newChartSpecPage = (tagName: string): ChartSpecPage => async props 
     widgetId: 'default-id',
     gestures: true,
     viewport: VIEWPORT,
+    setViewport: () => {},
     legend: {
       position: LEGEND_POSITION.BOTTOM,
       width: 300,

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/line-chart-viewport-change.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/line-chart-viewport-change.tsx
@@ -51,7 +51,12 @@ export class LineChartViewportChange {
         <br />
         <br />
         <div id="chart-container" style={{ marginTop: '20px', width: '500px', height: '500px' }}>
-          <iot-app-kit-vis-line-chart widgetId="widget-id" dataStreams={[]} viewport={this.viewport} />
+          <iot-app-kit-vis-line-chart
+            widgetId="widget-id"
+            dataStreams={[]}
+            viewport={this.viewport}
+            setViewport={this.setViewPort}
+          />
         </div>
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/performance/sc-line-chart-stream-data.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/performance/sc-line-chart-stream-data.tsx
@@ -92,6 +92,7 @@ export class ScLineChartStreamData {
             width: 500,
           }}
           viewport={this.viewport}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-annotations-draggable-multi.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-annotations-draggable-multi.tsx
@@ -50,6 +50,7 @@ export class ScAnnotationsDraggableMulti {
             annotations={ANNOTATIONS}
             size={SIZE}
             viewport={{ start: X_MIN, end: X_MAX }}
+            setViewport={() => {}}
           />
         </div>
         <div style={{ width: '500px', height: '500px' }}>
@@ -59,6 +60,7 @@ export class ScAnnotationsDraggableMulti {
             annotations={ANNOTATIONS}
             size={SIZE}
             viewport={{ start: X_MIN, end: X_MAX }}
+            setViewport={() => {}}
           />
         </div>
         <iot-app-kit-vis-webgl-context />

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-chart-y-range.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-chart-y-range.tsx
@@ -68,6 +68,7 @@ export class ScChartYRange {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-bar-margin.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-bar-margin.tsx
@@ -62,6 +62,7 @@ export class ScWebglBarChartDynamicBuffer {
           widgetId="widget-id"
           dataStreams={[DATA_STREAM_1, DATA_STREAM_2]}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
           bufferFactor={1}
           minBufferSize={1}
         />

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-dynamic-buffer.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-dynamic-buffer.tsx
@@ -61,6 +61,7 @@ export class ScWebglBarChartDynamicBuffer {
               start: X_MIN,
               end: X_MAX,
             }}
+            setViewport={() => {}}
             bufferFactor={1}
             minBufferSize={1}
           />

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-dynamic-data-streams.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-dynamic-data-streams.tsx
@@ -100,6 +100,7 @@ export class ScWebglBarChartDynamicDataStreams {
               start: X_MIN,
               end: X_MAX,
             }}
+            setViewport={() => {}}
           />
         </div>
         <iot-app-kit-vis-webgl-context />

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-dynamic-data.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-dynamic-data.tsx
@@ -77,6 +77,7 @@ export class ScWebglBarChartDynamicData {
               start: X_MIN,
               end: X_MAX,
             }}
+            setViewport={() => {}}
           />
           <iot-app-kit-vis-webgl-context />
         </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-negative.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-negative.tsx
@@ -50,6 +50,7 @@ export class ScWebglBarChartNegative {
             height: 500,
           }}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-positive-negative.component.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-positive-negative.component.tsx
@@ -53,6 +53,7 @@ export class ScWebglBarChartPositiveNegative {
             height: 500,
           }}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-standard.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-standard.tsx
@@ -39,6 +39,7 @@ export class ScWebglBarChartStandard {
             height: 500,
           }}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-start-from-zero.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-start-from-zero.tsx
@@ -63,6 +63,7 @@ export class ScWebglBarChartStartFromZero {
               height: 500,
             }}
             viewport={{ start: X_MIN, end: X_MAX }}
+            setViewport={() => {}}
           />
           <iot-app-kit-vis-webgl-context />
         </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-band.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-band.tsx
@@ -66,6 +66,7 @@ export class ScWebglBarChartThresholdBand {
             height: 500,
           }}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-coloration.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-coloration.tsx
@@ -55,6 +55,7 @@ export class ScWebglBarChartThresholdColoration {
             height: 500,
           }}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-exact-point.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-exact-point.tsx
@@ -53,6 +53,7 @@ export class ScWebglBarChartThresholdExactPoint {
             height: 500,
           }}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-multiple-data-stream.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-multiple-data-stream.tsx
@@ -90,6 +90,7 @@ export class ScWebglBarChartThresholdMultipleDataStream {
             height: 500,
           }}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-multiple-thresholds.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-multiple-thresholds.tsx
@@ -64,6 +64,7 @@ export class ScWebglBarChartThresholdMultipleThresholds {
             height: 500,
           }}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-no-coloration.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-threshold-no-coloration.tsx
@@ -57,6 +57,7 @@ export class ScWebglBarChartThresholdNoColoration {
             height: 500,
           }}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-unsupported-data-types.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-bar-chart/sc-webgl-bar-chart-unsupported-data-types.tsx
@@ -64,6 +64,7 @@ export class ScWebglBarChartUnsupportedDataTypes {
               start: X_MIN,
               end: X_MAX,
             }}
+            setViewport={() => {}}
           />
         </div>
         <iot-app-kit-vis-webgl-context />

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-annotation-editable.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-annotation-editable.tsx
@@ -182,6 +182,7 @@ export class ScWebglChartAnnotationRescaling {
               height: 1000,
               width: 1000,
             }}
+            setViewport={() => {}}
           />
           <iot-app-kit-vis-webgl-context />
         </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-annotations-always-in-viewport.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-annotations-always-in-viewport.tsx
@@ -64,6 +64,7 @@ export class ScWebglChartAnnotationsAlwaysInViewport {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
           widgetId="widget-id"
         />
         <iot-app-kit-vis-webgl-context />

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-annotations.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-annotations.tsx
@@ -63,6 +63,7 @@ export class ScWebglChartAnnotations {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-axis.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-axis.tsx
@@ -20,6 +20,7 @@ export class ScWebglChartAnnotations {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-dynamic-charts.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-dynamic-charts.tsx
@@ -143,6 +143,7 @@ export class ScWebglChartStandard {
               dataStreams={data}
               widgetId={key}
               viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+              setViewport={() => {}}
             />
           </div>
         ))}

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-large-viewport.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-large-viewport.tsx
@@ -44,6 +44,7 @@ export class ScWebglChartLargeViewport {
             width: 500,
           }}
           viewport={VIEWPORT}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-multi.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-multi.tsx
@@ -42,6 +42,7 @@ export class ScWebglChartMulti {
             },
           ]}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX, group: VIEWPORT_GROUP }}
+          setViewport={() => {}}
         />
 
         <iot-app-kit-vis-line-chart
@@ -62,6 +63,7 @@ export class ScWebglChartMulti {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX, group: VIEWPORT_GROUP }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-no-annotations.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-no-annotations.tsx
@@ -41,6 +41,7 @@ export class ScWebglChartNoAnnotations {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-standard-with-legend-on-right.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-standard-with-legend-on-right.tsx
@@ -43,6 +43,7 @@ export class ScWebglChartStandardWithLegendOnRight {
             position: LEGEND_POSITION.RIGHT,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-standard-with-legend.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-standard-with-legend.tsx
@@ -39,6 +39,7 @@ export class ScWebglChartStandardWithLegend {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
           legend={{
             position: LEGEND_POSITION.BOTTOM,
             width: 300,

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-standard.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-standard.tsx
@@ -44,6 +44,7 @@ export class ScWebglChartStandard {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration-band.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration-band.tsx
@@ -90,6 +90,7 @@ export class ScWebglThresholdColorationBand {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration-exact-point.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration-exact-point.tsx
@@ -63,6 +63,7 @@ export class ScWebglChartThresholdColorationExactPoint {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration-multiple-data-stream.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration-multiple-data-stream.tsx
@@ -76,6 +76,7 @@ export class ScWebglChartThresholdColorationMultipleDataStream {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration-multiple-thresholds.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration-multiple-thresholds.tsx
@@ -87,6 +87,7 @@ export class ScWebglChartThresholdColorationMultipleThresholds {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-threshold-coloration.tsx
@@ -58,6 +58,7 @@ export class ScWebglChartThresholdColoration {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-tooltip-with-multiple-data-streams.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-chart-tooltip-with-multiple-data-streams.tsx
@@ -56,6 +56,7 @@ export class ScWebglChartTooltipWithMultipleDataStreams {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-line-chart-dynamic-buffer.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-line-chart-dynamic-buffer.tsx
@@ -53,6 +53,7 @@ export class ScWebglLineChartDynamicBuffer {
               width: 500,
             }}
             viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+            setViewport={() => {}}
             bufferFactor={1}
             minBufferSize={1}
           />

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-line-chart-dynamic-data-streams.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-line-chart-dynamic-data-streams.tsx
@@ -82,6 +82,7 @@ export class ScWebglLineChartDynamicDataStreams {
               width: 500,
             }}
             viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+            setViewport={() => {}}
           />
         </div>
         <iot-app-kit-vis-webgl-context />

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-line-chart-dynamic-data.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-line-chart-dynamic-data.tsx
@@ -65,6 +65,7 @@ export class ScWebglLineChartDynamicData {
               width: 500,
             }}
             viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+            setViewport={() => {}}
           />
 
           <iot-app-kit-vis-webgl-context />

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-line-chart-unsupported-data-types.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-line-chart-unsupported-data-types.tsx
@@ -44,6 +44,7 @@ export class LineChartUnsupportedDataTypes {
               width: 500,
             }}
             viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+            setViewport={() => {}}
             bufferFactor={1}
             minBufferSize={1}
           />

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-dynamic-data.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-dynamic-data.tsx
@@ -69,6 +69,7 @@ export class ScScatterChartDynamicData {
               width: 500,
             }}
             viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+            setViewport={() => {}}
           />
 
           <iot-app-kit-vis-webgl-context />

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-band.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-band.tsx
@@ -102,6 +102,7 @@ export class ScScatterChartThresholdColorationBand {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-exact-point.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-exact-point.tsx
@@ -63,6 +63,7 @@ export class ScScatterChartThresholdColorationExactPoint {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-multiple-data-stream.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-multiple-data-stream.tsx
@@ -82,6 +82,7 @@ export class ScScatterChartThresholdColorationMultipleDataStream {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-multiple-thresholds.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration-multiple-thresholds.tsx
@@ -97,6 +97,7 @@ export class ScWebglChartThresholdColorationMultipleThresholds {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-coloration.tsx
@@ -60,6 +60,7 @@ export class ScScatterChartThresholdColoration {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-no-coloration.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-threshold-no-coloration.tsx
@@ -63,6 +63,7 @@ export class ScScatterChartThresholdNoColoration {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-tooltip-with-multiple-data-streams-and-trends.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-tooltip-with-multiple-data-streams-and-trends.tsx
@@ -75,6 +75,7 @@ export class ScScatterChartTooltipWithMultipleDataStreamsAndTrends {
             width: 500,
           }}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
           trends={[
             {
               type: TREND_TYPE.LINEAR,

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-trend-line-color-configuration.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-trend-line-color-configuration.tsx
@@ -57,6 +57,7 @@ export class ScScatterChartTrendLineColorConfiguration {
             yMin: Y_MIN,
             yMax: Y_MAX,
           }}
+          setViewport={() => {}}
           legend={{
             position: LEGEND_POSITION.BOTTOM,
             width: 300,

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-trend-line-with-legend.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-trend-line-with-legend.tsx
@@ -57,6 +57,7 @@ export class ScScatterChartTrendLineWithLegend {
             yMin: Y_MIN,
             yMax: Y_MAX,
           }}
+          setViewport={() => {}}
           legend={{
             position: LEGEND_POSITION.BOTTOM,
             width: 300,

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-unsupported-data-types.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/sc-webgl-scatter-chart/sc-scatter-chart-unsupported-data-types.tsx
@@ -43,6 +43,7 @@ export class ScScatterChartUnsupportedDataTypes {
           ]}
           annotations={{}}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-dynamic-buffer.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-dynamic-buffer.tsx
@@ -54,6 +54,7 @@ export class StatusTimelineDynamicBuffer {
               start: X_MIN,
               end: X_MAX,
             }}
+            setViewport={() => {}}
             bufferFactor={1}
             minBufferSize={1}
           />

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-dynamic-data-streams.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-dynamic-data-streams.tsx
@@ -96,6 +96,7 @@ export class StatusTimelineDynamicDataStreams {
               start: X_MIN,
               end: X_MAX,
             }}
+            setViewport={() => {}}
           />
         </div>
         <iot-app-kit-vis-webgl-context />

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-dynamic-data.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-dynamic-data.tsx
@@ -70,6 +70,7 @@ export class StatusTimelineDynamicData {
               start: X_MIN,
               end: X_MAX,
             }}
+            setViewport={() => {}}
           />
           <iot-app-kit-vis-webgl-context />
         </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-fast-viewport.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-fast-viewport.tsx
@@ -77,6 +77,7 @@ export class StatusTimelineFastViewport {
               start: this.start,
               end: this.end,
             }}
+            setViewport={() => {}}
           />
           <iot-app-kit-vis-webgl-context />
         </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-multiple-data-streams.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-multiple-data-streams.tsx
@@ -52,6 +52,7 @@ export class StatusTimelineMultipleDataStreams {
             height: 500,
           }}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-raw-data.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-raw-data.tsx
@@ -70,6 +70,7 @@ export class StatusTimelineRawData {
           }}
           annotations={annotations}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-standard.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-standard.tsx
@@ -29,6 +29,7 @@ export class StatusTimelineStandard {
             height: 500,
           }}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-status-margin.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-status-margin.tsx
@@ -52,6 +52,7 @@ export class StatusTimelineStatusMargin {
           widgetId="widget-id"
           dataStreams={[DATA_STREAM_1, DATA_STREAM_2]}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-band.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-band.tsx
@@ -67,6 +67,7 @@ export class StatusTimelineThresholdBand {
             height: 500,
           }}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-coloration.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-coloration.tsx
@@ -50,6 +50,7 @@ export class StatusTimelineThresholdColoration {
             height: 500,
           }}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-exact-point.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-exact-point.tsx
@@ -50,6 +50,7 @@ export class StatusTimelineThresholdExactPoint {
             height: 500,
           }}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-multiple-data-stream.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-multiple-data-stream.tsx
@@ -83,6 +83,7 @@ export class StatusTimelineThresholdMultipleDataStream {
             height: 500,
           }}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-multiple-thresholds.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-multiple-thresholds.tsx
@@ -57,6 +57,7 @@ export class StatusTimelineThresholdMultipleThresholds {
             height: 500,
           }}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-no-coloration.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/charts/status-timeline/status-timeline-threshold-no-coloration.tsx
@@ -50,6 +50,7 @@ export class StatusTimelineThresholdNoColoration {
             height: 500,
           }}
           viewport={{ yMin: Y_MIN, yMax: Y_MAX, start: X_MIN, end: X_MAX }}
+          setViewport={() => {}}
         />
         <iot-app-kit-vis-webgl-context />
       </div>

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/sc-webgl-context/sc-webgl-context-nested.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/sc-webgl-context/sc-webgl-context-nested.tsx
@@ -79,6 +79,7 @@ export class ScWebglContextNested {
             },
           ]}
           viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+          setViewport={() => {}}
         />
       </div>
     );

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/sc-webgl-context/sc-webgl-context-root.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/sc-webgl-context/sc-webgl-context-root.tsx
@@ -61,6 +61,7 @@ export class ScWebglContextRoot {
                 width: 500,
               }}
               viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+              setViewport={() => {}}
             />
           </div>
           <div style={{ height: '500px', width: '500px' }}>
@@ -81,6 +82,7 @@ export class ScWebglContextRoot {
                 width: 500,
               }}
               viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+              setViewport={() => {}}
             />
           </div>
           <div style={{ height: '500px', width: '500px' }}>
@@ -101,6 +103,7 @@ export class ScWebglContextRoot {
                 width: 500,
               }}
               viewport={{ start: X_MIN, end: X_MAX, yMin: Y_MIN, yMax: Y_MAX }}
+              setViewport={() => {}}
             />
           </div>
           <iot-app-kit-vis-webgl-context />

--- a/packages/iot-app-kit-visualizations/src/testing/test-routes/widget-test-route.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/test-routes/widget-test-route.tsx
@@ -1,7 +1,7 @@
-import { Component, h, Listen, Prop } from '@stencil/core';
+import { Component, h, Listen, Prop, State } from '@stencil/core';
 import { SIZE, VIEWPORT as DEFAULT_VIEWPORT } from '../dynamicWidgetUtils/constants';
 import { testCaseParameters } from '../dynamicWidgetUtils/testCaseParameters';
-import { DataStreamInfo } from '../../utils/dataTypes';
+import { DataStreamInfo, MinimalViewPortConfig } from '../../utils/dataTypes';
 
 const DEFAULT_WIDTH = 700;
 const DEFAULT_HEIGHT = 400;
@@ -47,6 +47,7 @@ const styleSize = (value: number | string): string => {
   tag: 'widget-test-route',
 })
 export class WidgetTestRoute {
+  @State() viewport: MinimalViewPortConfig = DEFAULT_VIEWPORT;
   @Prop() dataStreamInfos: DataStreamInfo[] = [];
   @Prop() component: string = componentTag;
 
@@ -56,6 +57,10 @@ export class WidgetTestRoute {
       this.dataStreamInfos = configUpdate.dataStreamInfo;
     }
   }
+
+  setViewPort = viewport => {
+    this.viewport = viewport;
+  };
 
   render() {
     const viewport = {
@@ -80,6 +85,7 @@ export class WidgetTestRoute {
           isEditing={isEditing}
           alarms={alarms}
           viewport={viewport}
+          setViewport={this.setViewPort}
           legend={legend}
           size={getSize(width)}
           axis={axis}

--- a/packages/iot-app-kit-visualizations/src/utils/dataTypes.ts
+++ b/packages/iot-app-kit-visualizations/src/utils/dataTypes.ts
@@ -101,6 +101,7 @@ interface MinimalViewportConfigBase {
 
   yMin?: number;
   yMax?: number;
+  lastUpdatedBy?: string;
 }
 
 export interface MinimalStaticViewport extends MinimalViewportConfigBase {
@@ -266,3 +267,7 @@ export interface DataStream<T extends Primitive = Primitive> extends DataStreamI
  * a single point in time (which is an interval of time with a duration of zero).
  */
 export type Resolution = number;
+
+export type DurationViewport = { duration: string | number; group?: string };
+export type HistoricalViewport = { start: Date; end: Date; group?: string };
+export type AppKitViewport = DurationViewport | HistoricalViewport;


### PR DESCRIPTION
## Overview
- use setViewport instead of dateRangeChanged event emitter
- dont update viewport if viewports were lastUpdatedBy a chart-gesture, since the new TimeSync logic in iot-app-kit will handle it

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
