### PR TITLE
feat(react): fix broken copy styles script

### DIFF
--- a/packages/iot-app-kit-visualizations-react/package.json
+++ b/packages/iot-app-kit-visualizations-react/package.json
@@ -18,7 +18,7 @@
     "build": "tsc --outDir dist",
     "clean": "rm -rf dist *.tsbuildinfo",
     "release": "yarn build",
-    "copy:styles": "cp ../../node_modules/@iot-app-kit-visualizations/core/dist/iot-app-kit-visualizations/iot-app-kit-visualizations.css dist/styles.css",
+    "copy:styles": "cp ../../node_modules/@iot-app-kit/charts-core/dist/iot-app-kit-visualizations/iot-app-kit-visualizations.css dist/styles.css",
     "copy:license": "cp ../../LICENSE LICENSE",
     "copy:notice": "cp ../../NOTICE NOTICE",
     "copy:code-of-conduct": "cp ../../CODE_OF_CONDUCT.md CODE_OF_CONDUCT.md",


### PR DESCRIPTION
## Overview
remove reference to `iot-app-kit-vis/core` in `iot-app-kit/charts` copy styles script
which broke the NPM publish step

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
