### PR TITLE
fix(legend): fix name and unit gap in legend

### DIFF
--- a/packages/iot-app-kit-visualizations/src/components/charts/sc-legend/sc-legend-row/sc-legend-row.tsx
+++ b/packages/iot-app-kit-visualizations/src/components/charts/sc-legend/sc-legend-row/sc-legend-row.tsx
@@ -18,7 +18,7 @@ const EDIT_MODE_STYLE: StencilCSSProperty = {
   top: '-2px',
 };
 const VIEW_MODE_STYLE: StencilCSSProperty = {
-  top: '-11px',
+  top: '-4px',
 };
 
 @Component({


### PR DESCRIPTION
## Overview
<img width="163" alt="Screenshot 2023-03-29 at 18 39 35" src="https://user-images.githubusercontent.com/28601414/228698919-33fffcb2-61be-4438-9c7d-573f0b29d9d4.png">
<img width="209" alt="Screenshot 2023-03-29 at 18 38 59" src="https://user-images.githubusercontent.com/28601414/228698922-a581d1d1-efd5-4af9-81ad-3c90b020a8b4.png">

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
