### PR TITLE
fix: hide legend and error state on loading or empty state

### DIFF
--- a/packages/iot-app-kit-visualizations/src/components/charts/sc-webgl-base-chart/UnsupportedDataTypeStatus.tsx
+++ b/packages/iot-app-kit-visualizations/src/components/charts/sc-webgl-base-chart/UnsupportedDataTypeStatus.tsx
@@ -8,20 +8,25 @@ import { MessageOverrides, SizeConfig } from '../../../utils/dataTypes';
 export const UnsupportedDataTypeStatus = ({
   supportedDataTypes,
   messageOverrides,
+  hasUnsupportedData,
   size,
 }: {
   supportedDataTypes: DataType[];
   messageOverrides: MessageOverrides;
+  hasUnsupportedData: boolean;
   size: SizeConfig;
 }) => {
-  const { width, height, marginLeft, marginRight, marginTop, marginBottom } = size;
+  const { width, height } = size;
+
+  if (!hasUnsupportedData) return <div />;
+
   return (
     <div
       id="unsupported-data-type-error"
       class="unsupported-data-type-status"
       style={{
-        width: `${width + marginLeft + marginRight}px`,
-        height: `${height + marginBottom + marginTop}px`,
+        width: `${width}px`,
+        height: `${height}px`,
         padding: '24px',
         background: 'white',
         border: 'solid 4px black',

--- a/packages/iot-app-kit-visualizations/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.spec.tsx
+++ b/packages/iot-app-kit-visualizations/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.spec.tsx
@@ -121,12 +121,13 @@ const newChartSpecPage = async (chartProps: Partial<Components.IotAppKitVisWebgl
 };
 
 describe('legend', () => {
-  it('renders a legend with provided with a legend config', async () => {
+  it('renders a legend with provided with a legend config and data streams', async () => {
     const { chart } = await newChartSpecPage({
       legend: {
         position: LEGEND_POSITION.BOTTOM,
         width: 200,
       },
+      dataStreams: [STREAM],
     });
 
     const legend = chart.querySelector('iot-app-kit-vis-legend');
@@ -139,6 +140,7 @@ describe('legend', () => {
         position: LEGEND_POSITION.BOTTOM,
         width: 200,
       },
+      dataStreams: [STREAM],
       isEditing: true,
     });
 
@@ -152,6 +154,7 @@ describe('legend', () => {
         position: LEGEND_POSITION.BOTTOM,
         width: 200,
       },
+      dataStreams: [STREAM],
       viewport: VIEWPORT,
     });
 
@@ -163,6 +166,7 @@ describe('legend', () => {
   it('should render with custom legend', async () => {
     const { chart, page } = await newChartSpecPage({
       renderLegend: props => <div class="custom-test-legend" {...props} />,
+      dataStreams: [STREAM],
     });
 
     await page.waitForChanges();
@@ -542,7 +546,7 @@ describe('loading status', () => {
       const loadingSpinner = chart.querySelector(LOADING_SPINNER_SELECTOR);
       const legend = chart.querySelector('iot-app-kit-vis-legend');
 
-      expect(legend).toHaveAttribute('isLoading');
+      expect(legend).toBeNull();
       expect(loadingSpinner).not.toBeNull();
     });
 

--- a/packages/iot-app-kit-visualizations/src/testing/chartDescriptions/describeLegend.tsx
+++ b/packages/iot-app-kit-visualizations/src/testing/chartDescriptions/describeLegend.tsx
@@ -1,17 +1,32 @@
 import { ChartSpecPage } from './newChartSpecPage';
 import { Threshold } from '../../components/charts/common/types';
 import { COMPARISON_OPERATOR, LEGEND_POSITION } from '../../components/charts/common/constants';
+import { DATA_STREAM } from '../__mocks__/mockWidgetProperties';
 
 const VIEWPORT = { start: new Date(2000), end: new Date(2001, 0, 0), yMin: 0, yMax: 100 };
 
 export const describeLegend = (newChartSpecPage: ChartSpecPage) => {
   describe('legend', () => {
-    it('renders a legend when provided with a legend config', async () => {
+    it('renders a legend when provided with a legend config and dataStreams', async () => {
       const { chart } = await newChartSpecPage({
         legend: {
           position: LEGEND_POSITION.BOTTOM,
           width: 200,
         },
+        dataStreams: [DATA_STREAM],
+      });
+
+      const legend = chart.querySelector('iot-app-kit-vis-legend');
+      expect(legend).toBeDefined();
+    });
+
+    it('does not render a legend when provided with a legend config and empty dataStreams', async () => {
+      const { chart } = await newChartSpecPage({
+        legend: {
+          position: LEGEND_POSITION.BOTTOM,
+          width: 200,
+        },
+        dataStreams: [],
       });
 
       const legend = chart.querySelector('iot-app-kit-vis-legend');
@@ -24,6 +39,7 @@ export const describeLegend = (newChartSpecPage: ChartSpecPage) => {
           position: LEGEND_POSITION.BOTTOM,
           width: 200,
         },
+        dataStreams: [DATA_STREAM],
         isEditing: true,
       });
 
@@ -37,6 +53,7 @@ export const describeLegend = (newChartSpecPage: ChartSpecPage) => {
           position: LEGEND_POSITION.BOTTOM,
           width: 200,
         },
+        dataStreams: [DATA_STREAM],
         viewport: VIEWPORT,
       });
 
@@ -68,6 +85,7 @@ export const describeLegend = (newChartSpecPage: ChartSpecPage) => {
           position: LEGEND_POSITION.BOTTOM,
           width: 200,
         },
+        dataStreams: [DATA_STREAM],
       });
 
       const legend = chart.querySelector('iot-app-kit-vis-legend') as HTMLIotAppKitVisLegendElement;


### PR DESCRIPTION
## Overview
fix legend spacing
fix flash of error state when widg
![legend](https://user-images.githubusercontent.com/28601414/234696160-c6ad48bf-b135-46ce-ad0c-d5afb5119a8f.gif)
et is first added



## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
