### PR TITLE
fix: check if data is loading for unsupported types

### DIFF
--- a/packages/iot-app-kit-visualizations/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
+++ b/packages/iot-app-kit-visualizations/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
@@ -458,10 +458,13 @@ export class ScWebglBaseChart {
   };
 
   getHasUnsupportedData = (): boolean => {
-    if (this.dataStreams.length === 0) return false;
+    const visualizedDataStreams = this.visualizedDataStreams();
 
-    return !this.dataStreams.every(
-      ({ streamType, dataType }) => streamType === StreamType.ALARM || this.supportedDataTypes.includes(dataType)
+    if (visualizedDataStreams.length === 0) return false;
+
+    return !visualizedDataStreams.every(
+      ({ streamType, dataType, isLoading }) =>
+        !isLoading && (streamType === StreamType.ALARM || this.supportedDataTypes.includes(dataType))
     );
   };
 


### PR DESCRIPTION
## Overview
check if data is loading before checking if dataStream type is unsupported

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
