### PR TITLE
fix(base-chart): only check datastreams with data types in unsupported check

### DIFF
--- a/packages/iot-app-kit-visualizations/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
+++ b/packages/iot-app-kit-visualizations/src/components/charts/sc-webgl-base-chart/sc-webgl-base-chart.tsx
@@ -461,7 +461,9 @@ export class ScWebglBaseChart {
 
     if (visualizedDataStreams.length === 0) return false;
 
-    return !visualizedDataStreams.every(
+    const dataStreamsWithDataType = visualizedDataStreams.filter(({ dataType }) => dataType != null);
+
+    return !dataStreamsWithDataType.every(
       ({ streamType, dataType }) => streamType === StreamType.ALARM || this.supportedDataTypes.includes(dataType)
     );
   };


### PR DESCRIPTION
## Overview
unsupported data streams check was running against datastreams which do not yet have the dataType property. this caused the check to return that it does have unsupported datastreams since undefined was not in the list.

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
