### PR TITLE
fix: remove test files from build

### DIFF
--- a/packages/iot-app-kit-visualizations/stencil.config.ts
+++ b/packages/iot-app-kit-visualizations/stencil.config.ts
@@ -15,6 +15,7 @@ export const config: Config = {
   plugins: [nodePolyfills()],
   copy: [{ src: 'globals' }],
   globalStyle: 'src/globals/globals.css',
+  tsconfig: './tsconfig.build.json',
   testing: {
     setupFilesAfterEnv: ['<rootDir>/configuration/jest/setupTests.ts', 'jest-extended'],
     collectCoverageFrom: ['src/**/*.{ts,tsx}'],

--- a/packages/iot-app-kit-visualizations/tsconfig.build.json
+++ b/packages/iot-app-kit-visualizations/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src", "types/jsx.d.ts"],
+  "exclude": ["node_modules", "./src/testing", "./src/**.test.*", "./src/**.spec.*"]
+}


### PR DESCRIPTION
## Overview
This change removes ~2 MB of test files from ending up in the dist by ensuring the test files are excluded in the build.

#### Before
![Screenshot 2024-11-17 at 9 42 37 AM](https://github.com/user-attachments/assets/b37d485d-bdb7-415c-9ee1-1e1409b58004)

#### After
![Screenshot 2024-11-17 at 9 43 32 AM](https://github.com/user-attachments/assets/4a8394e4-64d2-4794-9637-0c26dc646950)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
